### PR TITLE
Fix outer loop workflow

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcloadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcloadFlowEngine.java
@@ -59,6 +59,44 @@ public class AcloadFlowEngine {
         }
     }
 
+    private static class OuterLoopRunningContext {
+
+        private NewtonRaphsonResult lastNrResult;
+
+        private int outerLoopIteration = 0;
+    }
+
+    private void runOuterLoop(OuterLoop outerLoop, LfNetwork network, EquationSystem equationSystem, VariableSet variableSet,
+                              NewtonRaphson newtonRaphson, NewtonRaphsonParameters nrParameters, OuterLoopRunningContext runningContext) {
+        // for each outer loop re-run Newton-Raphson until stabilization
+        OuterLoopStatus outerLoopStatus;
+        do {
+            parameters.getObserver().beforeOuterLoopStatusCheck(runningContext.outerLoopIteration, outerLoop.getName());
+
+            // check outer loop status
+            outerLoopStatus = outerLoop.check(new OuterLoopContext(runningContext.outerLoopIteration, network, equationSystem, variableSet, runningContext.lastNrResult));
+
+            parameters.getObserver().afterOuterLoopStatusCheck(runningContext.outerLoopIteration, outerLoop.getName(), outerLoopStatus == OuterLoopStatus.STABLE);
+
+            if (outerLoopStatus == OuterLoopStatus.UNSTABLE) {
+                parameters.getObserver().beforeOuterLoopBody(runningContext.outerLoopIteration, outerLoop.getName());
+
+                // if not yet stable, restart Newton-Raphson
+                runningContext.lastNrResult = newtonRaphson.run(nrParameters);
+                if (runningContext.lastNrResult.getStatus() != NewtonRaphsonStatus.CONVERGED) {
+                    return;
+                }
+
+                parameters.getObserver().afterOuterLoopBody(runningContext.outerLoopIteration, outerLoop.getName());
+
+                // update PV buses reactive power some outer loops might need this information
+                updatePvBusesReactivePower(runningContext.lastNrResult, network, equationSystem);
+
+                runningContext.outerLoopIteration++;
+            }
+        } while (outerLoopStatus == OuterLoopStatus.UNSTABLE);
+    }
+
     public AcLoadFlowResult run() {
         Stopwatch stopwatch = Stopwatch.createStarted();
 
@@ -72,53 +110,46 @@ public class AcloadFlowEngine {
 
         parameters.getObserver().afterEquationSystemCreation();
 
-        NewtonRaphsonResult lastNrResult;
-        int outerLoopIteration = 0;
+        OuterLoopRunningContext runningContext = new OuterLoopRunningContext();
         try (NewtonRaphson newtonRaphson = new NewtonRaphson(network, parameters.getMatrixFactory(), parameters.getObserver(), equationSystem, parameters.getStoppingCriteria())) {
 
             NewtonRaphsonParameters nrParameters = new NewtonRaphsonParameters().setVoltageInitializer(parameters.getVoltageInitializer());
 
-            // initial Newton-Raphson
-            lastNrResult = newtonRaphson.run(nrParameters);
+            // run initial Newton-Raphson
+            runningContext.lastNrResult = newtonRaphson.run(nrParameters);
 
-            updatePvBusesReactivePower(lastNrResult, network, equationSystem);
+            // continue with outer loops only if initial Newton-Raphson succeed
+            if (runningContext.lastNrResult.getStatus() == NewtonRaphsonStatus.CONVERGED) {
+                updatePvBusesReactivePower(runningContext.lastNrResult, network, equationSystem);
 
-            // for each outer loop re-run Newton-Raphson until stabilization
-            // outer loops are nested: inner most loop first in the list, outer mosy loop last
-            for (OuterLoop outerLoop : parameters.getOuterLoops()) {
-                OuterLoopStatus outerLoopStatus;
+                // re-run all outer loops until Newton-Raphson failed or no more Newton-Raphson iterations are needed
+                int oldIterationCount;
                 do {
-                    parameters.getObserver().beforeOuterLoopStatusCheck(outerLoopIteration, outerLoop.getName());
+                    oldIterationCount = runningContext.lastNrResult.getIteration();
 
-                    // check outer loop status
-                    outerLoopStatus = outerLoop.check(new OuterLoopContext(outerLoopIteration, network, equationSystem, variableSet, lastNrResult));
+                    // outer loops are nested: inner most loop first in the list, outer most loop last
+                    for (OuterLoop outerLoop : parameters.getOuterLoops()) {
+                        runOuterLoop(outerLoop, network, equationSystem, variableSet, newtonRaphson, nrParameters, runningContext);
 
-                    parameters.getObserver().afterOuterLoopStatusCheck(outerLoopIteration, outerLoop.getName(), outerLoopStatus == OuterLoopStatus.STABLE);
-
-                    if (outerLoopStatus == OuterLoopStatus.UNSTABLE) {
-                        parameters.getObserver().beforeOuterLoopBody(outerLoopIteration, outerLoop.getName());
-
-                        // if not yet stable, restart Newton-Raphson
-                        lastNrResult = newtonRaphson.run(nrParameters);
-
-                        parameters.getObserver().afterOuterLoopBody(outerLoopIteration, outerLoop.getName());
-
-                        updatePvBusesReactivePower(lastNrResult, network, equationSystem);
-
-                        outerLoopIteration++;
+                        // continue with next outer loop only if last Newton-Raphson succeed
+                        if (runningContext.lastNrResult.getStatus() != NewtonRaphsonStatus.CONVERGED) {
+                            break;
+                        }
                     }
-                } while (outerLoopStatus == OuterLoopStatus.UNSTABLE);
+                } while (runningContext.lastNrResult.getIteration() > oldIterationCount
+                        && runningContext.lastNrResult.getStatus() == NewtonRaphsonStatus.CONVERGED);
             }
         }
 
         stopwatch.stop();
 
-        int nrIterations = lastNrResult.getIteration();
-        int outerLoopIterations = outerLoopIteration + 1;
+        int nrIterations = runningContext.lastNrResult.getIteration();
+        int outerLoopIterations = runningContext.outerLoopIteration + 1;
 
         LOGGER.debug(Markers.PERFORMANCE_MARKER, "Ac loadflow ran in {} ms", stopwatch.elapsed(TimeUnit.MILLISECONDS));
 
-        AcLoadFlowResult result = new AcLoadFlowResult(networks, outerLoopIterations, nrIterations, lastNrResult.getStatus(), lastNrResult.getSlackBusActivePowerMismatch());
+        AcLoadFlowResult result = new AcLoadFlowResult(networks, outerLoopIterations, nrIterations, runningContext.lastNrResult.getStatus(),
+                runningContext.lastNrResult.getSlackBusActivePowerMismatch());
 
         LOGGER.info("Ac loadflow complete (result={})", result);
 


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
This PR fix to issues related to outer loop workflow
  - Outer loops are only run one time each. This could lead to unstabilized loop as one outer run might impact previous one. So we need to re-run all outer loops until it is all stabilized.
 - In case of Newton-Raphson divergence (max iteration reached), the workflow is not stopped and we encounter a distributed slack bus failure instead of real max iteration failure.  

**What is the new behavior (if this is a feature change)?**
Outer loop workflow has been fixed.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
