### PR TITLE
[WIP] Update to breaking changes powsybl-core 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <slf4j.version>1.7.22</slf4j.version>
         <slf4jtoys.version>1.6.2</slf4jtoys.version>
 
-        <powsyblcore.version>3.2.0</powsyblcore.version>
+        <powsyblcore.version>3.3.0-SNAPSHOT</powsyblcore.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfVscConverterStationImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfVscConverterStationImpl.java
@@ -32,6 +32,7 @@ public final class LfVscConverterStationImpl extends AbstractLfGenerator {
     }
 
     private static double getHvdcLineTargetP(VscConverterStation vscCs) {
+
         HvdcLine line = vscCs.getHvdcLine();
         return (line.getConverterStation1() == vscCs && line.getConvertersMode() == HvdcLine.ConvertersMode.SIDE_1_RECTIFIER_SIDE_2_INVERTER)
                 || (line.getConverterStation2() == vscCs && line.getConvertersMode() == HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER)

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlow3wtTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlow3wtTest.java
@@ -105,6 +105,7 @@ public class AcLoadFlow3wtTest {
                 .newLinearModel()
                     .setbPerSection(-0.16)
                     .setMaximumSectionCount(1)
+                    .add()
                 .add();
 
         twt = s.newThreeWindingsTransformer()

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlow3wtTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlow3wtTest.java
@@ -101,9 +101,10 @@ public class AcLoadFlow3wtTest {
                 .setId("sc3")
                 .setConnectableBus("b3")
                 .setBus("b3")
-                .setbPerSection(-0.16)
-                .setMaximumSectionCount(1)
                 .setCurrentSectionCount(0)
+                .newLinearModel()
+                    .setbPerSection(-0.16)
+                    .setMaximumSectionCount(1)
                 .add();
 
         twt = s.newThreeWindingsTransformer()

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
@@ -194,9 +194,10 @@ public class AcLoadFlowEurostagTutorialExample1Test {
                 .setId("SC")
                 .setBus(loadBus.getId())
                 .setConnectableBus(loadBus.getId())
-                .setbPerSection(3.25 * Math.pow(10, -3))
-                .setMaximumSectionCount(1)
                 .setCurrentSectionCount(1)
+                .newLinearModel()
+                    .setbPerSection(3.25 * Math.pow(10, -3))
+                    .setMaximumSectionCount(1)
                 .add();
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
@@ -198,6 +198,7 @@ public class AcLoadFlowEurostagTutorialExample1Test {
                 .newLinearModel()
                     .setbPerSection(3.25 * Math.pow(10, -3))
                     .setMaximumSectionCount(1)
+                    .add()
                 .add();
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);

--- a/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.ac;
 
 import com.powsybl.iidm.network.*;
-import com.powsybl.iidm.network.extensions.CoordinatedReactiveControl;
+import com.powsybl.iidm.network.extensions.CoordinatedReactiveControlAdder;
 import com.powsybl.loadflow.LoadFlow;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.LoadFlowResult;
@@ -198,9 +198,9 @@ public class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
 
     @Test
     public void testWith3GeneratorsAndCoordinatedReactiveControlExtensions() {
-        g1.addExtension(CoordinatedReactiveControl.class, new CoordinatedReactiveControl(g1, 60));
-        g2.addExtension(CoordinatedReactiveControl.class, new CoordinatedReactiveControl(g2, 30));
-        g3.addExtension(CoordinatedReactiveControl.class, new CoordinatedReactiveControl(g3, 10));
+        g1.newExtension(CoordinatedReactiveControlAdder.class).withQPercent(60).add();
+        g2.newExtension(CoordinatedReactiveControlAdder.class).withQPercent(30).add();
+        g3.newExtension(CoordinatedReactiveControlAdder.class).withQPercent(10).add();
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isOk());
         assertVoltageEquals(21.709276, b1);

--- a/src/test/java/com/powsybl/openloadflow/network/LfNetworkTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/LfNetworkTest.java
@@ -45,9 +45,10 @@ public class LfNetworkTest extends AbstractConverterTest {
                 .setId("SC")
                 .setBus("NLOAD")
                 .setConnectableBus("NLOAD")
-                .setbPerSection(3.25 * Math.pow(10, -3))
-                .setMaximumSectionCount(1)
                 .setCurrentSectionCount(1)
+                .newLinearModel()
+                    .setbPerSection(3.25 * Math.pow(10, -3))
+                    .setMaximumSectionCount(1)
                 .add();
 
         List<LfNetwork> lfNetworks = LfNetwork.load(network, new MostMeshedSlackBusSelector());

--- a/src/test/java/com/powsybl/openloadflow/network/LfNetworkTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/LfNetworkTest.java
@@ -49,6 +49,7 @@ public class LfNetworkTest extends AbstractConverterTest {
                 .newLinearModel()
                     .setbPerSection(3.25 * Math.pow(10, -3))
                     .setMaximumSectionCount(1)
+                    .add()
                 .add();
 
         List<LfNetwork> lfNetworks = LfNetwork.load(network, new MostMeshedSlackBusSelector());


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <atilloy@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Nothing.

**What is the current behavior?** *(You can also link to an open issue here)*


**What is the new behavior (if this is a feature change)?**

The ShuntCompensator API will change in powsybl-core version 3.3.0. 
The CoordinatedReactiveControl extension changes its design in powsybl-core version 3.3.0.

This PR only updates the open loadflow Following theses change. This PR has to be merged after powsybl-core new release.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
