### PR TITLE
Exclude fictitious buses from slack bus selection

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/AbstractFictitiousLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractFictitiousLfBus.java
@@ -19,6 +19,11 @@ public abstract class AbstractFictitiousLfBus extends AbstractLfBus {
     }
 
     @Override
+    public boolean isFictitious() {
+        return true;
+    }
+
+    @Override
     public boolean hasVoltageControl() {
         return false;
     }

--- a/src/main/java/com/powsybl/openloadflow/network/LfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBus.java
@@ -17,6 +17,8 @@ public interface LfBus {
 
     int getNum();
 
+    boolean isFictitious();
+
     boolean isSlack();
 
     void setSlack(boolean slack);

--- a/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
+++ b/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
@@ -22,9 +22,9 @@ public class MostMeshedSlackBusSelector implements SlackBusSelector {
                 .max()
                 .orElseThrow(AssertionError::new);
 
-        // select most meshed bus among buses with highest nominal voltage
+        // select non fictitious and most meshed bus among buses with highest nominal voltage
         return buses.stream()
-                .filter(bus -> bus.getNominalV() == maxNominalV)
+                .filter(bus -> !bus.isFictitious() && bus.getNominalV() == maxNominalV)
                 .max(Comparator.comparingInt(LfBus::getNeighbors))
                 .orElseThrow(AssertionError::new);
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
@@ -70,6 +70,11 @@ public class LfBusImpl extends AbstractLfBus {
     }
 
     @Override
+    public boolean isFictitious() {
+        return false;
+    }
+
+    @Override
     public boolean hasVoltageControl() {
         return voltageControl;
     }

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlow3wtTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlow3wtTest.java
@@ -156,10 +156,10 @@ public class AcLoadFlow3wtTest {
         assertTrue(result.isOk());
 
         assertVoltageEquals(405, bus1);
-        LoadFlowAssert.assertAngleEquals(2.720264, bus1);
+        LoadFlowAssert.assertAngleEquals(0, bus1);
         assertVoltageEquals(235.132, bus2);
-        LoadFlowAssert.assertAngleEquals(0.462642, bus2);
+        LoadFlowAssert.assertAngleEquals(-2.259241, bus2);
         assertVoltageEquals(20.834, bus3);
-        LoadFlowAssert.assertAngleEquals(0, bus3);
+        LoadFlowAssert.assertAngleEquals(-2.721885, bus3);
     }
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Fictitious bus could be created for 3 windings transformers and dangling lines. Unfortunatly, it could happen that one of the fictitious bus is  selected as slack by "most meshed" slack bus selector. 


**What is the new behavior (if this is a feature change)?**
Fictitious buses are discarded from slack bus selection.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
