### PR TITLE
Add target voltage consistency validations

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/ReactiveLimitsOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/ReactiveLimitsOuterLoop.java
@@ -42,22 +42,20 @@ public class ReactiveLimitsOuterLoop implements OuterLoop {
         Equation qEq = equationSystem.createEquation(bus.getNum(), EquationType.BUS_Q);
         qEq.setActive(true);
 
-        LfBus remoteControltargetBus = bus.getRemoteControlTargetBus().orElse(null);
-        if (remoteControltargetBus != null) {
-            // target bus only control voltage if one of the source bus has voltage control on
-            List<LfBus> sourceBusesControllingVoltage = remoteControltargetBus.getRemoteControlSourceBuses().stream()
+        LfBus controlledBus = bus.getControlledBus().orElse(null);
+        if (controlledBus != null) {
+            // clean reactive power distribution equations
+            controlledBus.getControllerBuses().forEach(b -> equationSystem.removeEquation(b.getNum(), EquationType.ZERO));
+
+            // controlled bus has a voltage equation only if one of the controller bus has voltage control on
+            List<LfBus> controllerBusesWithVoltageControlOn = controlledBus.getControllerBuses().stream()
                     .filter(LfBus::hasVoltageControl)
                     .collect(Collectors.toList());
-            equationSystem.createEquation(remoteControltargetBus.getNum(), EquationType.BUS_V).setActive(!sourceBusesControllingVoltage.isEmpty());
+            equationSystem.createEquation(controlledBus.getNum(), EquationType.BUS_V).setActive(!controllerBusesWithVoltageControlOn.isEmpty());
 
-            // clean reactive power distribution equations
-            for (LfBus remoteControlSourceBus : remoteControltargetBus.getRemoteControlSourceBuses()) {
-                equationSystem.removeEquation(remoteControlSourceBus.getNum(), EquationType.ZERO);
-            }
-
-            // create reactive power equations on source buses controlling voltage
-            if (!sourceBusesControllingVoltage.isEmpty()) {
-                AcEquationSystem.createReactivePowerDistributionEquations(equationSystem, variableSet, sourceBusesControllingVoltage);
+            // create reactive power equations on controller buses that have voltage control on
+            if (!controllerBusesWithVoltageControlOn.isEmpty()) {
+                AcEquationSystem.createReactivePowerDistributionEquations(equationSystem, variableSet, controllerBusesWithVoltageControlOn);
             }
         } else {
             Equation vEq = equationSystem.createEquation(bus.getNum(), EquationType.BUS_V);

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.openloadflow.ac.equations;
 
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.openloadflow.equations.*;
 import com.powsybl.openloadflow.network.*;
 import org.slf4j.Logger;
@@ -74,15 +73,9 @@ public final class AcEquationSystem {
         if (sourceBusesControllingVoltage.isEmpty()) {
             vEq.setActive(false);
         } else {
-            // check voltage target consistency
-            if (sourceBusesControllingVoltage.stream().mapToDouble(LfBus::getTargetV).distinct().count() != 1) {
-                throw new PowsyblException("Inconsistent target voltage at bus " + bus.getId());
-            }
-
             // create reactive power distribution equations at remote control sources buses (except one)
             createReactivePowerDistributionEquations(equationSystem, variableSet, sourceBusesControllingVoltage);
         }
-
     }
 
     public static void createReactivePowerDistributionEquations(EquationSystem equationSystem, VariableSet variableSet,

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
@@ -46,7 +46,7 @@ public final class AcEquationSystem {
                 equationSystem.createEquation(bus.getNum(), EquationType.BUS_Q).setActive(false);
             }
 
-            // in case of voltage remote control set target equations
+            // in case voltage remote control is activated, set voltage equation on this controlled bus
             if (voltageRemoteControl && !bus.getControllerBuses().isEmpty()) {
                 createVoltageControlledBusEquations(bus, equationSystem, variableSet);
             }

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
@@ -39,15 +39,16 @@ public final class AcEquationSystem {
             }
 
             if (bus.hasVoltageControl()) {
-                if (!voltageRemoteControl || !bus.getRemoteControlTargetBus().isPresent()) {
+                // local voltage control
+                if (!voltageRemoteControl || !bus.getControlledBus().isPresent()) {
                     equationSystem.createEquation(bus.getNum(), EquationType.BUS_V).addTerm(new BusVoltageEquationTerm(bus, variableSet));
                 }
                 equationSystem.createEquation(bus.getNum(), EquationType.BUS_Q).setActive(false);
             }
 
             // in case of voltage remote control set target equations
-            if (voltageRemoteControl && !bus.getRemoteControlSourceBuses().isEmpty()) {
-                createTargetBusEquations(bus, equationSystem, variableSet);
+            if (voltageRemoteControl && !bus.getControllerBuses().isEmpty()) {
+                createVoltageControlledBusEquations(bus, equationSystem, variableSet);
             }
 
             createShuntEquations(network, variableSet, equationSystem, bus);
@@ -62,44 +63,44 @@ public final class AcEquationSystem {
         }
     }
 
-    private static void createTargetBusEquations(LfBus bus, EquationSystem equationSystem, VariableSet variableSet) {
-        // create voltage equation at remote control target bus
+    private static void createVoltageControlledBusEquations(LfBus bus, EquationSystem equationSystem, VariableSet variableSet) {
+        // create voltage equation at voltage controlled bus
         Equation vEq = equationSystem.createEquation(bus.getNum(), EquationType.BUS_V)
                 .addTerm(new BusVoltageEquationTerm(bus, variableSet));
 
-        List<LfBus> sourceBusesControllingVoltage = bus.getRemoteControlSourceBuses().stream()
+        List<LfBus> controllerBuses = bus.getControllerBuses().stream()
                 .filter(LfBus::hasVoltageControl)
                 .collect(Collectors.toList());
-        if (sourceBusesControllingVoltage.isEmpty()) {
+        if (controllerBuses.isEmpty()) {
             vEq.setActive(false);
         } else {
-            // create reactive power distribution equations at remote control sources buses (except one)
-            createReactivePowerDistributionEquations(equationSystem, variableSet, sourceBusesControllingVoltage);
+            // create reactive power distribution equations at voltage controller buses (except one)
+            createReactivePowerDistributionEquations(equationSystem, variableSet, controllerBuses);
         }
     }
 
     public static void createReactivePowerDistributionEquations(EquationSystem equationSystem, VariableSet variableSet,
-                                                                List<LfBus> sourceBusesControllingVoltage) {
-        double[] qKeys = createReactiveKeys(sourceBusesControllingVoltage);
+                                                                List<LfBus> controllerBuses) {
+        double[] qKeys = createReactiveKeys(controllerBuses);
 
-        // we choose first source bus as reference one for reactive power
-        LfBus firstSourceBus = sourceBusesControllingVoltage.get(0);
+        // we choose first controller bus as reference for reactive power
+        LfBus firstControllerBus = controllerBuses.get(0);
 
-        // create a reactive power distribution equation for all the other source buses
-        for (int i = 1; i < sourceBusesControllingVoltage.size(); i++) {
-            LfBus sourceBus = sourceBusesControllingVoltage.get(i);
+        // create a reactive power distribution equation for all the other controller buses
+        for (int i = 1; i < controllerBuses.size(); i++) {
+            LfBus controllerBus = controllerBuses.get(i);
             double c = qKeys[0] / qKeys[i];
 
             // 0 = q0 + c * qi
-            Equation zero = equationSystem.createEquation(sourceBus.getNum(), EquationType.ZERO);
-            for (LfBranch branch : firstSourceBus.getBranches()) {
-                LfBus otherSideBus = branch.getBus1() == firstSourceBus ? branch.getBus2() : branch.getBus1();
-                EquationTerm q = new ClosedBranchSide1ReactiveFlowEquationTerm(branch, firstSourceBus, otherSideBus, variableSet);
+            Equation zero = equationSystem.createEquation(controllerBus.getNum(), EquationType.ZERO);
+            for (LfBranch branch : firstControllerBus.getBranches()) {
+                LfBus otherSideBus = branch.getBus1() == firstControllerBus ? branch.getBus2() : branch.getBus1();
+                EquationTerm q = new ClosedBranchSide1ReactiveFlowEquationTerm(branch, firstControllerBus, otherSideBus, variableSet);
                 zero.addTerm(q);
             }
-            for (LfBranch branch : sourceBus.getBranches()) {
-                LfBus otherSideBus = branch.getBus1() == sourceBus ? branch.getBus2() : branch.getBus1();
-                EquationTerm q = new ClosedBranchSide1ReactiveFlowEquationTerm(branch, sourceBus, otherSideBus, variableSet);
+            for (LfBranch branch : controllerBus.getBranches()) {
+                LfBus otherSideBus = branch.getBus1() == controllerBus ? branch.getBus2() : branch.getBus1();
+                EquationTerm q = new ClosedBranchSide1ReactiveFlowEquationTerm(branch, controllerBus, otherSideBus, variableSet);
                 EquationTerm minusQ = EquationTerm.multiply(q, -c);
                 zero.addTerm(minusQ);
             }
@@ -112,18 +113,18 @@ public final class AcEquationSystem {
         return qKeys;
     }
 
-    private static double[] createReactiveKeys(List<LfBus> sourceBuses) {
-        double[] qKeys = new double[sourceBuses.size()];
-        for (int i = 0; i < sourceBuses.size(); i++) {
-            LfBus sourceBus = sourceBuses.get(i);
-            for (LfGenerator generator : sourceBus.getGenerators()) {
+    private static double[] createReactiveKeys(List<LfBus> controllerBuses) {
+        double[] qKeys = new double[controllerBuses.size()];
+        for (int i = 0; i < controllerBuses.size(); i++) {
+            LfBus controllerBus = controllerBuses.get(i);
+            for (LfGenerator generator : controllerBus.getGenerators()) {
                 double qKey = generator.getRemoteControlReactiveKey().orElse(Double.NaN);
                 if (Double.isNaN(qKey) || qKey == 0) {
                     if (qKey == 0) {
                         LOGGER.error("Generator '{}' remote control reactive key value is zero", generator.getId());
                     }
                     // in case of one missing key, we fallback to same reactive power for all buses
-                    return createReactiveKeysFallBack(sourceBuses.size());
+                    return createReactiveKeysFallBack(controllerBuses.size());
                 } else {
                     qKeys[i] += qKey;
                 }

--- a/src/main/java/com/powsybl/openloadflow/equations/Equation.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/Equation.java
@@ -99,14 +99,14 @@ public class Equation implements Evaluable, Comparable<Equation> {
 
             case BUS_V:
                 LfBus bus = network.getBus(num);
-                if (bus.getRemoteControlSourceBuses().isEmpty()) {
+                if (bus.getControllerBuses().isEmpty()) {
                     targets[row] = bus.getTargetV();
                 } else {
-                    targets[row] = bus.getRemoteControlSourceBuses()
+                    targets[row] = bus.getControllerBuses()
                             .stream()
                             .filter(LfBus::hasVoltageControl)
                             .findFirst()
-                            .orElseThrow(() -> new IllegalStateException("None of the remote control source buses have voltage control on"))
+                            .orElseThrow(() -> new IllegalStateException("None of the controller buses has voltage control on"))
                             .getTargetV();
                 }
                 break;

--- a/src/main/java/com/powsybl/openloadflow/network/AbstractFictitiousLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractFictitiousLfBus.java
@@ -34,7 +34,7 @@ public abstract class AbstractFictitiousLfBus extends AbstractLfBus {
     }
 
     @Override
-    public List<LfBus> getRemoteControlSourceBuses() {
+    public List<LfBus> getControllerBuses() {
         return Collections.emptyList();
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractLfBus.java
@@ -44,7 +44,7 @@ public abstract class AbstractLfBus implements LfBus {
     }
 
     @Override
-    public Optional<LfBus> getRemoteControlTargetBus() {
+    public Optional<LfBus> getControlledBus() {
         return Optional.empty();
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBus.java
@@ -30,9 +30,9 @@ public interface LfBus {
 
     void setVoltageControl(boolean voltageControl);
 
-    Optional<LfBus> getRemoteControlTargetBus();
+    Optional<LfBus> getControlledBus();
 
-    List<LfBus> getRemoteControlSourceBuses();
+    List<LfBus> getControllerBuses();
 
     double getTargetP();
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -146,7 +146,7 @@ public class LfNetwork {
         if (bus.getLoadTargetQ() != 0) {
             jsonGenerator.writeNumberField("loadTargetQ", bus.getLoadTargetQ());
         }
-        bus.getRemoteControlTargetBus().ifPresent(lfBus -> {
+        bus.getControlledBus().ifPresent(lfBus -> {
             try {
                 jsonGenerator.writeNumberField("remoteControlTargetBus", lfBus.getNum());
             } catch (IOException e) {
@@ -280,18 +280,18 @@ public class LfNetwork {
     }
 
     private void logSize() {
-        int remoteControlSources = 0;
-        int remoteControlTargets = 0;
+        int controlledBusCount = 0;
+        int controllerBusCount = 0;
         for (LfBus bus : busesById.values()) {
-            if (bus.getRemoteControlTargetBus().isPresent()) {
-                remoteControlSources++;
+            if (bus.getControlledBus().isPresent()) {
+                controlledBusCount++;
             }
-            if (!bus.getRemoteControlSourceBuses().isEmpty()) {
-                remoteControlTargets++;
+            if (!bus.getControllerBuses().isEmpty()) {
+                controllerBusCount++;
             }
         }
-        LOGGER.info("Network has {} buses (voltage remote control: {} sources, {} targets) and {} branches",
-                busesById.values().size(), remoteControlSources, remoteControlTargets, branches.size());
+        LOGGER.info("Network has {} buses (voltage remote control: {} controllers, {} controlled) and {} branches",
+                busesById.values().size(), controlledBusCount, controllerBusCount, branches.size());
     }
 
     public void logBalance() {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -43,7 +43,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
     private static void createBuses(List<Bus> buses, boolean voltageRemoteControl, LfNetwork lfNetwork,
                                     LoadingContext loadingContext, LfNetworkLoadingReport report) {
         int[] generatorCount = new int[1];
-        Map<LfBusImpl, String> voltageRemoteControlTargetBusId = new HashMap<>();
+        Map<LfBusImpl, String> voltageRemoteControlTargetBusId = new LinkedHashMap<>();
 
         for (Bus bus : buses) {
             LfBusImpl lfBus = LfBusImpl.create(bus);

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -43,7 +43,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
     private static void createBuses(List<Bus> buses, boolean voltageRemoteControl, LfNetwork lfNetwork,
                                     LoadingContext loadingContext, LfNetworkLoadingReport report) {
         int[] generatorCount = new int[1];
-        Map<LfBusImpl, String> voltageRemoteControlTargetBusId = new LinkedHashMap<>();
+        Map<LfBusImpl, String> controllerBusToControlledBusId = new LinkedHashMap<>();
 
         for (Bus bus : buses) {
             LfBusImpl lfBus = LfBusImpl.create(bus);
@@ -72,13 +72,13 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
 
                 private double checkVoltageRemoteControl(Injection injection, Terminal regulatingTerminal, double previousTargetV) {
                     double scaleV = 1;
-                    String controlBusId = regulatingTerminal.getBusView().getBus().getId();
+                    String controlledBusId = regulatingTerminal.getBusView().getBus().getId();
                     String connectedBusId = injection.getTerminal().getBusView().getBus().getId();
-                    if (!Objects.equals(controlBusId, connectedBusId)) {
+                    if (!Objects.equals(controlledBusId, connectedBusId)) {
                         if (voltageRemoteControl) {
-                            // remote control target bus will be set later because target bus might not have
+                            // controller to controlled bus link will be set later because controlled bus might not have
                             // been yet created
-                            voltageRemoteControlTargetBusId.put(lfBus, controlBusId);
+                            controllerBusToControlledBusId.put(lfBus, controlledBusId);
                         } else {
                             double remoteNominalV = regulatingTerminal.getVoltageLevel().getNominalV();
                             double localNominalV = injection.getTerminal().getVoltageLevel().getNominalV();
@@ -144,12 +144,12 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
             throw new PowsyblException("Connected component without any regulating generator");
         }
 
-        // set voltage remote control target bus
-        for (Map.Entry<LfBusImpl, String> e : voltageRemoteControlTargetBusId.entrySet()) {
-            LfBusImpl sourceBus = e.getKey();
-            String targetBusId = e.getValue();
-            LfBus targetBus = lfNetwork.getBusById(targetBusId);
-            sourceBus.setRemoteControlTargetBus((LfBusImpl) targetBus);
+        // set controller -> controlled link
+        for (Map.Entry<LfBusImpl, String> e : controllerBusToControlledBusId.entrySet()) {
+            LfBusImpl controllerBus = e.getKey();
+            String controlledBusId = e.getValue();
+            LfBus controlledBus = lfNetwork.getBusById(controlledBusId);
+            controllerBus.setControlledBus((LfBusImpl) controlledBus);
         }
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/GeneratorTargetVoltageInconsistencyTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/GeneratorTargetVoltageInconsistencyTest.java
@@ -90,7 +90,7 @@ public class GeneratorTargetVoltageInconsistencyTest {
                 .add();
 
         PowsyblException exception = assertThrows(PowsyblException.class, () -> LfNetwork.load(network, new FirstSlackBusSelector()));
-        assertEquals("Generators [g1, g2] are connected to the same local bus 'vl1_0' with a different target voltages: 412.0 and 413.0", exception.getMessage());
+        assertEquals("Generators [g1, g2] are connected to the same bus 'vl1_0' with a different target voltages: 412.0 and 413.0", exception.getMessage());
     }
 
     @Test
@@ -190,7 +190,7 @@ public class GeneratorTargetVoltageInconsistencyTest {
                 .add();
 
         PowsyblException exception = assertThrows(PowsyblException.class, () -> LfNetwork.load(network, new FirstSlackBusSelector(), true));
-        assertEquals("Bus 'vl2_0' control voltage of target bus 'vl3_0' which is already controlled by at least the bus 'vl1_0' with a different target voltage: 413.0 and 412.0", exception.getMessage());
+        assertEquals("Bus 'vl2_0' control voltage of bus 'vl3_0' which is already controlled by at least the bus 'vl1_0' with a different target voltage: 413.0 and 412.0", exception.getMessage());
     }
 
     @Test
@@ -290,6 +290,6 @@ public class GeneratorTargetVoltageInconsistencyTest {
                 .add();
 
         PowsyblException exception = assertThrows(PowsyblException.class, () -> LfNetwork.load(network, new FirstSlackBusSelector(), true));
-        assertEquals("Voltage control target bus 'vl2_0' of bus 'vl1_0' has also a local voltage control with a different value: 413.0 and 412.0", exception.getMessage());
+        assertEquals("Bus 'vl2_0' controlled by bus 'vl1_0' has also a local voltage control with a different value: 413.0 and 412.0", exception.getMessage());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/GeneratorTargetVoltageInconsistencyTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/GeneratorTargetVoltageInconsistencyTest.java
@@ -1,0 +1,295 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.ac;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.*;
+import com.powsybl.openloadflow.network.FirstSlackBusSelector;
+import com.powsybl.openloadflow.network.LfNetwork;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class GeneratorTargetVoltageInconsistencyTest {
+
+    @Test
+    public void localTest() {
+        Network network = Network.create("generatorLocalInconsistentTargetVoltage", "code");
+        Substation s = network.newSubstation()
+                .setId("s")
+                .add();
+        VoltageLevel vl1 = s.newVoltageLevel()
+                .setId("vl1")
+                .setNominalV(20)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl1.getBusBreakerView().newBus()
+                .setId("b1")
+                .add();
+
+        vl1.newGenerator()
+                .setId("g1")
+                .setBus("b1")
+                .setConnectableBus("b1")
+                .setEnergySource(EnergySource.THERMAL)
+                .setMinP(0)
+                .setMaxP(200)
+                .setTargetP(100)
+                .setTargetV(413)
+                .setVoltageRegulatorOn(true)
+                .add();
+        vl1.newGenerator()
+                .setId("g2")
+                .setBus("b1")
+                .setConnectableBus("b1")
+                .setEnergySource(EnergySource.THERMAL)
+                .setMinP(0)
+                .setMaxP(200)
+                .setTargetP(100)
+                .setTargetV(412)
+                .setVoltageRegulatorOn(true)
+                .add();
+
+        VoltageLevel vl2 = s.newVoltageLevel()
+                .setId("vl2")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl2.getBusBreakerView().newBus()
+                .setId("b2")
+                .add();
+        vl2.newLoad()
+                .setId("ld2")
+                .setBus("b2")
+                .setConnectableBus("b2")
+                .setP0(99.9)
+                .setQ0(80)
+                .add();
+        network.newLine()
+                .setId("l1")
+                .setVoltageLevel1("vl1")
+                .setConnectableBus1("b1")
+                .setBus1("b1")
+                .setVoltageLevel2("vl2")
+                .setConnectableBus2("b2")
+                .setBus2("b2")
+                .setR(1)
+                .setX(1)
+                .setG1(0)
+                .setG2(0)
+                .setB1(0)
+                .setB2(0)
+                .add();
+
+        PowsyblException exception = assertThrows(PowsyblException.class, () -> LfNetwork.load(network, new FirstSlackBusSelector()));
+        assertEquals("Generators [g1, g2] are connected to the same local bus 'vl1_0' with a different target voltages: 412.0 and 413.0", exception.getMessage());
+    }
+
+    @Test
+    public void remoteTest() {
+        Network network = Network.create("generatorRemoteInconsistentTargetVoltage", "code");
+        Substation s = network.newSubstation()
+                .setId("s")
+                .add();
+
+        VoltageLevel vl3 = s.newVoltageLevel()
+                .setId("vl3")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl3.getBusBreakerView().newBus()
+                .setId("b3")
+                .add();
+        Load ld = vl3.newLoad()
+                .setId("ld")
+                .setBus("b3")
+                .setConnectableBus("b3")
+                .setP0(99.9)
+                .setQ0(80)
+                .add();
+
+        VoltageLevel vl1 = s.newVoltageLevel()
+                .setId("vl1")
+                .setNominalV(20)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl1.getBusBreakerView().newBus()
+                .setId("b1")
+                .add();
+        vl1.newGenerator()
+                .setId("g1")
+                .setBus("b1")
+                .setConnectableBus("b1")
+                .setEnergySource(EnergySource.THERMAL)
+                .setMinP(0)
+                .setMaxP(200)
+                .setTargetP(100)
+                .setTargetV(413)
+                .setVoltageRegulatorOn(true)
+                .setRegulatingTerminal(ld.getTerminal())
+                .add();
+
+        VoltageLevel vl2 = s.newVoltageLevel()
+                .setId("vl2")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl2.getBusBreakerView().newBus()
+                .setId("b2")
+                .add();
+        vl2.newGenerator()
+                .setId("g2")
+                .setBus("b2")
+                .setConnectableBus("b2")
+                .setEnergySource(EnergySource.THERMAL)
+                .setMinP(0)
+                .setMaxP(200)
+                .setTargetP(100)
+                .setTargetV(412)
+                .setVoltageRegulatorOn(true)
+                .setRegulatingTerminal(ld.getTerminal())
+                .add();
+
+        network.newLine()
+                .setId("l1")
+                .setVoltageLevel1("vl1")
+                .setConnectableBus1("b1")
+                .setBus1("b1")
+                .setVoltageLevel2("vl3")
+                .setConnectableBus2("b3")
+                .setBus2("b3")
+                .setR(1)
+                .setX(1)
+                .setG1(0)
+                .setG2(0)
+                .setB1(0)
+                .setB2(0)
+                .add();
+        network.newLine()
+                .setId("l2")
+                .setVoltageLevel1("vl2")
+                .setConnectableBus1("b2")
+                .setBus1("b2")
+                .setVoltageLevel2("vl3")
+                .setConnectableBus2("b3")
+                .setBus2("b3")
+                .setR(1)
+                .setX(1)
+                .setG1(0)
+                .setG2(0)
+                .setB1(0)
+                .setB2(0)
+                .add();
+
+        PowsyblException exception = assertThrows(PowsyblException.class, () -> LfNetwork.load(network, new FirstSlackBusSelector(), true));
+        assertEquals("Bus 'vl2_0' control voltage of target bus 'vl3_0' which is already controlled by at least the bus 'vl1_0' with a different target voltage: 413.0 and 412.0", exception.getMessage());
+    }
+
+    @Test
+    public void remoteAndLocalTest() {
+        Network network = Network.create("generatorRemoteAndLocalInconsistentTargetVoltage", "code");
+        Substation s = network.newSubstation()
+                .setId("s")
+                .add();
+
+        VoltageLevel vl2 = s.newVoltageLevel()
+                .setId("vl2")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl2.getBusBreakerView().newBus()
+                .setId("b2")
+                .add();
+        Generator g2 = vl2.newGenerator()
+                .setId("g2")
+                .setBus("b2")
+                .setConnectableBus("b2")
+                .setEnergySource(EnergySource.THERMAL)
+                .setMinP(0)
+                .setMaxP(200)
+                .setTargetP(100)
+                .setTargetV(413)
+                .setVoltageRegulatorOn(true)
+                .add();
+
+        VoltageLevel vl1 = s.newVoltageLevel()
+                .setId("vl1")
+                .setNominalV(20)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl1.getBusBreakerView().newBus()
+                .setId("b1")
+                .add();
+        vl1.newGenerator()
+                .setId("g1")
+                .setBus("b1")
+                .setConnectableBus("b1")
+                .setEnergySource(EnergySource.THERMAL)
+                .setMinP(0)
+                .setMaxP(200)
+                .setTargetP(100)
+                .setTargetV(412)
+                .setVoltageRegulatorOn(true)
+                .setRegulatingTerminal(g2.getTerminal())
+                .add();
+
+        network.newLine()
+                .setId("l1")
+                .setVoltageLevel1("vl1")
+                .setConnectableBus1("b1")
+                .setBus1("b1")
+                .setVoltageLevel2("vl2")
+                .setConnectableBus2("b2")
+                .setBus2("b2")
+                .setR(1)
+                .setX(1)
+                .setG1(0)
+                .setG2(0)
+                .setB1(0)
+                .setB2(0)
+                .add();
+
+        VoltageLevel vl3 = s.newVoltageLevel()
+                .setId("vl3")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl3.getBusBreakerView().newBus()
+                .setId("b3")
+                .add();
+        vl3.newLoad()
+                .setId("ld")
+                .setBus("b3")
+                .setConnectableBus("b3")
+                .setP0(99.9)
+                .setQ0(80)
+                .add();
+
+        network.newLine()
+                .setId("l2")
+                .setVoltageLevel1("vl2")
+                .setConnectableBus1("b2")
+                .setBus1("b2")
+                .setVoltageLevel2("vl3")
+                .setConnectableBus2("b3")
+                .setBus2("b3")
+                .setR(1)
+                .setX(1)
+                .setG1(0)
+                .setG2(0)
+                .setB1(0)
+                .setB2(0)
+                .add();
+
+        PowsyblException exception = assertThrows(PowsyblException.class, () -> LfNetwork.load(network, new FirstSlackBusSelector(), true));
+        assertEquals("Voltage control target bus 'vl2_0' of bus 'vl1_0' has also a local voltage control with a different value: 413.0 and 412.0", exception.getMessage());
+    }
+}


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
There is missing validation of generator target voltage. 


**What is the new behavior (if this is a feature change)?**
Added 3 kinds of validation:
  - local: generators connected to same bus with local voltage control
  - remote: generators connected to different buses and controlling voltage at a remote target bus.
  - local/remote: a target bus both controlled remotely by a generator and locally by another one.



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
