### PR TITLE
Discard synchronous components with no PV bus

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -40,16 +40,11 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
 
     private static void createBuses(List<Bus> buses, boolean voltageRemoteControl, LfNetwork lfNetwork,
                                     LoadingContext loadingContext, LfNetworkLoadingReport report) {
-        int[] voltageControllerCount = new int[1];
         Map<LfBusImpl, String> controllerBusToControlledBusId = new LinkedHashMap<>();
 
         for (Bus bus : buses) {
-            LfBusImpl lfBus = createBus(bus, voltageRemoteControl, loadingContext, report, voltageControllerCount, controllerBusToControlledBusId);
+            LfBusImpl lfBus = createBus(bus, voltageRemoteControl, loadingContext, report, controllerBusToControlledBusId);
             lfNetwork.addBus(lfBus);
-        }
-
-        if (voltageControllerCount[0] == 0) {
-            LOGGER.error("Network {} has no equipment to control voltage", lfNetwork.getNum());
         }
 
         // set controller -> controlled link
@@ -62,7 +57,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
     }
 
     private static LfBusImpl createBus(Bus bus, boolean voltageRemoteControl, LoadingContext loadingContext, LfNetworkLoadingReport report,
-                                       int[] voltageControllerCount, Map<LfBusImpl, String> controllerBusToControlledBusId) {
+                                       Map<LfBusImpl, String> controllerBusToControlledBusId) {
         LfBusImpl lfBus = LfBusImpl.create(bus);
 
         bus.visitConnectedEquipments(new DefaultTopologyVisitor() {
@@ -117,7 +112,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
                 double scaleV = checkVoltageRemoteControl(generator, generator.getRegulatingTerminal(), generator.getTargetV());
                 lfBus.addGenerator(generator, scaleV, report);
                 if (generator.isVoltageRegulatorOn()) {
-                    voltageControllerCount[0]++;
+                    report.voltageControllerCount++;
                 }
             }
 
@@ -141,6 +136,9 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
                 double scaleV = checkVoltageRemoteControl(staticVarCompensator, staticVarCompensator.getRegulatingTerminal(),
                         staticVarCompensator.getVoltageSetPoint());
                 lfBus.addStaticVarCompensator(staticVarCompensator, scaleV, report);
+                if (staticVarCompensator.getRegulationMode() == StaticVarCompensator.RegulationMode.VOLTAGE) {
+                    report.voltageControllerCount++;
+                }
             }
 
             @Override
@@ -155,7 +153,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
                         VscConverterStation vscConverterStation = (VscConverterStation) converterStation;
                         lfBus.addVscConverterStation(vscConverterStation, report);
                         if (vscConverterStation.isVoltageRegulatorOn()) {
-                            voltageControllerCount[0]++;
+                            report.voltageControllerCount++;
                         }
                         break;
                     case LCC:
@@ -226,31 +224,36 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
         createBranches(lfNetwork, loadingContext, report);
 
         if (report.generatorsDiscardedFromVoltageControlBecauseNotStarted > 0) {
-            LOGGER.warn("{} generators have been discarded from voltage control because not started",
-                    report.generatorsDiscardedFromVoltageControlBecauseNotStarted);
+            LOGGER.warn("Network {}: {} generators have been discarded from voltage control because not started",
+                    num.getValue(), report.generatorsDiscardedFromVoltageControlBecauseNotStarted);
         }
         if (report.generatorsDiscardedFromVoltageControlBecauseMaxReactiveRangeIsTooSmall > 0) {
-            LOGGER.warn("{} generators have been discarded from voltage control because of a too small max reactive range",
-                    report.generatorsDiscardedFromVoltageControlBecauseMaxReactiveRangeIsTooSmall);
+            LOGGER.warn("Network {}: {} generators have been discarded from voltage control because of a too small max reactive range",
+                    num.getValue(), report.generatorsDiscardedFromVoltageControlBecauseMaxReactiveRangeIsTooSmall);
         }
         if (report.generatorsDiscardedFromActivePowerControlBecauseTargetPLesserOrEqualsToZero > 0) {
-            LOGGER.warn("{} generators have been discarded from active power control because of a targetP <= 0",
-                    report.generatorsDiscardedFromActivePowerControlBecauseTargetPLesserOrEqualsToZero);
+            LOGGER.warn("Network {}: {} generators have been discarded from active power control because of a targetP <= 0",
+                    num.getValue(), report.generatorsDiscardedFromActivePowerControlBecauseTargetPLesserOrEqualsToZero);
         }
         if (report.generatorsDiscardedFromActivePowerControlBecauseTargetPGreaterThenMaxP > 0) {
-            LOGGER.warn("{} generators have been discarded from active power control because of a targetP > maxP",
-                    report.generatorsDiscardedFromActivePowerControlBecauseTargetPGreaterThenMaxP);
+            LOGGER.warn("Network {}: {} generators have been discarded from active power control because of a targetP > maxP",
+                    num.getValue(), report.generatorsDiscardedFromActivePowerControlBecauseTargetPGreaterThenMaxP);
         }
         if (report.generatorsDiscardedFromActivePowerControlBecauseMaxPNotPlausible > 0) {
-            LOGGER.warn("{} generators have been discarded from active power control because of maxP not plausible",
-                    report.generatorsDiscardedFromActivePowerControlBecauseMaxPNotPlausible);
+            LOGGER.warn("Network {}: {} generators have been discarded from active power control because of maxP not plausible",
+                    num.getValue(), report.generatorsDiscardedFromActivePowerControlBecauseMaxPNotPlausible);
         }
         if (report.branchesDiscardedBecauseConnectedToSameBusAtBothEnds > 0) {
-            LOGGER.warn("{} branches have been discarded because connected to same bus at both ends",
-                    report.branchesDiscardedBecauseConnectedToSameBusAtBothEnds);
+            LOGGER.warn("Network {}: {} branches have been discarded because connected to same bus at both ends",
+                    num.getValue(), report.branchesDiscardedBecauseConnectedToSameBusAtBothEnds);
         }
         if (report.nonImpedantBranches > 0) {
-            LOGGER.warn("{} branches are non impedant", report.nonImpedantBranches);
+            LOGGER.warn("Network {}: {} branches are non impedant", num.getValue(), report.nonImpedantBranches);
+        }
+
+        if (report.voltageControllerCount == 0) {
+            LOGGER.error("Discard network {} because there is no equipment to control voltage", lfNetwork.getNum());
+            return null;
         }
 
         return lfNetwork;

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoadingReport.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoadingReport.java
@@ -24,4 +24,6 @@ class LfNetworkLoadingReport {
     int branchesDiscardedBecauseConnectedToSameBusAtBothEnds = 0;
 
     int nonImpedantBranches = 0;
+
+    int voltageControllerCount = 0;
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
We try to run a power flow even if there is no PV bus but it is possible to converge to a realistic state if there is no at least one bus to control voltage.


**What is the new behavior (if this is a feature change)?**
We discard synchronous components with non PV bus.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
