### PR TITLE
Throws an exception in case of generator remote voltage

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworks.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworks.java
@@ -79,6 +79,10 @@ public final class LfNetworks {
 
                 @Override
                 public void visitGenerator(Generator generator) {
+                    if (!Objects.equals(generator.getRegulatingTerminal().getBusView().getBus().getId(),
+                            generator.getTerminal().getBusView().getBus().getId())) {
+                        throw new PowsyblException("Generator remote voltage control is not yet supported");
+                    }
                     lfBus.addGenerator(generator);
                     generatorCount[0]++;
                 }
@@ -115,7 +119,7 @@ public final class LfNetworks {
                             lfBus.addVscConverterStation((VscConverterStation) converterStation);
                             break;
                         case LCC:
-                            throw new UnsupportedOperationException("TODO: LCC");
+                            throw new UnsupportedOperationException("LCC converter station is not yet supported");
                         default:
                             throw new IllegalStateException("Unknown HVDC converter station type: " + converterStation.getHvdcType());
                     }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix.


**What is the current behavior?** *(You can also link to an open issue here)*
In case of generator with remote voltage control, there is no check and loadflow compute wrong state.


**What is the new behavior (if this is a feature change)?**
An exception is thrown to warn users that is it not yet supported.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
