### PR TITLE
Reactive power set point of IIDM static var compensator follows a load sign convention

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
@@ -245,7 +245,7 @@ public class LfBusImpl extends AbstractLfBus {
         if (staticVarCompensator.getRegulationMode() != StaticVarCompensator.RegulationMode.OFF) {
             add(LfStaticVarCompensatorImpl.create(staticVarCompensator),
                     staticVarCompensator.getRegulationMode() == StaticVarCompensator.RegulationMode.VOLTAGE,
-                    staticVarCompensator.getVoltageSetPoint() * scaleV, staticVarCompensator.getReactivePowerSetPoint(),
+                    staticVarCompensator.getVoltageSetPoint() * scaleV, -staticVarCompensator.getReactivePowerSetPoint(),
                     report);
         }
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfStaticVarCompensatorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfStaticVarCompensatorImpl.java
@@ -77,7 +77,7 @@ public final class LfStaticVarCompensatorImpl extends AbstractLfGenerator {
 
     @Override
     public double getTargetQ() {
-        return svc.getReactivePowerSetPoint() / PerUnit.SB;
+        return -svc.getReactivePowerSetPoint() / PerUnit.SB;
     }
 
     @Override
@@ -109,6 +109,6 @@ public final class LfStaticVarCompensatorImpl extends AbstractLfGenerator {
     public void updateState() {
         svc.getTerminal()
                 .setP(0)
-                .setQ(Double.isNaN(calculatedQ) ? -svc.getReactivePowerSetPoint() : -calculatedQ);
+                .setQ(Double.isNaN(calculatedQ) ? svc.getReactivePowerSetPoint() : -calculatedQ);
     }
 }


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <anne.tilloy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

OLF diverges on TTG network, but no issue has been written.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

The OLF manages a static var compenstor as a generator (with a zero active power). In IIDM, a static var compensator follows a load sign convention for the reactive power set point. 

**What is the current behavior?** *(You can also link to an open issue here)*

No sign change is done.

**What is the new behavior (if this is a feature change)?**

A sign change has to be done to go from a load sign convention to a generator modeling in the power flow engines.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
