### PR TITLE
A generator with maxP equal to Infinity is discarded from active power control.

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
@@ -59,6 +59,11 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
             report.generatorsDiscardedFromActivePowerControlBecauseTargetPGreaterThenMaxP++;
             participating = false;
         }
+        if (generator.getMaxP() > Double.MAX_VALUE) {
+            LOGGER.trace("Discard generator '{}' from active power control because maxP ({}) > Infinity",
+                    generator.getId(), generator.getMaxP());
+            participating = false;
+        }
     }
 
     public static LfGeneratorImpl create(Generator generator, LfNetworkLoadingReport report) {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
@@ -59,8 +59,8 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
             report.generatorsDiscardedFromActivePowerControlBecauseTargetPGreaterThenMaxP++;
             participating = false;
         }
-        if (generator.getMaxP() > Double.MAX_VALUE) {
-            LOGGER.trace("Discard generator '{}' from active power control because maxP ({}) > Infinity",
+        if (generator.getMaxP() > 10000) {
+            LOGGER.trace("Discard generator '{}' from active power control because maxP ({}) > 10000 MW",
                     generator.getId(), generator.getMaxP());
             participating = false;
         }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
@@ -64,6 +64,7 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
         if (generator.getMaxP() > PLAUSIBLE_ACTIVE_POWER_LIMIT) {
             LOGGER.trace("Discard generator '{}' from active power control because maxP ({}) > {}} MW",
                     generator.getId(), generator.getMaxP(), PLAUSIBLE_ACTIVE_POWER_LIMIT);
+            report.generatorsDiscardedFromActivePowerControlBecauseMaxPNotPlausible++;
             participating = false;
         }
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
@@ -27,6 +27,8 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
 
     private static final double DEFAULT_DROOP = 4; // why not
 
+    private static final int PLAUSIBLE_ACTIVE_POWER_LIMIT = 10000;
+
     private final Generator generator;
 
     private boolean participating;
@@ -59,9 +61,9 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
             report.generatorsDiscardedFromActivePowerControlBecauseTargetPGreaterThenMaxP++;
             participating = false;
         }
-        if (generator.getMaxP() > 10000) {
-            LOGGER.trace("Discard generator '{}' from active power control because maxP ({}) > 10000 MW",
-                    generator.getId(), generator.getMaxP());
+        if (generator.getMaxP() > PLAUSIBLE_ACTIVE_POWER_LIMIT) {
+            LOGGER.trace("Discard generator '{}' from active power control because maxP ({}) > {}} MW",
+                    generator.getId(), generator.getMaxP(), PLAUSIBLE_ACTIVE_POWER_LIMIT);
             participating = false;
         }
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -203,6 +203,10 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
             LOGGER.warn("{} generators have been discarded from active power control because of a targetP > maxP",
                     report.generatorsDiscardedFromActivePowerControlBecauseTargetPGreaterThenMaxP);
         }
+        if (report.generatorsDiscardedFromActivePowerControlBecauseMaxPNotPlausible > 0) {
+            LOGGER.warn("{} generators have been discarded from active power control because of maxP not plausible",
+                    report.generatorsDiscardedFromActivePowerControlBecauseMaxPNotPlausible);
+        }
 
         return lfNetwork;
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoadingReport.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoadingReport.java
@@ -18,4 +18,6 @@ class LfNetworkLoadingReport {
     int generatorsDiscardedFromActivePowerControlBecauseTargetPLesserOrEqualsToZero = 0;
 
     int generatorsDiscardedFromActivePowerControlBecauseTargetPGreaterThenMaxP = 0;
+
+    int generatorsDiscardedFromActivePowerControlBecauseMaxPNotPlausible = 0;
 }


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <atilloy@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

A bug fix. I have just added a test to discard from the active power control generators which Pmax are close to Infinity. This test seams necessary for computations that comes from a CGMES conversion.  

**What is the current behavior?** *(You can also link to an open issue here)*

The compensation fails because factors are equal to zero when they are rescaled by the sum of factors (=Infinity).

**What is the new behavior (if this is a feature change)?**

The sum is done without any Infinity value.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
