### PR TITLE
Fixes on discrete controls

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -250,12 +250,12 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
             }
             LfBranch controlledBranch = lfNetwork.getBranchById(controlledBranchId);
             LfBranch controllerBranch = lfNetwork.getBranchById(controllerBranchId + legId);
-            if (controllerBranch.getBus1() == null && controllerBranch.getBus2() == null) {
-                LOGGER.warn("Phase controller branch '" + controllerBranch.getId() + "' is open: no phase control created");
+            if (controllerBranch.getBus1() == null || controllerBranch.getBus2() == null) {
+                LOGGER.warn("Phase controller branch {} is open: no phase control created", controllerBranch.getId());
                 return;
             }
             if (ptc.getRegulationTerminal().getBusView().getBus() == null) {
-                LOGGER.warn("Regulating terminal of phase controller branch '" + controllerBranch.getId() + "' is out of voltage: no phase control created");
+                LOGGER.warn("Regulating terminal of phase controller branch {} is out of voltage: no phase control created", controllerBranch.getId());
                 return;
             }
             LfBus controlledBus = lfNetwork.getBusById(ptc.getRegulationTerminal().getBusView().getBus().getId());
@@ -282,20 +282,20 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
     private static void createVoltageControl(LfNetwork lfNetwork, RatioTapChanger rtc, String controllerBranchId, String legId) {
         if (rtc != null && rtc.isRegulating()) {
             LfBranch controllerBranch = lfNetwork.getBranchById(controllerBranchId + legId);
-            if (controllerBranch.getBus1() == null && controllerBranch.getBus2() == null) {
-                LOGGER.warn("Voltage controller branch '" + controllerBranch.getId() + "' is open: no voltage control created");
+            if (controllerBranch.getBus1() == null || controllerBranch.getBus2() == null) {
+                LOGGER.warn("Voltage controller branch {} is open: no voltage control created", controllerBranch.getId());
                 return;
             }
             Terminal regulationTerminal = rtc.getRegulationTerminal();
             if (regulationTerminal.getBusView().getBus() == null) {
-                LOGGER.warn("Regulating terminal of voltage controller branch '" + controllerBranch.getId() + "' is out of voltage: no voltage control created");
+                LOGGER.warn("Regulating terminal of voltage controller branch {} is out of voltage: no voltage control created", controllerBranch.getId());
                 return;
             }
             LfBus controlledBus = lfNetwork.getBusById(regulationTerminal.getBusView().getBus().getId());
             if ((controlledBus.getControllerBuses().isEmpty() && controlledBus.hasVoltageControl()) || !controlledBus.getControllerBuses().isEmpty()) {
-                LOGGER.warn("The bus '" + controlledBus.getId() + "' has both generator and transformer voltage control on. Only generator control is kept");
+                LOGGER.warn("Controlled bus {} has both generator and transformer voltage control on: only generator control is kept", controlledBus.getId());
             } else if (controlledBus.isDiscreteVoltageControlled()) {
-                LOGGER.trace("The bus '" + controlledBus.getId() + "' already has a transformer voltage control. A shared control is created");
+                LOGGER.trace("Controlled bus {} already has a transformer voltage control: a shared control is created", controlledBus.getId());
                 controlledBus.getDiscreteVoltageControl().addController(controllerBranch);
                 controllerBranch.setDiscreteVoltageControl(controlledBus.getDiscreteVoltageControl());
             } else {

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowPhaseShifterTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowPhaseShifterTest.java
@@ -165,6 +165,42 @@ class AcLoadFlowPhaseShifterTest {
     }
 
     @Test
+    void openT2wtTest() {
+        selectNetwork(createNetworkWithT2wt());
+        parameters.setPhaseShifterRegulationOn(true);
+        t2wt.getPhaseTapChanger().setRegulationMode(PhaseTapChanger.RegulationMode.ACTIVE_POWER_CONTROL)
+                .setTargetDeadband(1) // FIXME how to take this into account
+                .setRegulating(true)
+                .setTapPosition(2)
+                .setRegulationTerminal(t2wt.getTerminal1())
+                .setRegulationValue(83);
+        t2wt.getTerminal1().disconnect();
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertEquals(2, t2wt.getPhaseTapChanger().getTapPosition());
+    }
+
+    @Test
+    void regulatingTerminalDisconnectedTest() {
+        selectNetwork(createNetworkWithT2wt());
+        Line line = network.getLine("L2");
+        line.getTerminal2().disconnect();
+
+        parameters.setPhaseShifterRegulationOn(true);
+        t2wt.getPhaseTapChanger().setRegulationMode(PhaseTapChanger.RegulationMode.ACTIVE_POWER_CONTROL)
+                .setTargetDeadband(1) // FIXME how to take this into account
+                .setRegulating(true)
+                .setTapPosition(2)
+                .setRegulationTerminal(line.getTerminal2())
+                .setRegulationValue(83);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertEquals(2, t2wt.getPhaseTapChanger().getTapPosition());
+    }
+
+    @Test
     void baseCaseT3wtTest() {
         selectNetwork(createNetworkWithT3wt());
         LoadFlowResult result = loadFlowRunner.run(network, parameters);

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
@@ -246,6 +246,41 @@ class AcLoadFlowTransformerControlTest {
     }
 
     @Test
+    void openT2wtTest() {
+        selectNetwork(createNetworkWithT2wt());
+
+        t2wt.getRatioTapChanger()
+                .setTargetDeadband(0)
+                .setRegulating(true)
+                .setTapPosition(2)
+                .setRegulationTerminal(network.getGenerator("GEN_1").getTerminal())
+                .setTargetV(33.0);
+        t2wt.getTerminal2().disconnect();
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertEquals(2, t2wt.getRatioTapChanger().getTapPosition());
+    }
+
+    @Test
+    void regulatingTerminalDisconnectedTest() {
+        selectNetwork(createNetworkWithT2wt());
+        Load load = network.getLoad("LOAD_2");
+        load.getTerminal().disconnect();
+
+        t2wt.getRatioTapChanger()
+                .setTargetDeadband(0)
+                .setRegulating(true)
+                .setTapPosition(2)
+                .setRegulationTerminal(load.getTerminal())
+                .setTargetV(33.0);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertEquals(2, t2wt.getRatioTapChanger().getTapPosition());
+    }
+
+    @Test
     void baseCaseT3wtTest() {
         selectNetwork(createNetworkWithT3wt());
 


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <anne.tilloy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No. I have performed some functional tests on IOP dataset. Even if voltage regulation is disabled and phase regulation is disabled, we create discrete voltage and phase control. I have tested OLF on the CGMES files in that context of no discrete regualtion activated. But I have found issues when the regulating terminal does not refer to a bus.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

We now check if it refers the regulating terminal refers to a bus before creating a discrete control. I wonder if it is enough for phase control as the controlled branch can be opened at both side. 

**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
