### PR TITLE
Make the most meshed bus selector deterministic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </parent>
 
     <artifactId>powsybl-open-loadflow</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
 
     <name>powsybl open loadflow</name>
     <description>An open source loadflow based on PowSyBl</description>

--- a/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
+++ b/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
@@ -28,6 +28,7 @@ public class MostMeshedSlackBusSelector implements SlackBusSelector {
         // select non fictitious and most meshed bus among buses with highest nominal voltage
         return buses.stream()
                 .filter(bus -> !bus.isFictitious() && bus.getNominalV() == maxNominalV)
+                .sorted(Comparator.comparing(bus -> bus.getId()))
                 .max(Comparator.comparingInt(bus -> bus.getBranches().size()))
                 .orElseThrow(AssertionError::new);
     }

--- a/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
+++ b/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
@@ -27,9 +27,8 @@ public class MostMeshedSlackBusSelector implements SlackBusSelector {
 
         // select non fictitious and most meshed bus among buses with highest nominal voltage
         return buses.stream()
-                .filter(bus -> !bus.isFictitious() && bus.getNominalV() == maxNominalV)
-                .sorted(Comparator.comparing(bus -> bus.getId()))
-                .max(Comparator.comparingInt(bus -> bus.getBranches().size()))
-                .orElseThrow(AssertionError::new);
+            .filter(bus -> !bus.isFictitious() && bus.getNominalV() == maxNominalV)
+            .max(Comparator.comparingInt((LfBus bus) -> bus.getBranches().size()).thenComparing(Comparator.comparing(LfBus::getId).reversed()))
+            .orElseThrow(AssertionError::new);
     }
 }


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <anne.tilloy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

I have performed a test on a classical merged network and on a network merged through the merging view. In some cases, the slack bus selection is not the same in these 2 networks that are functionally identical. 

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

The selection algorihtm becomes deterministic. 

**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**

I have added a sort by bus id before max branches selection.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
