### PR TITLE
Allow three windings transformers to have a RTC or a PTC at any leg

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ network.getBusView().getBusStream().forEach(b -> System.out.println(b.getId() + 
 
 PowSyBl Open Load Flow could support more features. The following list is not exhaustive and is an invitation to collaborate:  
 - Distributed slack on loads;
+- The possibility for an initial PV bus that has switched to PQ bus to go back to PV node. 
 - A distributed slack that can be configured by country;
 - A better treatment of non and low impedance lines. A good way to deal with this kind of lines is to merge the buses;
 - Computation on all connected components;

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
@@ -31,10 +31,11 @@ public class LfLegBranch extends AbstractLfBranch {
     private Evaluable q = NAN;
 
     protected LfLegBranch(LfBus bus1, LfBus bus0, ThreeWindingsTransformer twt, ThreeWindingsTransformer.Leg leg) {
-        super(bus1, bus0, new PiModel(leg.getR(), leg.getX())
-                            .setR1(Transformers.getRatioLeg(twt, leg))
-                            .setG1(leg.getG())
-                            .setB1(leg.getB()),
+        super(bus1, bus0, new PiModel(Transformers.getR(leg), Transformers.getX(leg))
+                        .setG1(Transformers.getG1(leg))
+                        .setB1(Transformers.getB1(leg))
+                        .setR1(Transformers.getRatioLeg(twt, leg))
+                        .setA1(Transformers.getAngleLeg(leg)),
                 twt.getId(),
                 leg.getTerminal().getVoltageLevel().getNominalV(),
                 twt.getRatedU0()); // Star bus.

--- a/src/main/java/com/powsybl/openloadflow/network/impl/Transformers.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/Transformers.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.openloadflow.network.impl;
 
+import com.powsybl.iidm.network.PhaseTapChanger;
+import com.powsybl.iidm.network.RatioTapChanger;
 import com.powsybl.iidm.network.ThreeWindingsTransformer;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
 
@@ -18,7 +20,7 @@ public final class Transformers {
     }
 
     /**
-     * Get ratio on side 1.
+     * Get ratio on side 1 of a two windings transformer.
      */
     public static double getRatio(TwoWindingsTransformer twt) {
         double rho = twt.getRatedU2() / twt.getRatedU1();
@@ -32,57 +34,130 @@ public final class Transformers {
     }
 
     /**
-     * Get ratio of a three windings transformer leg.
+     * Get ratio on network side of a three windings transformer leg.
      */
     public static double getRatioLeg(ThreeWindingsTransformer twt, ThreeWindingsTransformer.Leg leg) {
         double rho = twt.getRatedU0() / leg.getRatedU();
         if (leg.getRatioTapChanger() != null) {
             rho *= leg.getRatioTapChanger().getCurrentStep().getRho();
         }
+        if (leg.getPhaseTapChanger() != null) {
+            rho *= leg.getPhaseTapChanger().getCurrentStep().getRho();
+        }
         return rho;
     }
 
     /**
-     * Get shift angle on side 1.
+     * Get shift angle on side 1 of a two windings transformer.
      */
     public static double getAngle(TwoWindingsTransformer twt) {
         return twt.getPhaseTapChanger() != null ? Math.toRadians(twt.getPhaseTapChanger().getCurrentStep().getAlpha()) : 0f;
+    }
+
+    /**
+     * Get shift angle on network side of a three windings transformer leg.
+     */
+    public static double getAngleLeg(ThreeWindingsTransformer.Leg leg) {
+        return leg.getPhaseTapChanger() != null ? Math.toRadians(leg.getPhaseTapChanger().getCurrentStep().getAlpha()) : 0f;
     }
 
     private static double getValue(double initialValue, double rtcStepValue, double ptcStepValue) {
         return initialValue * (1 + rtcStepValue / 100) * (1 + ptcStepValue / 100);
     }
 
+    /**
+     * Get the nominal series resistance of a two windings transformer, located on side 2.
+     */
     public static double getR(TwoWindingsTransformer twt) {
-        return getValue(twt.getR(),
-                twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getR() : 0,
-                twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getR() : 0);
+        return getX(twt.getR(), twt.getRatioTapChanger(), twt.getPhaseTapChanger());
     }
 
+    /**
+     * Get the nominal series resistance of a three windings transformer leg, located on bus star side.
+     */
+    public static double getR(ThreeWindingsTransformer.Leg leg) {
+        return getR(leg.getR(), leg.getRatioTapChanger(), leg.getPhaseTapChanger());
+    }
+
+    private static double getR(double r, RatioTapChanger rtc, PhaseTapChanger ptc) {
+        return getValue(r,
+                rtc != null ? rtc.getCurrentStep().getR() : 0,
+                ptc != null ? ptc.getCurrentStep().getR() : 0);
+    }
+
+    /**
+     * Get the nominal series reactance of a two windings transformer, located on side 2.
+     */
     public static double getX(TwoWindingsTransformer twt) {
-        return getValue(twt.getX(),
-                twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getX() : 0,
-                twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getX() : 0);
+        return getX(twt.getX(), twt.getRatioTapChanger(), twt.getPhaseTapChanger());
+    }
+
+    /**
+     * Get the nominal series reactance of a three windings transformer leg, located on bus star side.
+     */
+    public static double getX(ThreeWindingsTransformer.Leg leg) {
+        return getX(leg.getX(), leg.getRatioTapChanger(), leg.getPhaseTapChanger());
+    }
+
+    private static double getX(double x, RatioTapChanger rtc, PhaseTapChanger ptc) {
+        return getValue(x,
+                rtc != null ? rtc.getCurrentStep().getX() : 0,
+                ptc != null ? ptc.getCurrentStep().getX() : 0);
+    }
+
+    /**
+     * Get the nominal magnetizing conductance of a two windings transformer, located on side 2.
+     */
+    public static double getG1(TwoWindingsTransformer twt, boolean specificCompatibility) {
+        return getG1(specificCompatibility ? twt.getG() / 2 : twt.getG(), twt.getRatioTapChanger(), twt.getPhaseTapChanger());
+    }
+
+    /**
+     * Get the nominal magnetizing conductance of a three windings transformer, located on bus star side.
+     */
+    public static double getG1(ThreeWindingsTransformer.Leg leg, boolean specificCompatibility) {
+        return getG1(specificCompatibility ? leg.getG() / 2 : leg.getG(), leg.getRatioTapChanger(), leg.getPhaseTapChanger());
     }
 
     public static double getG1(TwoWindingsTransformer twt) {
         return getG1(twt, false);
     }
 
-    public static double getG1(TwoWindingsTransformer twt, boolean specificCompatibility) {
-        return getValue(specificCompatibility ? twt.getG() / 2 : twt.getG(),
-                twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getG() : 0,
-                twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getG() : 0);
+    public static double getG1(ThreeWindingsTransformer.Leg leg) {
+        return getG1(leg, false);
+    }
+
+    private static double getG1(double g1, RatioTapChanger rtc, PhaseTapChanger ptc) {
+        return getValue(g1,
+                rtc != null ? rtc.getCurrentStep().getG() : 0,
+                ptc != null ? ptc.getCurrentStep().getG() : 0);
+    }
+
+    /**
+     * Get the nominal magnetizing susceptance of a two windings transformer, located on side 2.
+     */
+    public static double getB1(TwoWindingsTransformer twt, boolean specificCompatibility) {
+        return getB1(specificCompatibility ? twt.getB() / 2 : twt.getB(), twt.getRatioTapChanger(), twt.getPhaseTapChanger());
+    }
+
+    /**
+     * Get the nominal magnetizing susceptance of a three windings transformer, located on bus star side.
+     */
+    public static double getB1(ThreeWindingsTransformer.Leg leg, boolean specificCompatibility) {
+        return getB1(specificCompatibility ? leg.getB() / 2 : leg.getB(), leg.getRatioTapChanger(), leg.getPhaseTapChanger());
     }
 
     public static double getB1(TwoWindingsTransformer twt) {
         return getB1(twt, false);
     }
 
-    public static double getB1(TwoWindingsTransformer twt, boolean specificCompatibility) {
-        return getValue(specificCompatibility ? twt.getB() / 2 : twt.getB(),
-                twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getB() : 0,
-                twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getB() : 0);
+    public static double getB1(ThreeWindingsTransformer.Leg leg) {
+        return getB1(leg, false);
     }
 
+    private static double getB1(double b1, RatioTapChanger rtc, PhaseTapChanger ptc) {
+        return getValue(b1,
+                rtc != null ? rtc.getCurrentStep().getB() : 0,
+                ptc != null ? ptc.getCurrentStep().getB() : 0);
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlow3wtTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlow3wtTest.java
@@ -206,7 +206,7 @@ public class AcLoadFlow3wtTest {
                 .setAlpha(0)
                 .endStep()
                 .add();
-        // create a transformer in // between bus 1 / bus2
+        // create a transformer between bus 1 / bus2 in parallel of leg1 / leg2
         TwoWindingsTransformer twtParallel = s.newTwoWindingsTransformer()
                 .setId("2wt")
                 .setVoltageLevel1("vl1")

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlow3wtTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlow3wtTest.java
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class AcLoadFlow3wtTest {
 
     private Network network;
+    private Substation s;
     private Bus bus1;
     private Bus bus2;
     private Bus bus3;
@@ -50,7 +51,7 @@ public class AcLoadFlow3wtTest {
     private Network createNetwork() {
         Network network = Network.create("vsc", "test");
 
-        Substation s = network.newSubstation()
+        s = network.newSubstation()
                 .setId("s")
                 .add();
         VoltageLevel vl1 = s.newVoltageLevel()
@@ -167,5 +168,70 @@ public class AcLoadFlow3wtTest {
         assertReactivePowerEquals(-74, twt.getLeg2().getTerminal());
         assertActivePowerEquals(0, twt.getLeg3().getTerminal());
         assertReactivePowerEquals(0, twt.getLeg3().getTerminal());
+    }
+
+    @Test
+    public void testWithRatioTapChangers() {
+        // create a ratio tap changer on leg 1 and check that voltages on leg 2 and 3 have changed compare to previous
+        // test
+        twt.getLeg1().newRatioTapChanger()
+                .setLoadTapChangingCapabilities(false)
+                .setTapPosition(0)
+                .beginStep()
+                    .setR(5)
+                    .setX(10)
+                    .setG(0)
+                    .setB(0)
+                    .setRho(0.9)
+                .endStep()
+            .add();
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertVoltageEquals(405, bus1);
+        assertVoltageEquals(209.886, bus2);
+        assertVoltageEquals(18.582, bus3);
+    }
+
+    @Test
+    public void testWithPhaseTapChangers() {
+        // create a phase tap changer at leg 2 with a zero phase shifting
+        PhaseTapChanger ptc = twt.getLeg2().newPhaseTapChanger()
+                .setTapPosition(0)
+                .beginStep()
+                .setR(0)
+                .setX(0)
+                .setG(0)
+                .setB(0)
+                .setRho(1)
+                .setAlpha(0)
+                .endStep()
+                .add();
+        // create a transformer in // between bus 1 / bus2
+        TwoWindingsTransformer twtParallel = s.newTwoWindingsTransformer()
+                .setId("2wt")
+                .setVoltageLevel1("vl1")
+                .setBus1("b1")
+                .setConnectableBus1("b1")
+                .setVoltageLevel2("vl2")
+                .setBus2("b2")
+                .setConnectableBus2("b2")
+                .setRatedU1(390)
+                .setRatedU2(220)
+                .setR(4)
+                .setX(80)
+                .setG(0)
+                .setB(0)
+                .add();
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertActivePowerEquals(21.97, twtParallel.getTerminal1());
+        assertActivePowerEquals(-139.088, twt.getLeg2().getTerminal());
+
+        // set the phase shifting to 10 degree and check active flow change
+        ptc.getStep(0).setAlpha(10);
+        result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertActivePowerEquals(121.691, twtParallel.getTerminal1());
+        assertActivePowerEquals(-40.451, twt.getLeg2().getTerminal());
     }
 }


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <atilloy@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No, but it could be classified as a bug fix. At that moment, the modeling of three windings transformers in the open load flow through the pi model only allows to have a constant R, X, G and B, and a ratio by leg. 

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

With this PR, we allow to model at any leg of a three windings transformers a ratio tap changer and a phase tap changer. It means that R, X, G and B depend on the tap position. We also introduce the possibility to have a ratio and a phase sfifting at any leg. 

Note that in this PR, the tap position is a constant for the open load flow.

**What is the current behavior?** *(You can also link to an open issue here)*

See above.

**What is the new behavior (if this is a feature change)?**

See above.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
