### PR TITLE
Fix slack distribution on generation 

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
@@ -28,6 +28,8 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
 
     private static final double DEFAULT_DROOP = 4; // why not
 
+    private static final double TARGET_P_EPSILON = 1e-2;
+
     private final Generator generator;
 
     private boolean participating;
@@ -48,10 +50,10 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
             }
         }
         participationFactor = generator.getMaxP() / droop;
-        if (generator.getTargetP() <= 0) {
-            LOGGER.trace("Discard generator '{}' from active power control because targetP ({}) <= 0",
+        if (Math.abs(generator.getTargetP()) < TARGET_P_EPSILON) {
+            LOGGER.trace("Discard generator '{}' from active power control because targetP ({}) equals 0",
                     generator.getId(), generator.getTargetP());
-            report.generatorsDiscardedFromActivePowerControlBecauseTargetPLesserOrEqualsToZero++;
+            report.generatorsDiscardedFromActivePowerControlBecauseTargetEqualsToZero++;
             participating = false;
         }
         if (generator.getTargetP() > generator.getMaxP()) {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
@@ -68,6 +68,12 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
             report.generatorsDiscardedFromActivePowerControlBecauseMaxPNotPlausible++;
             participating = false;
         }
+        if ((generator.getMaxP() - generator.getMinP()) < TARGET_P_EPSILON) {
+            LOGGER.trace("Discard generator '{}' from active power control because maxP ({} MW) equals minP ({} MW)",
+                    generator.getId(), generator.getMaxP(), generator.getMinP());
+            report.generatorsDiscardedFromActivePowerControlBecauseMaxPEqualsMinP++;
+            participating = false;
+        }
     }
 
     public static LfGeneratorImpl create(Generator generator, LfNetworkLoadingReport report) {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -350,9 +350,9 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
             LOGGER.warn("Network {}: {} generators have been discarded from voltage control because of a too small max reactive range",
                     lfNetwork.getNum(), report.generatorsDiscardedFromVoltageControlBecauseMaxReactiveRangeIsTooSmall);
         }
-        if (report.generatorsDiscardedFromActivePowerControlBecauseTargetPLesserOrEqualsToZero > 0) {
-            LOGGER.warn("Network {}: {} generators have been discarded from active power control because of a targetP <= 0",
-                    lfNetwork.getNum(), report.generatorsDiscardedFromActivePowerControlBecauseTargetPLesserOrEqualsToZero);
+        if (report.generatorsDiscardedFromActivePowerControlBecauseTargetEqualsToZero > 0) {
+            LOGGER.warn("Network {}: {} generators have been discarded from active power control because of a targetP equals 0",
+                    lfNetwork.getNum(), report.generatorsDiscardedFromActivePowerControlBecauseTargetEqualsToZero);
         }
         if (report.generatorsDiscardedFromActivePowerControlBecauseTargetPGreaterThenMaxP > 0) {
             LOGGER.warn("Network {}: {} generators have been discarded from active power control because of a targetP > maxP",

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -362,6 +362,10 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
             LOGGER.warn("Network {}: {} generators have been discarded from active power control because of maxP not plausible",
                     lfNetwork.getNum(), report.generatorsDiscardedFromActivePowerControlBecauseMaxPNotPlausible);
         }
+        if (report.generatorsDiscardedFromActivePowerControlBecauseMaxPEqualsMinP > 0) {
+            LOGGER.warn("Network {}: {} generators have been discarded from active power control because of maxP equals to minP",
+                    lfNetwork.getNum(), report.generatorsDiscardedFromActivePowerControlBecauseMaxPEqualsMinP);
+        }
         if (report.branchesDiscardedBecauseConnectedToSameBusAtBothEnds > 0) {
             LOGGER.warn("Network {}: {} branches have been discarded because connected to same bus at both ends",
                     lfNetwork.getNum(), report.branchesDiscardedBecauseConnectedToSameBusAtBothEnds);

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoadingReport.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoadingReport.java
@@ -15,7 +15,7 @@ class LfNetworkLoadingReport {
 
     int generatorsDiscardedFromVoltageControlBecauseMaxReactiveRangeIsTooSmall = 0;
 
-    int generatorsDiscardedFromActivePowerControlBecauseTargetPLesserOrEqualsToZero = 0;
+    int generatorsDiscardedFromActivePowerControlBecauseTargetEqualsToZero = 0;
 
     int generatorsDiscardedFromActivePowerControlBecauseTargetPGreaterThenMaxP = 0;
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoadingReport.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoadingReport.java
@@ -21,6 +21,8 @@ class LfNetworkLoadingReport {
 
     int generatorsDiscardedFromActivePowerControlBecauseMaxPNotPlausible = 0;
 
+    int generatorsDiscardedFromActivePowerControlBecauseMaxPEqualsMinP = 0;
+
     int branchesDiscardedBecauseConnectedToSameBusAtBothEnds = 0;
 
     int nonImpedantBranches = 0;

--- a/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
@@ -81,7 +81,7 @@ class DistributedSlackOnGenerationTest {
     void testUnsupportedGenerationBalanceType() {
         parameters.setBalanceType(LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P);
         assertThrows(CompletionException.class, () -> loadFlowRunner.run(network, parameters),
-            "java.lang.UnsupportedOperationException: Unsupported balance type mode: PROPORTIONAL_TO_GENERATION_P");
+                "java.lang.UnsupportedOperationException: Unsupported balance type mode: PROPORTIONAL_TO_GENERATION_P");
     }
 
     @Test
@@ -116,17 +116,15 @@ class DistributedSlackOnGenerationTest {
         g2.getExtension(ActivePowerControl.class).setDroop(-3);
         g3.getExtension(ActivePowerControl.class).setDroop(0);
         g4.getExtension(ActivePowerControl.class).setDroop(0);
-        assertThrows(CompletionException.class,
-            () -> loadFlowRunner.run(network, parameters),
-            "No more generator participating to slack distribution");
+        assertThrows(CompletionException.class, () -> loadFlowRunner.run(network, parameters),
+                "No more generator participating to slack distribution");
     }
 
     @Test
     void notEnoughActivePowerFailureTest() {
         network.getLoad("l1").setP0(1000);
-        assertThrows(CompletionException.class,
-            () -> loadFlowRunner.run(network, parameters),
-            "Failed to distribute slack bus active power mismatch");
+        assertThrows(CompletionException.class, () -> loadFlowRunner.run(network, parameters),
+                "Failed to distribute slack bus active power mismatch");
     }
 
     @Test
@@ -139,5 +137,14 @@ class DistributedSlackOnGenerationTest {
         LoadFlowResult result = LoadFlow.find("OpenLoadFlow").run(network, parameters);
         assertTrue(result.isOk());
         assertActivePowerEquals(595.350, network.getGenerator("GEN").getTerminal());
+    }
+
+    @Test
+    void generatorWithMaxPEqualsToMinP() {
+        Network network = EurostagTutorialExample1Factory.create();
+        network.getGenerator("GEN").setMaxP(1000);
+        network.getGenerator("GEN").setMinP(1000);
+        assertThrows(CompletionException.class, () -> loadFlowRunner.run(network, parameters),
+                "Failed to distribute slack bus active power mismatch, -1.4404045651214226 MW remains");
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
@@ -10,6 +10,7 @@ import com.powsybl.iidm.network.Generator;
 import com.powsybl.iidm.network.Line;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.extensions.ActivePowerControl;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.loadflow.LoadFlow;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.LoadFlowResult;
@@ -126,5 +127,17 @@ class DistributedSlackOnGenerationTest {
         assertThrows(CompletionException.class,
             () -> loadFlowRunner.run(network, parameters),
             "Failed to distribute slack bus active power mismatch");
+    }
+
+    @Test
+    void generatorWithNegativeTargetP() {
+        Network network = EurostagTutorialExample1Factory.create();
+        network.getGenerator("GEN").setMaxP(1000);
+        network.getGenerator("GEN").setTargetP(-607);
+        network.getLoad("LOAD").setP0(-600);
+        network.getLoad("LOAD").setQ0(-200);
+        LoadFlowResult result = LoadFlow.find("OpenLoadFlow").run(network, parameters);
+        assertTrue(result.isOk());
+        assertActivePowerEquals(595.350, network.getGenerator("GEN").getTerminal());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImplTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImplTest.java
@@ -49,9 +49,9 @@ class LfNetworkLoaderImplTest extends AbstractLoadFlowNetworkFactory {
     }
 
     @Test
-    void generatorNegativeActivePowerTargetTest() {
-        // targetP < 0, generator is discarded from active power control
-        g.setTargetP(-10);
+    void generatorZeroActivePowerTargetTest() {
+        // targetP == 0, generator is discarded from active power control
+        g.setTargetP(0);
         LfNetwork lfNetwork = LfNetwork.load(network, new FirstSlackBusSelector()).get(0);
         assertFalse(lfNetwork.getBus(0).getGenerators().get(0).isParticipating());
     }


### PR DESCRIPTION
With this PR, only generator with a zero target P are discarded from the slack distribution. In master branch, generator with negative target P are also discarded.

Signed-off-by: Anne Tilloy <anne.tilloy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
