### PR TITLE
Add MatPower and PSS/E importers to GraalVM native image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,6 +339,16 @@
                 <artifactId>powsybl-triple-store-impl-rdf4j</artifactId>
                 <version>${powsyblcore.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.powsybl</groupId>
+                <artifactId>powsybl-matpower-converter</artifactId>
+                <version>${powsyblcore.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.powsybl</groupId>
+                <artifactId>powsybl-psse-converter</artifactId>
+                <version>${powsyblcore.version}</version>
+            </dependency>
         </dependencies>
         </profile>
     </profiles>

--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -98,6 +98,78 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"com.powsybl.psse.model.PsseArea",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"com.powsybl.psse.model.PsseBus",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"com.powsybl.psse.model.PsseCaseIdentification",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"com.powsybl.psse.model.PsseFixedShunt",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"com.powsybl.psse.model.PsseGenerator",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"com.powsybl.psse.model.PsseLoad",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"com.powsybl.psse.model.PsseNonTransformerBranch",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"com.powsybl.psse.model.PsseOwner",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"com.powsybl.psse.model.PsseTransformer$FirstRecord",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"com.powsybl.psse.model.PsseTransformer$SecondRecord",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"com.powsybl.psse.model.PsseTransformer$ThirdRecord",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"com.powsybl.psse.model.PsseZone",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
   "name":"com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
@@ -106,7 +178,19 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"com.univocity.parsers.conversions.DoubleConversion",
+  "allPublicMethods":true
+},
+{
   "name":"com.univocity.parsers.conversions.EnumConversion",
+  "allPublicMethods":true
+},
+{
+  "name":"com.univocity.parsers.conversions.IntegerConversion",
+  "allPublicMethods":true
+},
+{
+  "name":"com.univocity.parsers.conversions.ValidatedConversion",
   "allPublicMethods":true
 },
 {


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature



**What is the new behavior (if this is a feature change)?**
PowSyBl 3.4.0 has 2 new supported import format: MatPower and PSS/E.
This 2 importers are new supported in GraalVM native image


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
