### PR TITLE
Add smarter reactive power keys fallback

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
@@ -108,9 +108,27 @@ public final class AcEquationSystem {
         }
     }
 
-    private static double[] createReactiveKeysFallBack(int n) {
+    private static double[] createUniformReactiveKeys(int n) {
         double[] qKeys = new double[n];
         Arrays.fill(qKeys, 1d);
+        return qKeys;
+    }
+
+    private static double[] createReactiveKeysFromMaxReactivePowerRange(List<LfBus> controllerBuses) {
+        double[] qKeys = new double[controllerBuses.size()];
+        // try to build keys from reactive power range
+        for (int i = 0; i < controllerBuses.size(); i++) {
+            LfBus controllerBus = controllerBuses.get(i);
+            for (LfGenerator generator : controllerBus.getGenerators()) {
+                double maxRangeQ = generator.getMaxRangeQ();
+                // if one reactive range is not plausible, we fallback to uniform keys
+                if (maxRangeQ < PlausibleValues.MIN_REACTIVE_RANGE / PerUnit.SB || maxRangeQ > PlausibleValues.MAX_REACTIVE_RANGE / PerUnit.SB) {
+                    return createUniformReactiveKeys(controllerBuses.size());
+                } else {
+                    qKeys[i] += maxRangeQ;
+                }
+            }
+        }
         return qKeys;
     }
 
@@ -124,8 +142,8 @@ public final class AcEquationSystem {
                     if (qKey == 0) {
                         LOGGER.error("Generator '{}' remote control reactive key value is zero", generator.getId());
                     }
-                    // in case of one missing key, we fallback to same reactive power for all buses
-                    return createReactiveKeysFallBack(controllerBuses.size());
+                    // in case of one missing key, we fallback to keys based on reactive power range
+                    return createReactiveKeysFromMaxReactivePowerRange(controllerBuses);
                 } else {
                     qKeys[i] += qKey;
                 }

--- a/src/main/java/com/powsybl/openloadflow/network/PlausibleValues.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PlausibleValues.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.network;
+
+/**
+ * Network related plausible values in SI unit.
+ *
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class PlausibleValues {
+
+    private PlausibleValues() {
+    }
+
+    public static final double MIN_REACTIVE_RANGE = 1; // MVar
+    public static final double MAX_REACTIVE_RANGE = 10000; // MVar
+    public static final int ACTIVE_POWER_LIMIT = 10000; // MW
+}

--- a/src/main/java/com/powsybl/openloadflow/network/PlausibleValues.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PlausibleValues.java
@@ -11,7 +11,7 @@ package com.powsybl.openloadflow.network;
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public class PlausibleValues {
+public final class PlausibleValues {
 
     private PlausibleValues() {
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
@@ -24,7 +24,6 @@ public class LfBusImpl extends AbstractLfBus {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LfBusImpl.class);
 
-    private static final double REACTIVE_RANGE_THRESHOLD_PU = 1d / PerUnit.SB;
     private static final double POWER_EPSILON_SI = 1e-4;
     private static final double Q_DISPATCH_EPSILON = 1e-3;
     private static final double TARGET_V_EPSILON = 1e-2;
@@ -215,7 +214,7 @@ public class LfBusImpl extends AbstractLfBus {
         generators.add(generator);
         boolean modifiedVoltageControl = voltageControl;
         double maxRangeQ = generator.getMaxRangeQ();
-        if (voltageControl && maxRangeQ < REACTIVE_RANGE_THRESHOLD_PU) {
+        if (voltageControl && maxRangeQ < PlausibleValues.MIN_REACTIVE_RANGE / PerUnit.SB) {
             LOGGER.trace("Discard generator '{}' from voltage control because max reactive range ({}) is too small",
                     generator.getId(), maxRangeQ);
             report.generatorsDiscardedFromVoltageControlBecauseMaxReactiveRangeIsTooSmall++;

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
@@ -11,6 +11,7 @@ import com.powsybl.iidm.network.ReactiveLimits;
 import com.powsybl.iidm.network.extensions.ActivePowerControl;
 import com.powsybl.iidm.network.extensions.CoordinatedReactiveControl;
 import com.powsybl.openloadflow.network.PerUnit;
+import com.powsybl.openloadflow.network.PlausibleValues;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,8 +27,6 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
     private static final Logger LOGGER = LoggerFactory.getLogger(LfGeneratorImpl.class);
 
     private static final double DEFAULT_DROOP = 4; // why not
-
-    private static final int PLAUSIBLE_ACTIVE_POWER_LIMIT = 10000;
 
     private final Generator generator;
 
@@ -61,9 +60,9 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
             report.generatorsDiscardedFromActivePowerControlBecauseTargetPGreaterThenMaxP++;
             participating = false;
         }
-        if (generator.getMaxP() > PLAUSIBLE_ACTIVE_POWER_LIMIT) {
+        if (generator.getMaxP() > PlausibleValues.ACTIVE_POWER_LIMIT) {
             LOGGER.trace("Discard generator '{}' from active power control because maxP ({}) > {}} MW",
-                    generator.getId(), generator.getMaxP(), PLAUSIBLE_ACTIVE_POWER_LIMIT);
+                    generator.getId(), generator.getMaxP(), PlausibleValues.ACTIVE_POWER_LIMIT);
             report.generatorsDiscardedFromActivePowerControlBecauseMaxPNotPlausible++;
             participating = false;
         }

--- a/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
@@ -213,6 +213,24 @@ public class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
     }
 
     @Test
+    public void testWith3GeneratorsAndReactiveLimits() {
+        // as there is no CoordinatedReactiveControl extension, reactive limit range will be used to create reactive
+        // keys
+        g1.newMinMaxReactiveLimits().setMinQ(0).setMaxQ(60).add();
+        g2.newMinMaxReactiveLimits().setMinQ(0).setMaxQ(30).add();
+        g3.newMinMaxReactiveLimits().setMinQ(0).setMaxQ(10).add();
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertVoltageEquals(21.709276, b1);
+        assertVoltageEquals(21.264396, b2);
+        assertVoltageEquals(22.331965, b3);
+        assertVoltageEquals(413.4, b4);
+        assertReactivePowerEquals(-126.14, g1.getTerminal());
+        assertReactivePowerEquals(-63.07, g2.getTerminal());
+        assertReactivePowerEquals(-21.023, g3.getTerminal());
+    }
+
+    @Test
     public void testErrorWhenDifferentTargetV() {
         g3.setTargetV(413.3);
         assertThrows(CompletionException.class, () -> loadFlowRunner.run(network, parameters));


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
In case of missing reactive key used to distribute reactive power to generators with shared remote voltage bus, we fallback to uniform keys (so same value for all generators).
The problem is that in case of generator with different reactive capabilities (and associated step up transformer), we can end up to no solution. 


**What is the new behavior (if this is a feature change)?**
If not reactive keys are defined from IIDM extension, we first fallback to reactive keys based on generators reactive range and then if not consistent enough we fallback to uniform keys.  


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
