### PR TITLE
Security Analysis: avoid looping on all network branches

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysis.java
@@ -426,9 +426,7 @@ public class OpenSecurityAnalysis implements SecurityAnalysis {
             // add to contingency description buses and branches that won't be part of the main connected
             // component in post contingency state
             Set<LfBus> buses = connectivity.getSmallComponents().stream().flatMap(Set::stream).collect(Collectors.toSet());
-            network.getBranches().stream()
-                .filter(br -> buses.contains(br.getBus1()) && buses.contains(br.getBus2()))
-                .forEach(branches::add);
+            buses.forEach(b -> branches.addAll(b.getBranches()));
 
             // reset connectivity to discard triggered branches
             connectivity.reset();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Computation time improvement


**What is the current behavior?** *(You can also link to an open issue here)*
Looping over all branches of the network to add to the contingency the branches corresponding to the buses which aren't part of the main connected component in post contingency state

**What is the new behavior (if this is a feature change)?**
Just adding the branches linked to those buses. On the test nework of 10k branches used, LfContingencies are calculated from contingency contexts in 300ms instead of 2s. 

**Does this PR introduce a breaking change or deprecate an API?**
No


**Other information**:
Improve to a slight extent the computation time of security analysis outlined in issue #129 
