### PR TITLE
Fix NaN targetQ issue

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
@@ -232,7 +232,9 @@ public class LfBusImpl extends AbstractLfBus {
             this.voltageControl = true;
             this.voltageControlCapacility = true;
         } else {
-            generationTargetQ += targetQ;
+            if (!Double.isNaN(targetQ)) {
+                generationTargetQ += targetQ;
+            }
         }
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
@@ -7,10 +7,7 @@
 
 package com.powsybl.openloadflow.ac;
 
-import com.powsybl.iidm.network.Bus;
-import com.powsybl.iidm.network.Generator;
-import com.powsybl.iidm.network.Line;
-import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.loadflow.LoadFlow;
 import com.powsybl.loadflow.LoadFlowParameters;
@@ -25,8 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static com.powsybl.openloadflow.util.LoadFlowAssert.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -207,5 +203,26 @@ public class AcLoadFlowEurostagTutorialExample1Test {
         assertReactivePowerEquals(-95.063, line1.getTerminal2());
         assertReactivePowerEquals(52.987, line2.getTerminal1());
         assertReactivePowerEquals(-95.063, line2.getTerminal2());
+    }
+
+    @Test
+    public void invalidTargetQIssueTest() {
+        // create a generator with a targetP to 0 and a minP > 0 so that the generator will be discarded from voltage
+        // regulation
+        // targetQ is not defined so value is NaN
+        Generator g1 = loadBus.getVoltageLevel().newGenerator()
+                .setId("g1")
+                .setBus(loadBus.getId())
+                .setConnectableBus(loadBus.getId())
+                .setEnergySource(EnergySource.THERMAL)
+                .setMinP(10)
+                .setMaxP(200)
+                .setTargetP(0)
+                .setTargetV(150)
+                .setVoltageRegulatorOn(true)
+                .add();
+        // check that the issue that add an undefined targetQ (NaN) to bus generation sum is solved
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
     }
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When a IIDM generator control voltage, targetQ is optional and could be let to NaN.
When adding a generator at LF network creation, some consistency check may change the voltage control status of the generator. In that case a NaN from the targetQ is added to the bus reactive injection. 


**What is the new behavior (if this is a feature change)?**
NaN is not added anymore to bus active reactive power injection.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
