### PR TITLE
Run SonarCloud Analysis on same job as build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,24 +22,12 @@ jobs:
           java-version: 1.8
 
       - name: Build with Maven
-        run: mvn -B package --file pom.xml
+        run: mvn --batch-mode package
 
-  sonar:
-    name: SonarCloud analysis
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v1
-
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
-      - name: Run SonarCloud analyse
+      - name: Run SonarCloud analysis
+        if: matrix.os == 'ubuntu-latest'
         run: >
-          mvn --batch-mode -Pjacoco clean package sonar:sonar
+          mvn --batch-mode -Pjacoco sonar:sonar
           -Dsonar.host.url=https://sonarcloud.io
           -Dsonar.organization=powsybl-ci-github
           -Dsonar.projectKey=com.powsybl:powsybl-open-loadflow


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
SonarCloud analysis is run in its own job after build build job have complete.


**What is the new behavior (if this is a feature change)?**
To save time, SonarCloud analysis is run inside Linux build job.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
