### PR TITLE
Improve most meshed slack bus selection

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
+++ b/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
@@ -9,21 +9,17 @@ package com.powsybl.openloadflow.network;
 import java.util.Comparator;
 import java.util.List;
 
+import org.apache.commons.math3.stat.descriptive.rank.Percentile;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class MostMeshedSlackBusSelector implements SlackBusSelector {
 
-    public static final double NOMINALV_HUPPER_BOUND = 500d;
-
     @Override
     public LfBus select(List<LfBus> buses) {
-        double maxNominalV = buses.stream()
-                .map(LfBus::getNominalV)
-                .mapToDouble(Double::valueOf)
-                .filter(value -> value < NOMINALV_HUPPER_BOUND)
-                .max()
-                .orElseThrow(AssertionError::new);
+        double[] nominalVoltages = buses.stream().map(LfBus::getNominalV).mapToDouble(Double::valueOf).toArray();
+        double maxNominalV = new Percentile().evaluate(nominalVoltages, 90);
 
         // select non fictitious and most meshed bus among buses with highest nominal voltage
         return buses.stream()

--- a/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
+++ b/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
@@ -14,11 +14,14 @@ import java.util.List;
  */
 public class MostMeshedSlackBusSelector implements SlackBusSelector {
 
+    public static final double NOMINALV_HUPPER_BOUND = 500d;
+
     @Override
     public LfBus select(List<LfBus> buses) {
         double maxNominalV = buses.stream()
                 .map(LfBus::getNominalV)
                 .mapToDouble(Double::valueOf)
+                .filter(value -> value < NOMINALV_HUPPER_BOUND)
                 .max()
                 .orElseThrow(AssertionError::new);
 


### PR DESCRIPTION
New method to select the most Meshed slack bus, based on percentile 90 of nominal voltages.

Signed-off-by: Anne Tilloy <anne.tilloy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

Not an issue but from a real use case divergence of the OLF. In that case, the most meshed bus selector selects a bus that have the greatest nominal voltage (750 kV) but that is not really meshed. The OLF fails to redistribue the slack. 

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

We avoid from selection really high voltages that are uncommon in the network = not numerous.

**What is the current behavior?** *(You can also link to an open issue here)*

We first select the highest nominal voltage in the network and then we select the most meshed of them.

**What is the new behavior (if this is a feature change)?**

We select the slack bus from nominal voltage corresponding to the percentile 90. But I am not sure it is enough: we need this nominal voltage to have many occurrences in the network. 

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
