### PR TITLE
Remote voltage control not yet supported: rescale to a local control.

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
@@ -123,8 +123,8 @@ public class LfBusImpl extends AbstractLfBus {
         }
     }
 
-    void addGenerator(Generator generator) {
-        add(LfGeneratorImpl.create(generator), generator.isVoltageRegulatorOn(), generator.getTargetV(),
+    void addGenerator(Generator generator, double scaleV) {
+        add(LfGeneratorImpl.create(generator), generator.isVoltageRegulatorOn(), generator.getTargetV() * scaleV,
                 generator.getTargetQ());
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -69,17 +69,18 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
 
                 @Override
                 public void visitGenerator(Generator generator) {
+                    double scaleV = 1;
                     if (!Objects.equals(generator.getRegulatingTerminal().getBusView().getBus().getId(),
                             generator.getTerminal().getBusView().getBus().getId())) {
                         double previousTargetV = generator.getTargetV();
                         double remoteNominalV = generator.getRegulatingTerminal().getVoltageLevel().getNominalV();
                         double localNominalV = generator.getTerminal().getVoltageLevel().getNominalV();
-                        generator.setTargetV((generator.getTargetV() * localNominalV) / remoteNominalV);
+                        scaleV = localNominalV / remoteNominalV;
                         LOGGER.warn("Generator remote voltage control is not yet supported. The voltage target of generator "
                                 + generator.getId() + " with remote control is rescaled from " + previousTargetV + " to "
-                                + generator.getTargetV());
+                                + previousTargetV * scaleV);
                     }
-                    lfBus.addGenerator(generator);
+                    lfBus.addGenerator(generator, scaleV);
                     generatorCount[0]++;
                 }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworks.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworks.java
@@ -81,7 +81,13 @@ public final class LfNetworks {
                 public void visitGenerator(Generator generator) {
                     if (!Objects.equals(generator.getRegulatingTerminal().getBusView().getBus().getId(),
                             generator.getTerminal().getBusView().getBus().getId())) {
-                        throw new PowsyblException("Generator remote voltage control is not yet supported");
+                        double previousTargetV = generator.getTargetV();
+                        double remoteNominalV = generator.getRegulatingTerminal().getVoltageLevel().getNominalV();
+                        double localNominalV = generator.getTerminal().getVoltageLevel().getNominalV();
+                        generator.setTargetV((generator.getTargetV() * localNominalV) / remoteNominalV);
+                        LOGGER.warn("Generator remote voltage control is not yet supported. The voltage target of generator "
+                                + generator.getId() + " with remote control is rescaled from " + previousTargetV + " to "
+                                + generator.getTargetV());
                     }
                     lfBus.addGenerator(generator);
                     generatorCount[0]++;

--- a/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlLocalRescaleTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlLocalRescaleTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.ac;
+
+import com.powsybl.iidm.network.*;
+import com.powsybl.loadflow.LoadFlow;
+import com.powsybl.loadflow.LoadFlowResult;
+import com.powsybl.math.matrix.DenseMatrixFactory;
+import com.powsybl.openloadflow.OpenLoadFlowProvider;
+import com.powsybl.openloadflow.util.LoadFlowAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class GeneratorRemoteControlLocalRescaleTest {
+
+    private Network network;
+    private Bus b1;
+    private Bus b2;
+    private LoadFlow.Runner loadFlowRunner;
+
+    @BeforeEach
+    public void setUp() {
+        network = Network.create("GeneratorRemoteControlLocalRescaleTest", "code");
+        Substation s = network.newSubstation()
+                .setId("s")
+                .add();
+        VoltageLevel vl1 = s.newVoltageLevel()
+                .setId("vl1")
+                .setNominalV(20)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        b1 = vl1.getBusBreakerView().newBus()
+                .setId("b1")
+                .add();
+        VoltageLevel vl2 = s.newVoltageLevel()
+                .setId("vl2")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        b2 = vl2.getBusBreakerView().newBus()
+                .setId("b2")
+                .add();
+        Load l2 = vl2.newLoad()
+                .setId("l2")
+                .setBus("b2")
+                .setConnectableBus("b2")
+                .setP0(99.9)
+                .setQ0(80)
+                .add();
+        b1.getVoltageLevel()
+                .newGenerator()
+                .setId("g1")
+                .setBus("b1")
+                .setConnectableBus("b1")
+                .setEnergySource(EnergySource.THERMAL)
+                .setMinP(0)
+                .setMaxP(200)
+                .setTargetP(100)
+                .setTargetV(413.4)
+                .setVoltageRegulatorOn(true)
+                .setRegulatingTerminal(l2.getTerminal())
+                .add();
+        s.newTwoWindingsTransformer()
+                .setId("tr1")
+                .setVoltageLevel1(b1.getVoltageLevel().getId())
+                .setBus1(b1.getId())
+                .setConnectableBus1(b1.getId())
+                .setVoltageLevel2(vl2.getId())
+                .setBus2(b2.getId())
+                .setConnectableBus2(b2.getId())
+                .setRatedU1(20.5)
+                .setRatedU2(399)
+                .setR(1)
+                .setX(30)
+                .setG(0)
+                .setB(0)
+                .add();
+
+        loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
+    }
+
+    @Test
+    public void test() {
+        LoadFlowResult result = loadFlowRunner.run(network);
+        assertTrue(result.isOk());
+        LoadFlowAssert.assertVoltageEquals(20.67, b1); // check local targetV has been correctly rescaled
+        LoadFlowAssert.assertVoltageEquals(395.927, b2);
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

The remote voltage control for generators is not yet supported. The loadflow fails.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

The target voltage of the generator is rescaled to a value that is coherent with the local nominal voltage.

**What is the current behavior?** *(You can also link to an open issue here)*

No calculation.

**What is the new behavior (if this is a feature change)?**

An approximative calculation.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

This PR has to be completed in order to use a parameter from the config file, once the remote control is implemented.
