### PR TITLE
Fix LfDanglingLineBranch P1, P2, Q1 and Q2 

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
@@ -54,22 +54,22 @@ public class LfDanglingLineBranch extends AbstractLfBranch {
 
     @Override
     public void setP1(Evaluable p1) {
-        // nothing to do
+        this.p = Objects.requireNonNull(p1);
     }
 
     @Override
     public void setP2(Evaluable p2) {
-        this.p = Objects.requireNonNull(p2);
-    }
-
-    @Override
-    public void setQ1(Evaluable q1) {
         // nothing to do
     }
 
     @Override
+    public void setQ1(Evaluable q1) {
+        this.q = Objects.requireNonNull(q1);
+    }
+
+    @Override
     public void setQ2(Evaluable q2) {
-        this.q = Objects.requireNonNull(q2);
+        // nothing to do
     }
 
     @Override
@@ -79,7 +79,7 @@ public class LfDanglingLineBranch extends AbstractLfBranch {
 
     @Override
     public void updateState() {
-        danglingLine.getTerminal().setP(-p.eval() * PerUnit.SB);
-        danglingLine.getTerminal().setQ(-q.eval() * PerUnit.SB);
+        danglingLine.getTerminal().setP(p.eval() * PerUnit.SB);
+        danglingLine.getTerminal().setQ(q.eval() * PerUnit.SB);
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowDanglingLineTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowDanglingLineTest.java
@@ -125,8 +125,8 @@ class AcLoadFlowDanglingLineTest {
         assertAngleEquals(0.058104, bus1);
         assertVoltageEquals(388.582864, bus2);
         assertAngleEquals(0, bus2);
-        assertActivePowerEquals(101, dl1.getTerminal());
-        assertReactivePowerEquals(150, dl1.getTerminal());
+        assertActivePowerEquals(101.302, dl1.getTerminal());
+        assertReactivePowerEquals(149.764, dl1.getTerminal());
     }
 
     @Test
@@ -147,8 +147,8 @@ class AcLoadFlowDanglingLineTest {
         assertAngleEquals(0.114371, bus1);
         assertVoltageEquals(390.181, bus2);
         assertAngleEquals(0, bus2);
-        assertActivePowerEquals(101, dl1.getTerminal());
-        assertReactivePowerEquals(0.187604, dl1.getTerminal());
+        assertActivePowerEquals(101.2, dl1.getTerminal());
+        assertReactivePowerEquals(-0.202, dl1.getTerminal());
 
         parametersExt.setDistributedSlack(true);
         parameters.setNoGeneratorReactiveLimits(false);
@@ -159,7 +159,7 @@ class AcLoadFlowDanglingLineTest {
         assertAngleEquals(0.114259, bus1);
         assertVoltageEquals(390.181, bus2);
         assertAngleEquals(0, bus2);
-        assertActivePowerEquals(101, dl1.getTerminal());
-        assertReactivePowerEquals(0.187604, dl1.getTerminal());
+        assertActivePowerEquals(101.2, dl1.getTerminal());
+        assertReactivePowerEquals(-0.202, dl1.getTerminal());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

How P1, P2, Q1 and Q2 are linked to IIDM danglingLine.

**What is the current behavior?** *(You can also link to an open issue here)*

It seems that bus2 of the LfDanglingLineBranch is linked to the IIDM dangling line terminal.

**What is the new behavior (if this is a feature change)?**

Now, It is bus1 of the LfDanglingLineBranch is linked to the IIDM dangling line terminal. But I am not sure and I need a review.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
