### PR TITLE
Avoid switching all buses PV to PQ

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/ReactiveLimitsOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/ReactiveLimitsOuterLoop.java
@@ -31,11 +31,11 @@ public class ReactiveLimitsOuterLoop implements OuterLoop {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ReactiveLimitsOuterLoop.class);
 
-    private static final Comparator<PvToPqBus> BY_NOMINAL_V_COMPARISON = Comparator.comparingDouble(pvToPqBus -> -pvToPqBus.bus.getNominalV());
+    private static final Comparator<PvToPqBus> BY_NOMINAL_V_COMPARATOR = Comparator.comparingDouble(pvToPqBus -> -pvToPqBus.bus.getNominalV());
 
-    private static final Comparator<PvToPqBus> BY_TARGET_P_COMPARISON = Comparator.comparingDouble(pvToPqBus -> -pvToPqBus.bus.getTargetP());
+    private static final Comparator<PvToPqBus> BY_TARGET_P_COMPARATOR = Comparator.comparingDouble(pvToPqBus -> -pvToPqBus.bus.getTargetP());
 
-    private static final Comparator<PvToPqBus> BY_ID_COMPARISON = Comparator.comparing(pvToPqBus -> pvToPqBus.bus.getId());
+    private static final Comparator<PvToPqBus> BY_ID_COMPARATOR = Comparator.comparing(pvToPqBus -> pvToPqBus.bus.getId());
 
     @Override
     public String getName() {
@@ -122,9 +122,9 @@ public class ReactiveLimitsOuterLoop implements OuterLoop {
                 // keep one bus PV, the strongest one which is one at the highest nominal level and highest active power
                 // target
                 PvToPqBus strongestPvToPqBus = pvToPqBuses.stream()
-                        .min(BY_NOMINAL_V_COMPARISON
-                                .thenComparing(BY_TARGET_P_COMPARISON)
-                                .thenComparing(BY_ID_COMPARISON)) // for stability of the sort
+                        .min(BY_NOMINAL_V_COMPARATOR
+                                .thenComparing(BY_TARGET_P_COMPARATOR)
+                                .thenComparing(BY_ID_COMPARATOR)) // for stability of the sort
                         .orElseThrow(IllegalStateException::new);
                 pvToPqBuses.remove(strongestPvToPqBus);
                 remainingPvBusCount++;

--- a/src/main/java/com/powsybl/openloadflow/ac/ReactiveLimitsOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/ReactiveLimitsOuterLoop.java
@@ -31,7 +31,11 @@ public class ReactiveLimitsOuterLoop implements OuterLoop {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ReactiveLimitsOuterLoop.class);
 
-    private static final Comparator<PvToPqBus> BY_NOMINAL_V_COMPARATOR = Comparator.comparingDouble(pvToPqBus -> -pvToPqBus.bus.getNominalV());
+    private static final Comparator<PvToPqBus> BY_NOMINAL_V_COMPARATOR = Comparator.comparingDouble(pvToPqBus -> {
+        LfBus bus = pvToPqBus.bus;
+        LfBus controlledBus = bus.getControlledBus().orElse(null);
+        return controlledBus == null ? -bus.getNominalV() : -controlledBus.getNominalV();
+    });
 
     private static final Comparator<PvToPqBus> BY_TARGET_P_COMPARATOR = Comparator.comparingDouble(pvToPqBus -> -pvToPqBus.bus.getTargetP());
 

--- a/src/main/java/com/powsybl/openloadflow/ac/ReactiveLimitsOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/ReactiveLimitsOuterLoop.java
@@ -94,7 +94,8 @@ public class ReactiveLimitsOuterLoop implements OuterLoop {
     }
 
     private void switchPvPq(List<PvToPqBus> pvToPqBuses, EquationSystem equationSystem, VariableSet variableSet, int remainingPvBusCount) {
-        if (remainingPvBusCount == 0) {
+        int modifiedRemainingPvBusCount = remainingPvBusCount;
+        if (modifiedRemainingPvBusCount == 0) {
             // keep one bus PV, the strongest one which is one at the highest nominal level and highest active power
             // target
             PvToPqBus strongestPvToPqBus = pvToPqBuses.stream()
@@ -103,7 +104,7 @@ public class ReactiveLimitsOuterLoop implements OuterLoop {
                             .thenComparing(BY_ID_COMPARATOR)) // for stability of the sort
                     .orElseThrow(IllegalStateException::new);
             pvToPqBuses.remove(strongestPvToPqBus);
-            remainingPvBusCount++;
+            modifiedRemainingPvBusCount++;
             LOGGER.warn("All PV buses should switch PQ, strongest one '{}' will stay PV", strongestPvToPqBus.bus.getId());
         }
 
@@ -114,7 +115,7 @@ public class ReactiveLimitsOuterLoop implements OuterLoop {
                     pvToPqBus.limitDirection == ReactiveLimitDirection.MAX ? "max" : "min", pvToPqBus.qLimit * PerUnit.SB);
         }
 
-        LOGGER.info("{} buses switched PV -> PQ ({} bus remains PV}", pvToPqBuses.size(), remainingPvBusCount);
+        LOGGER.info("{} buses switched PV -> PQ ({} bus remains PV}", pvToPqBuses.size(), modifiedRemainingPvBusCount);
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/ac/ReactiveLimitsOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/ReactiveLimitsOuterLoop.java
@@ -35,6 +35,8 @@ public class ReactiveLimitsOuterLoop implements OuterLoop {
 
     private static final Comparator<PvToPqBus> BY_TARGET_P_COMPARISON = Comparator.comparingDouble(pvToPqBus -> -pvToPqBus.bus.getTargetP());
 
+    private static final Comparator<PvToPqBus> BY_ID_COMPARISON = Comparator.comparing(pvToPqBus -> pvToPqBus.bus.getId());
+
     @Override
     public String getName() {
         return "Reactive limits";
@@ -120,7 +122,9 @@ public class ReactiveLimitsOuterLoop implements OuterLoop {
                 // keep one bus PV, the strongest one which is one at the highest nominal level and highest active power
                 // target
                 PvToPqBus strongestPvToPqBus = pvToPqBuses.stream()
-                        .min(BY_NOMINAL_V_COMPARISON.thenComparing(BY_TARGET_P_COMPARISON))
+                        .min(BY_NOMINAL_V_COMPARISON
+                                .thenComparing(BY_TARGET_P_COMPARISON)
+                                .thenComparing(BY_ID_COMPARISON)) // for stability of the sort
                         .orElseThrow(IllegalStateException::new);
                 pvToPqBuses.remove(strongestPvToPqBus);
                 remainingPvBusCount++;


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
In reactive limit outer loop, all PV buses could switch PQ (if reactive limit has been reach), leaving the network without any PV bus.


**What is the new behavior (if this is a feature change)?**
In reactive limit outer loop, we always keep at least one PV bus.
Among those who should switch PQ, we keep the strongest one, so the one at the highest nominal voltage and with the highest active power target.



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
