### PR TITLE
Fix distributed slack participation algorithm

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
@@ -24,6 +24,8 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LfGeneratorImpl.class);
 
+    private static final int DEFAULT_DROOP = 4; // why not
+
     private final Generator generator;
 
     private boolean participating;
@@ -34,16 +36,17 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
         super(generator.getTargetP());
         this.generator = generator;
         participating = true;
-        participationFactor = 4; // why not
+        double droop = DEFAULT_DROOP;
         // get participation factor from extension
         ActivePowerControl<Generator> activePowerControl = generator.getExtension(ActivePowerControl.class);
         if (activePowerControl != null) {
             participating = activePowerControl.isParticipate() && activePowerControl.getDroop() != 0;
             if (activePowerControl.getDroop() != 0) {
-                participationFactor = generator.getMaxP() / activePowerControl.getDroop();
+                droop = activePowerControl.getDroop();
             }
         }
-        if (generator.getTargetP() < 0) {
+        participationFactor = generator.getMaxP() / droop;
+        if (generator.getTargetP() <= 0) {
             LOGGER.warn("Discard generator '{}' from active power control because targetP ({}) <= 0",
                     generator.getId(), generator.getTargetP());
             participating = false;

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
@@ -24,7 +24,7 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LfGeneratorImpl.class);
 
-    private static final int DEFAULT_DROOP = 4; // why not
+    private static final double DEFAULT_DROOP = 4; // why not
 
     private final Generator generator;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The algorithm to compute a participation factor to distributed slack is different to the one in Hades2.


**What is the new behavior (if this is a feature change)?**
We have the same algo.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
