### PR TITLE
Improve the most meshed slack bus selection

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
+++ b/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
@@ -22,7 +22,7 @@ public class MostMeshedSlackBusSelector implements SlackBusSelector {
                 .filter(bus -> !bus.isFictitious())
                 .map(LfBus::getNominalV).mapToDouble(Double::valueOf).toArray();
         double maxNominalV = new Percentile()
-                .withEstimationType(org.apache.commons.math3.stat.descriptive.rank.Percentile.EstimationType.R_3)
+                .withEstimationType(Percentile.EstimationType.R_3)
                 .evaluate(nominalVoltages, 90);
 
         // select non fictitious and most meshed bus among buses with highest nominal voltage

--- a/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
+++ b/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
@@ -21,7 +21,9 @@ public class MostMeshedSlackBusSelector implements SlackBusSelector {
         double[] nominalVoltages = buses.stream()
                 .filter(bus -> !bus.isFictitious())
                 .map(LfBus::getNominalV).mapToDouble(Double::valueOf).toArray();
-        double maxNominalV = new Percentile().evaluate(nominalVoltages, 90);
+        double maxNominalV = new Percentile()
+                .withEstimationType(org.apache.commons.math3.stat.descriptive.rank.Percentile.EstimationType.R_3)
+                .evaluate(nominalVoltages, 90);
 
         // select non fictitious and most meshed bus among buses with highest nominal voltage
         return buses.stream()


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <anne.tilloy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No but we have a bug here.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

The slack bus is selected among observed voltage level and not more among a voltage level does not exist (because it is the result of an interpolation).

**What is the current behavior?** *(You can also link to an open issue here)*

We can have as 90th percentile an non observed voltage level. 

**What is the new behavior (if this is a feature change)?**

The estimation is precised and we use R_3.
https://en.wikipedia.org/wiki/Quantile

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
