### PR TITLE
SVC reactive limits

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/AbstractLfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractLfGenerator.java
@@ -66,7 +66,6 @@ public abstract class AbstractLfGenerator implements LfGenerator {
                             maxRangeQ = Math.max(maxRangeQ, point.getMaxQ() - point.getMinQ());
                         }
                     }
-                    maxRangeQ = maxRangeQ / PerUnit.SB;
                     break;
 
                 case MIN_MAX:
@@ -77,7 +76,7 @@ public abstract class AbstractLfGenerator implements LfGenerator {
                 default:
                     throw new IllegalStateException("Unknown reactive limits kind: " + reactiveLimits.getKind());
             }
-            return maxRangeQ;
+            return maxRangeQ / PerUnit.SB;
         } else {
             return Double.MAX_VALUE;
         }

--- a/src/main/java/com/powsybl/openloadflow/network/AbstractLfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractLfGenerator.java
@@ -65,6 +65,7 @@ public abstract class AbstractLfGenerator implements LfGenerator {
                         } else {
                             maxRangeQ = Math.max(maxRangeQ, point.getMaxQ() - point.getMinQ());
                         }
+                        maxRangeQ = maxRangeQ / PerUnit.SB;
                     }
                     break;
 
@@ -76,7 +77,7 @@ public abstract class AbstractLfGenerator implements LfGenerator {
                 default:
                     throw new IllegalStateException("Unknown reactive limits kind: " + reactiveLimits.getKind());
             }
-            return maxRangeQ / PerUnit.SB;
+            return maxRangeQ;
         } else {
             return Double.MAX_VALUE;
         }

--- a/src/main/java/com/powsybl/openloadflow/network/AbstractLfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractLfGenerator.java
@@ -65,8 +65,8 @@ public abstract class AbstractLfGenerator implements LfGenerator {
                         } else {
                             maxRangeQ = Math.max(maxRangeQ, point.getMaxQ() - point.getMinQ());
                         }
-                        maxRangeQ = maxRangeQ / PerUnit.SB;
                     }
+                    maxRangeQ = maxRangeQ / PerUnit.SB;
                     break;
 
                 case MIN_MAX:

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfStaticVarCompensatorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfStaticVarCompensatorImpl.java
@@ -6,7 +6,9 @@
  */
 package com.powsybl.openloadflow.network.impl;
 
+import com.powsybl.iidm.network.MinMaxReactiveLimits;
 import com.powsybl.iidm.network.ReactiveLimits;
+import com.powsybl.iidm.network.ReactiveLimitsKind;
 import com.powsybl.iidm.network.StaticVarCompensator;
 import com.powsybl.openloadflow.network.AbstractLfGenerator;
 import com.powsybl.openloadflow.network.PerUnit;
@@ -21,9 +23,43 @@ public final class LfStaticVarCompensatorImpl extends AbstractLfGenerator {
 
     private final StaticVarCompensator svc;
 
+    private final ReactiveLimits reactiveLimits;
+
     private LfStaticVarCompensatorImpl(StaticVarCompensator svc) {
         super(0);
         this.svc = svc;
+        double nominalV = svc.getTerminal().getVoltageLevel().getNominalV();
+        double zb = nominalV * nominalV / PerUnit.SB;
+        // min and  max reactive limit are calculated at nominal voltage
+        double minQ = svc.getBmin() * zb;
+        double maxQ = svc.getBmax() * zb;
+        reactiveLimits = new MinMaxReactiveLimits() {
+
+            @Override
+            public double getMinQ() {
+                return minQ;
+            }
+
+            @Override
+            public double getMaxQ() {
+                return maxQ;
+            }
+
+            @Override
+            public ReactiveLimitsKind getKind() {
+                return ReactiveLimitsKind.MIN_MAX;
+            }
+
+            @Override
+            public double getMinQ(double p) {
+                return getMinQ();
+            }
+
+            @Override
+            public double getMaxQ(double p) {
+                return getMaxQ();
+            }
+        };
     }
 
     public static LfStaticVarCompensatorImpl create(StaticVarCompensator svc) {
@@ -68,7 +104,7 @@ public final class LfStaticVarCompensatorImpl extends AbstractLfGenerator {
 
     @Override
     protected Optional<ReactiveLimits> getReactiveLimits() {
-        return Optional.empty();
+        return Optional.of(reactiveLimits);
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfStaticVarCompensatorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfStaticVarCompensatorImpl.java
@@ -29,10 +29,9 @@ public final class LfStaticVarCompensatorImpl extends AbstractLfGenerator {
         super(0);
         this.svc = svc;
         double nominalV = svc.getTerminal().getVoltageLevel().getNominalV();
-        double zb = nominalV * nominalV / PerUnit.SB;
         // min and  max reactive limit are calculated at nominal voltage
-        double minQ = svc.getBmin() * zb;
-        double maxQ = svc.getBmax() * zb;
+        double minQ = svc.getBmin() * nominalV * nominalV;
+        double maxQ = svc.getBmax() * nominalV * nominalV;
         reactiveLimits = new MinMaxReactiveLimits() {
 
             @Override


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Static var compensator reactive limits are not taken into account.


**What is the new behavior (if this is a feature change)?**
We use bmin and bmax to compute reactive limits at nominal voltage.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
