### PR TITLE
Fix Sonar cloud coverage

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,12 +20,12 @@ jobs:
           java-version: 1.8
 
       - name: Build with Maven
-        run: mvn --batch-mode package
+        run: mvn --batch-mode -Pjacoco install
 
       - name: Run SonarCloud analysis
         if: matrix.os == 'ubuntu-latest'
         run: >
-          mvn --batch-mode -Pjacoco package sonar:sonar
+          mvn --batch-mode -DskipTests sonar:sonar
           -Dsonar.host.url=https://sonarcloud.io
           -Dsonar.organization=powsybl-ci-github
           -Dsonar.projectKey=com.powsybl:powsybl-open-loadflow

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <maven.findbugs.version>3.0.5</maven.findbugs.version>
         <maven.gpg.version>1.6</maven.gpg.version>
         <maven.install.version>2.5.2</maven.install.version>
-        <maven.jacoco.version>0.8.1</maven.jacoco.version>
+        <maven.jacoco.version>0.8.2</maven.jacoco.version>
         <maven.jar.version>3.1.0</maven.jar.version>
         <maven.javadoc.version>3.0.1</maven.javadoc.version>
         <maven.plugin.version>3.5.2</maven.plugin.version>
@@ -230,6 +230,13 @@
                                 <id>prepare-agent</id>
                                 <goals>
                                     <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>report</goal>
                                 </goals>
                             </execution>
                         </executions>


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Sonar cloud coverage is broken as jacoco.exec support has been removed.


**What is the new behavior (if this is a feature change)?**
jacoco.xml is generated instead of jacoco.exec


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
