### PR TITLE
Use standard 'noGeneratorReactiveLimits' parameter.

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
@@ -25,8 +25,6 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
 
     private boolean distributedSlack = true;
 
-    private boolean reactiveLimits = true;
-
     private boolean dc = false;
 
     private final List<AcLoadFlowObserver> additionalObservers = new ArrayList<>();
@@ -51,15 +49,6 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
 
     public OpenLoadFlowParameters setDistributedSlack(boolean distributedSlack) {
         this.distributedSlack = distributedSlack;
-        return this;
-    }
-
-    public boolean hasReactiveLimits() {
-        return reactiveLimits;
-    }
-
-    public OpenLoadFlowParameters setReactiveLimits(boolean reactiveLimits) {
-        this.reactiveLimits = reactiveLimits;
         return this;
     }
 

--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
@@ -133,13 +133,13 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
             LOGGER.info("Slack bus selector: {}", slackBusSelector.getClass().getSimpleName());
             LOGGER.info("Voltage level initializer: {}", voltageInitializer.getClass().getSimpleName());
             LOGGER.info("Distributed slack: {}", parametersExt.isDistributedSlack());
-            LOGGER.info("Reactive limits: {}", parametersExt.hasReactiveLimits());
+            LOGGER.info("Reactive limits: {}", !parameters.isNoGeneratorReactiveLimits());
 
             List<OuterLoop> outerLoops = new ArrayList<>();
             if (parametersExt.isDistributedSlack()) {
                 outerLoops.add(new DistributedSlackOuterLoop());
             }
-            if (parametersExt.hasReactiveLimits()) {
+            if (!parameters.isNoGeneratorReactiveLimits()) {
                 outerLoops.add(new ReactiveLimitsOuterLoop());
             }
 
@@ -156,7 +156,7 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
 
             // update network state
             LfNetworks.resetState(network);
-            lfNetwork.updateState(parametersExt.hasReactiveLimits());
+            lfNetwork.updateState(!parameters.isNoGeneratorReactiveLimits());
 
             return new LoadFlowResultImpl(result.getNewtonRaphsonStatus() == NewtonRaphsonStatus.CONVERGED, createMetrics(result), null);
         });

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlow3wtTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlow3wtTest.java
@@ -143,10 +143,10 @@ public class AcLoadFlow3wtTest {
         network = createNetwork();
         loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
         parameters = new LoadFlowParameters();
+        parameters.setNoGeneratorReactiveLimits(true);
         OpenLoadFlowParameters parametersExt = new OpenLoadFlowParameters()
                 .setSlackBusSelector(new MostMeshedSlackBusSelector())
-                .setDistributedSlack(false)
-                .setReactiveLimits(false);
+                .setDistributedSlack(false);
         this.parameters.addExtension(OpenLoadFlowParameters.class, parametersExt);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowDanglingLineTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowDanglingLineTest.java
@@ -101,10 +101,10 @@ public class AcLoadFlowDanglingLineTest {
         network = createNetwork();
         loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
         parameters = new LoadFlowParameters();
+        parameters.setNoGeneratorReactiveLimits(true);
         OpenLoadFlowParameters parametersExt = new OpenLoadFlowParameters()
                 .setSlackBusSelector(new MostMeshedSlackBusSelector())
-                .setDistributedSlack(false)
-                .setReactiveLimits(false);
+                .setDistributedSlack(false);
         this.parameters.addExtension(OpenLoadFlowParameters.class, parametersExt);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
@@ -58,10 +58,10 @@ public class AcLoadFlowEurostagTutorialExample1Test {
 
         loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
         parameters = new LoadFlowParameters();
+        parameters.setNoGeneratorReactiveLimits(true);
         parametersExt = new OpenLoadFlowParameters()
                 .setSlackBusSelector(new FirstSlackBusSelector())
-                .setDistributedSlack(false)
-                .setReactiveLimits(false);
+                .setDistributedSlack(false);
         parameters.addExtension(OpenLoadFlowParameters.class, parametersExt);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowPhaseShifterTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowPhaseShifterTest.java
@@ -56,10 +56,10 @@ public class AcLoadFlowPhaseShifterTest {
 
         loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
         parameters = new LoadFlowParameters();
+        parameters.setNoGeneratorReactiveLimits(true);
         OpenLoadFlowParameters parametersExt = new OpenLoadFlowParameters()
                 .setSlackBusSelector(new FirstSlackBusSelector())
-                .setDistributedSlack(false)
-                .setReactiveLimits(false);
+                .setDistributedSlack(false);
         this.parameters.addExtension(OpenLoadFlowParameters.class, parametersExt);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowSvcTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowSvcTest.java
@@ -113,10 +113,10 @@ public class AcLoadFlowSvcTest {
         network = createNetwork();
         loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
         parameters = new LoadFlowParameters();
+        parameters.setNoGeneratorReactiveLimits(true);
         OpenLoadFlowParameters parametersExt = new OpenLoadFlowParameters()
                 .setSlackBusSelector(new MostMeshedSlackBusSelector())
-                .setDistributedSlack(false)
-                .setReactiveLimits(false);
+                .setDistributedSlack(false);
         this.parameters.addExtension(OpenLoadFlowParameters.class, parametersExt);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTwoBusNetworkTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTwoBusNetworkTest.java
@@ -46,10 +46,10 @@ public class AcLoadFlowTwoBusNetworkTest {
 
         loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
         parameters = new LoadFlowParameters();
+        parameters.setNoGeneratorReactiveLimits(true);
         OpenLoadFlowParameters parametersExt = new OpenLoadFlowParameters()
                 .setSlackBusSelector(new FirstSlackBusSelector())
-                .setDistributedSlack(false)
-                .setReactiveLimits(false);
+                .setDistributedSlack(false);
         this.parameters.addExtension(OpenLoadFlowParameters.class, parametersExt);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
@@ -159,10 +159,10 @@ public class AcLoadFlowVscTest {
         network = createNetwork();
         loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
         parameters = new LoadFlowParameters();
+        parameters.setNoGeneratorReactiveLimits(true);
         OpenLoadFlowParameters parametersExt = new OpenLoadFlowParameters()
                 .setSlackBusSelector(new MostMeshedSlackBusSelector())
-                .setDistributedSlack(false)
-                .setReactiveLimits(false);
+                .setDistributedSlack(false);
         this.parameters.addExtension(OpenLoadFlowParameters.class, parametersExt);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcloadFlowReactiveLimitsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcloadFlowReactiveLimitsTest.java
@@ -111,9 +111,9 @@ public class AcloadFlowReactiveLimitsTest {
         createNetwork();
         loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
         parameters = new LoadFlowParameters();
+        parameters.setNoGeneratorReactiveLimits(false);
         parametersExt = new OpenLoadFlowParameters()
-                .setDistributedSlack(false)
-                .setReactiveLimits(true);
+                .setDistributedSlack(false);
         parameters.addExtension(OpenLoadFlowParameters.class, parametersExt);
     }
 
@@ -131,14 +131,14 @@ public class AcloadFlowReactiveLimitsTest {
 
     @Test
     public void test() {
-        parametersExt.setReactiveLimits(false);
+        parameters.setNoGeneratorReactiveLimits(true);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isOk());
         assertReactivePowerEquals(-109.228, gen.getTerminal());
         assertReactivePowerEquals(-152.265, gen2.getTerminal());
         assertReactivePowerEquals(-199.998, nhv2Nload.getTerminal2());
 
-        parametersExt.setReactiveLimits(true);
+        parameters.setNoGeneratorReactiveLimits(false);
         result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isOk());
         assertReactivePowerEquals(-164.315, gen.getTerminal());

--- a/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackTest.java
@@ -50,10 +50,10 @@ public class DistributedSlackTest {
         g4 = network.getGenerator("g4");
         loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
         parameters = new LoadFlowParameters();
+        parameters.setNoGeneratorReactiveLimits(true);
         OpenLoadFlowParameters parametersExt = new OpenLoadFlowParameters()
                 .setSlackBusSelector(new MostMeshedSlackBusSelector())
-                .setDistributedSlack(true)
-                .setReactiveLimits(false);
+                .setDistributedSlack(true);
         parameters.addExtension(OpenLoadFlowParameters.class, parametersExt);
     }
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -16,7 +16,7 @@
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
-    <logger name="com.powsybl.loadflow.open" level="INFO" additivity="false">
+    <logger name="com.powsybl.openloadflow" level="INFO" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
 </configuration>


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug


**What is the current behavior?** *(You can also link to an open issue here)*
To activate/deactivate reactive limits current code rely on a specific parameter in a LoadFlowParameter extension, but there was already an existing parameter for that noGeneratorReactiveLimits.


**What is the new behavior (if this is a feature change)?**
New code use noGeneratorReactiveLimits.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
