### PR TITLE
Fix Appveyor build (Windows limitation on file path max size)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,9 @@ install:
   - cmd: SET M2_HOME=C:\maven\apache-maven-3.2.5
   - cmd: SET PATH=%M2_HOME%\bin;%JAVA_HOME%\bin;%PATH%
 before_build:
-  - git clone https://github.com/powsybl/powsybl-core.git powsybl/powsybl-core
+  - git clone https://github.com/powsybl/powsybl-core.git C:\projects\powsybl-core
   - ps: |
-      pushd powsybl/powsybl-core
+      pushd C:\projects\powsybl-core
       mvn -DskipTests install --batch-mode
       popd
 build_script:


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Appveyor Windows build failed because of a limitation to file path size. 


**What is the new behavior (if this is a feature change)?**
Core build has been move to c:\project to have shorter paths.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
