### PR TITLE
Throws an exception in case of x=0 in DC loadflow.

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
@@ -34,6 +34,9 @@ public abstract class AbstractClosedBranchDcFlowEquationTerm extends AbstractEqu
 
     protected AbstractClosedBranchDcFlowEquationTerm(LfBranch branch, LfBus bus1, LfBus bus2, VariableSet variableSet) {
         this.branch = Objects.requireNonNull(branch);
+        if (branch.x() == 0) {
+            throw new IllegalArgumentException("Branch '" + branch.getId() + "' has reactance equal to zero");
+        }
         ph1Var = variableSet.getVariable(bus1.getNum(), VariableType.BUS_PHI);
         ph2Var = variableSet.getVariable(bus2.getNum(), VariableType.BUS_PHI);
         variables = ImmutableList.of(ph1Var, ph2Var);

--- a/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowTest.java
@@ -22,8 +22,9 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.usefultoys.slf4j.LoggerFactory;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.concurrent.CompletionException;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
@@ -149,5 +150,12 @@ public class DcLoadFlowTest {
         assertEquals(-81.5, l2.getTerminal2().getP(), 0.01);
         assertEquals(81.5, ps1.getTerminal1().getP(), 0.01);
         assertEquals(-81.5, ps1.getTerminal2().getP(), 0.01);
+    }
+
+    @Test
+    public void reactanceEqualToZeroTest() {
+        Network network = FourBusNetworkFactory.create();
+        network.getLine("l14").setR(0.00001).setX(0);
+        assertThrows(CompletionException.class, () -> loadFlowRunner.run(network, parameters));
     }
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix.


**What is the current behavior?** *(You can also link to an open issue here)*
In case if a branch with x=0 in DC mode, we endup with a by zero division and NaN in the core computation.


**What is the new behavior (if this is a feature change)?**
Waiting for a real fix, we just throw an exception to stop the computation.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
