### PR TITLE
Activate distributed slack and reactive limits by default

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
@@ -23,9 +23,9 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
 
     private SlackBusSelector slackBusSelector = new MostMeshedSlackBusSelector();
 
-    private boolean distributedSlack = false;
+    private boolean distributedSlack = true;
 
-    private boolean reactiveLimits = false;
+    private boolean reactiveLimits = true;
 
     private boolean dc = false;
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlow3wtTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlow3wtTest.java
@@ -145,7 +145,8 @@ public class AcLoadFlow3wtTest {
         parameters = new LoadFlowParameters();
         OpenLoadFlowParameters parametersExt = new OpenLoadFlowParameters()
                 .setSlackBusSelector(new MostMeshedSlackBusSelector())
-                .setDistributedSlack(false);
+                .setDistributedSlack(false)
+                .setReactiveLimits(false);
         this.parameters.addExtension(OpenLoadFlowParameters.class, parametersExt);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowDanglingLineTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowDanglingLineTest.java
@@ -103,7 +103,8 @@ public class AcLoadFlowDanglingLineTest {
         parameters = new LoadFlowParameters();
         OpenLoadFlowParameters parametersExt = new OpenLoadFlowParameters()
                 .setSlackBusSelector(new MostMeshedSlackBusSelector())
-                .setDistributedSlack(false);
+                .setDistributedSlack(false)
+                .setReactiveLimits(false);
         this.parameters.addExtension(OpenLoadFlowParameters.class, parametersExt);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
@@ -60,7 +60,8 @@ public class AcLoadFlowEurostagTutorialExample1Test {
         parameters = new LoadFlowParameters();
         parametersExt = new OpenLoadFlowParameters()
                 .setSlackBusSelector(new FirstSlackBusSelector())
-                .setDistributedSlack(false);
+                .setDistributedSlack(false)
+                .setReactiveLimits(false);
         parameters.addExtension(OpenLoadFlowParameters.class, parametersExt);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowPhaseShifterTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowPhaseShifterTest.java
@@ -58,7 +58,8 @@ public class AcLoadFlowPhaseShifterTest {
         parameters = new LoadFlowParameters();
         OpenLoadFlowParameters parametersExt = new OpenLoadFlowParameters()
                 .setSlackBusSelector(new FirstSlackBusSelector())
-                .setDistributedSlack(false);
+                .setDistributedSlack(false)
+                .setReactiveLimits(false);
         this.parameters.addExtension(OpenLoadFlowParameters.class, parametersExt);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowSvcTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowSvcTest.java
@@ -115,7 +115,8 @@ public class AcLoadFlowSvcTest {
         parameters = new LoadFlowParameters();
         OpenLoadFlowParameters parametersExt = new OpenLoadFlowParameters()
                 .setSlackBusSelector(new MostMeshedSlackBusSelector())
-                .setDistributedSlack(false);
+                .setDistributedSlack(false)
+                .setReactiveLimits(false);
         this.parameters.addExtension(OpenLoadFlowParameters.class, parametersExt);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTwoBusNetworkTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTwoBusNetworkTest.java
@@ -48,7 +48,8 @@ public class AcLoadFlowTwoBusNetworkTest {
         parameters = new LoadFlowParameters();
         OpenLoadFlowParameters parametersExt = new OpenLoadFlowParameters()
                 .setSlackBusSelector(new FirstSlackBusSelector())
-                .setDistributedSlack(false);
+                .setDistributedSlack(false)
+                .setReactiveLimits(false);
         this.parameters.addExtension(OpenLoadFlowParameters.class, parametersExt);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
@@ -161,7 +161,8 @@ public class AcLoadFlowVscTest {
         parameters = new LoadFlowParameters();
         OpenLoadFlowParameters parametersExt = new OpenLoadFlowParameters()
                 .setSlackBusSelector(new MostMeshedSlackBusSelector())
-                .setDistributedSlack(false);
+                .setDistributedSlack(false)
+                .setReactiveLimits(false);
         this.parameters.addExtension(OpenLoadFlowParameters.class, parametersExt);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackTest.java
@@ -52,7 +52,8 @@ public class DistributedSlackTest {
         parameters = new LoadFlowParameters();
         OpenLoadFlowParameters parametersExt = new OpenLoadFlowParameters()
                 .setSlackBusSelector(new MostMeshedSlackBusSelector())
-                .setDistributedSlack(true);
+                .setDistributedSlack(true)
+                .setReactiveLimits(false);
         parameters.addExtension(OpenLoadFlowParameters.class, parametersExt);
     }
 


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Distributed slack and reactive limits are not activated by default. We have to add it using a LoadFlowParameter extension.


**What is the new behavior (if this is a feature change)?**
Distributed slack and reactive limits are now activated by default.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
