### PR TITLE
Use GraalVM Java11

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -25,10 +25,11 @@ jobs:
           architecture: x64
           jdkFile: graalvm-ce-java11-linux-amd64-20.0.0.tar.gz
 
+      - name: Install GraalVM native image
+        run: $JAVA_HOME/bin/gu install native-image
+
       - name: Build with Maven
         run: mvn --batch-mode -DskipTests=true -Pnative-image package
-        env:
-          MAVEN_OPTS: "'--add-exports=java.base/jdk.internal.module=ALL-UNNAMED'"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v1

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build with Maven
         run: mvn --batch-mode -DskipTests=true -Pnative-image package
         env:
-          MAVEN_OPTS: '--add-exports=java.base/jdk.internal.module=ALL-UNNAMED'
+          MAVEN_OPTS: "'--add-exports=java.base/jdk.internal.module=ALL-UNNAMED'"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v1

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Build with Maven
         run: mvn --batch-mode -DskipTests=true -Pnative-image package
+        env:
+          - MAVEN_OPTS '--add-exports=java.base/jdk.internal.module=ALL-UNNAMED'
 
       - name: Upload artifact
         uses: actions/upload-artifact@v1

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -25,8 +25,8 @@ jobs:
           architecture: x64
           jdkFile: graalvm-ce-java11-linux-amd64-20.0.0.tar.gz
 
-      - name: Install GraalVM native image
-        run: $JAVA_HOME/bin/gu install native-image
+      - name: Install GraalVM Native Image
+        run: $JAVA_HOME/bin/gu install --no-progress native-image
 
       - name: Build with Maven
         run: mvn --batch-mode -DskipTests=true -Pnative-image package

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -2,8 +2,6 @@ name: Native build CI
 
 on:
   push:
-    branches:
-      - master
 
 jobs:
   build:
@@ -17,15 +15,15 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v1
 
-      - name: Download GraalVM JDK 1.8
-        run: wget -nv https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.0.0/graalvm-ce-java8-linux-amd64-20.0.0.tar.gz
+      - name: Download GraalVM JDK 11
+        run: wget -nv https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.0.0/graalvm-ce-java11-linux-amd64-20.0.0.tar.gz
 
-      - name: Set up GraalVM JDK 1.8
+      - name: Set up GraalVM JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
           architecture: x64
-          jdkFile: graalvm-ce-java8-linux-amd64-20.0.0.tar.gz
+          jdkFile: graalvm-ce-java11-linux-amd64-20.0.0.tar.gz
 
       - name: Build with Maven
         run: mvn --batch-mode -DskipTests=true -Pnative-image package

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build with Maven
         run: mvn --batch-mode -DskipTests=true -Pnative-image package
         env:
-          - MAVEN_OPTS '--add-exports=java.base/jdk.internal.module=ALL-UNNAMED'
+          MAVEN_OPTS: '--add-exports=java.base/jdk.internal.module=ALL-UNNAMED'
 
       - name: Upload artifact
         uses: actions/upload-artifact@v1

--- a/src/main/resources/META-INF/native-image/resource-config.json
+++ b/src/main/resources/META-INF/native-image/resource-config.json
@@ -10,7 +10,7 @@
     {"pattern":"META-INF/services/com.powsybl.openloadflow.network.LfNetworkLoader"}, 
     {"pattern":"META-INF/services/com.powsybl.tools.Tool"}, 
     {"pattern":"natives/linux_64/libmath.so"},
-    {"pattern":"org/joda/time/tz/data/Europe/Paris"}, 
+    {"pattern":"org/joda/time/tz/data/.*"},
     {"pattern":"org/joda/time/tz/data/ZoneInfoMap"}, 
     {"pattern":"org/slf4j/impl/StaticLoggerBinder.class"},
     {"pattern":"logback.xml"}


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the new behavior (if this is a feature change)?**
As GraalVM Java8 has a bug that causes a NullPointerException in univocity parser, we switch to GraalVM Java11.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
