### PR TITLE
Discard phase control if controlled branch is null or open

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -249,6 +249,14 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
                 controlledBranchId += legId;
             }
             LfBranch controlledBranch = lfNetwork.getBranchById(controlledBranchId);
+            if (controlledBranch == null) {
+                LOGGER.warn("Phase controlled branch {} is null: no phase control created", controlledBranchId);
+                return;
+            }
+            if (controlledBranch.getBus1() == null || controlledBranch.getBus2() == null) {
+                LOGGER.warn("Phase controlled branch {} is open: no phase control created", controlledBranch.getId());
+                return;
+            }
             LfBranch controllerBranch = lfNetwork.getBranchById(controllerBranchId + legId);
             if (controllerBranch.getBus1() == null || controllerBranch.getBus2() == null) {
                 LOGGER.warn("Phase controller branch {} is open: no phase control created", controllerBranch.getId());

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowPhaseShifterTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowPhaseShifterTest.java
@@ -201,6 +201,54 @@ class AcLoadFlowPhaseShifterTest {
     }
 
     @Test
+    void nullControlledBranchTest() {
+        selectNetwork(createNetworkWithT2wt());
+        parameters.setPhaseShifterRegulationOn(true);
+        t2wt.getPhaseTapChanger().setRegulationMode(PhaseTapChanger.RegulationMode.ACTIVE_POWER_CONTROL)
+                .setTargetDeadband(1)
+                .setRegulating(true)
+                .setTapPosition(2)
+                .setRegulationTerminal(network.getLoad("LD2").getTerminal())
+                .setRegulationValue(83);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertEquals(2, t2wt.getPhaseTapChanger().getTapPosition());
+    }
+
+    @Test
+    void openControlledBranchTest() {
+        selectNetwork(createNetworkWithT2wt());
+        network.newLine()
+                .setId("L3")
+                .setVoltageLevel1("VL1")
+                .setConnectableBus1("B1")
+                .setBus1("B1")
+                .setVoltageLevel2("VL2")
+                .setConnectableBus2("B2")
+                .setBus2("B2")
+                .setR(4.0)
+                .setX(10.0)
+                .setG1(0.0)
+                .setB1(0.0)
+                .setG2(0.0)
+                .setB2(0.0)
+                .add();
+        line1.getTerminal1().disconnect();
+        parameters.setPhaseShifterRegulationOn(true);
+        t2wt.getPhaseTapChanger().setRegulationMode(PhaseTapChanger.RegulationMode.ACTIVE_POWER_CONTROL)
+                .setTargetDeadband(1)
+                .setRegulating(true)
+                .setTapPosition(2)
+                .setRegulationTerminal(line1.getTerminal1())
+                .setRegulationValue(83);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertEquals(2, t2wt.getPhaseTapChanger().getTapPosition());
+    }
+
+    @Test
     void baseCaseT3wtTest() {
         selectNetwork(createNetworkWithT3wt());
         LoadFlowResult result = loadFlowRunner.run(network, parameters);


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <anne.tilloy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No check is done.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Two checks have been added and in case of null controlled branch or open controlled branch, the phase control is not created.

**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
