### PR TITLE
Fix HVDC active power setpoint

### DIFF
--- a/src/test/java/com/powsybl/loadflow/open/ac/AcLoadFlowVscTest.java
+++ b/src/test/java/com/powsybl/loadflow/open/ac/AcLoadFlowVscTest.java
@@ -147,7 +147,7 @@ public class AcLoadFlowVscTest {
                 .setNominalV(400)
                 .setR(0.1)
                 .setActivePowerSetpoint(50)
-                .setConvertersMode(HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER)
+                .setConvertersMode(HvdcLine.ConvertersMode.SIDE_1_RECTIFIER_SIDE_2_INVERTER)
                 .setMaxP(500)
                 .add();
 


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
SVC active power setpoint is incorrect on one  side of the HVDC line.


**What is the new behavior (if this is a feature change)?**
SVC active power setpoint is now correct on both sides.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
