### PR TITLE
Fix DC equations when a1 is a variable

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
@@ -59,12 +59,18 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
 
     private final MatrixFactory matrixFactory;
 
+    private boolean forcePhaseControlOffAndAddAngle1Var = false; // just for unit testing
+
     public OpenLoadFlowProvider() {
         this(new SparseMatrixFactory());
     }
 
     public OpenLoadFlowProvider(MatrixFactory matrixFactory) {
         this.matrixFactory = Objects.requireNonNull(matrixFactory);
+    }
+
+    public void setForcePhaseControlOffAndAddAngle1Var(boolean forcePhaseControlOffAndAddAngle1Var) {
+        this.forcePhaseControlOffAndAddAngle1Var = forcePhaseControlOffAndAddAngle1Var;
     }
 
     @Override
@@ -222,7 +228,8 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
 
             SlackBusSelector slackBusSelector = getSlackBusSelector(network, parameters, parametersExt);
             DcLoadFlowParameters dcParameters = new DcLoadFlowParameters(slackBusSelector, matrixFactory, true,
-                    parametersExt.isDcUseTransformerRatio(), parameters.isDistributedSlack(), parameters.getBalanceType());
+                    parametersExt.isDcUseTransformerRatio(), parameters.isDistributedSlack(), parameters.getBalanceType(),
+                    forcePhaseControlOffAndAddAngle1Var);
 
             DcLoadFlowResult result = new DcLoadFlowEngine(network, dcParameters)
                     .run();

--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
@@ -45,7 +45,7 @@ public class DcLoadFlowEngine {
 
     public DcLoadFlowEngine(LfNetwork network, MatrixFactory matrixFactory) {
         this.networks = Collections.singletonList(network);
-        parameters = new DcLoadFlowParameters(new FirstSlackBusSelector(), matrixFactory, false, true, false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX);
+        parameters = new DcLoadFlowParameters(new FirstSlackBusSelector(), matrixFactory, false, true, false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX, false);
     }
 
     public DcLoadFlowEngine(Object network, DcLoadFlowParameters parameters) {
@@ -74,7 +74,8 @@ public class DcLoadFlowEngine {
             distributeSlack(network);
         }
 
-        EquationSystem equationSystem = DcEquationSystem.create(network, new VariableSet(), new DcEquationSystemCreationParameters(parameters.isUpdateFlows(), false, false, parameters.isUseTransformerRatio()));
+        DcEquationSystemCreationParameters creationParameters = new DcEquationSystemCreationParameters(parameters.isUpdateFlows(), false, parameters.isForcePhaseControlOffAndAddAngle1Var(), parameters.isUseTransformerRatio());
+        EquationSystem equationSystem = DcEquationSystem.create(network, new VariableSet(), creationParameters);
 
         double[] x = equationSystem.createStateVector(new UniformValueVoltageInitializer());
 

--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowParameters.java
@@ -23,20 +23,24 @@ public class DcLoadFlowParameters {
 
     private final boolean updateFlows;
 
-    boolean useTransformerRatio;
+    private final boolean useTransformerRatio;
 
-    private boolean distributedSlack;
+    private final boolean distributedSlack;
 
-    private LoadFlowParameters.BalanceType balanceType;
+    private final LoadFlowParameters.BalanceType balanceType;
+
+    private final boolean forcePhaseControlOffAndAddAngle1Var;
 
     public DcLoadFlowParameters(SlackBusSelector slackBusSelector, MatrixFactory matrixFactory, boolean updateFlows,
-                                boolean useTransformerRatio, boolean distributedSlack, LoadFlowParameters.BalanceType balanceType) {
+                                boolean useTransformerRatio, boolean distributedSlack, LoadFlowParameters.BalanceType balanceType,
+                                boolean forcePhaseControlOffAndAddAngle1Var) {
         this.slackBusSelector = Objects.requireNonNull(slackBusSelector);
         this.matrixFactory = Objects.requireNonNull(matrixFactory);
         this.updateFlows = updateFlows;
         this.useTransformerRatio = useTransformerRatio;
         this.distributedSlack = distributedSlack;
         this.balanceType = balanceType;
+        this.forcePhaseControlOffAndAddAngle1Var = forcePhaseControlOffAndAddAngle1Var;
     }
 
     public SlackBusSelector getSlackBusSelector() {
@@ -61,5 +65,9 @@ public class DcLoadFlowParameters {
 
     public boolean isUseTransformerRatio() {
         return useTransformerRatio;
+    }
+
+    public boolean isForcePhaseControlOffAndAddAngle1Var() {
+        return forcePhaseControlOffAndAddAngle1Var;
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
@@ -7,6 +7,7 @@
 package com.powsybl.openloadflow.dc.equations;
 
 import com.google.common.collect.ImmutableList;
+import com.powsybl.math.matrix.DenseMatrix;
 import com.powsybl.openloadflow.equations.*;
 import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.LfBus;
@@ -50,6 +51,24 @@ public abstract class AbstractClosedBranchDcFlowEquationTerm extends AbstractNam
             variablesBuilder.add(a1Var);
         }
         variables = variablesBuilder.build();
+    }
+
+    public double calculate(DenseMatrix x, int column) {
+        Objects.requireNonNull(x);
+        double ph1 = x.get(ph1Var.getRow(), column);
+        double ph2 = x.get(ph2Var.getRow(), column);
+        double a1 = getA1(x, column);
+        return calculate(ph1, ph2, a1);
+    }
+
+    private double getA1(DenseMatrix x, int column) {
+        return a1Var != null && a1Var.isActive() ? x.get(a1Var.getRow(), column) : branch.getPiModel().getA1();
+    }
+
+    protected abstract double calculate(double ph1, double ph2, double a1);
+
+    protected double getA1(double[] stateVector) {
+        return a1Var != null && a1Var.isActive() ? stateVector[a1Var.getRow()] : branch.getPiModel().getA1();
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide1DcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide1DcFlowEquationTerm.java
@@ -47,7 +47,7 @@ public final class ClosedBranchSide1DcFlowEquationTerm extends AbstractClosedBra
         Objects.requireNonNull(x);
         double ph1 = x.get(ph1Var.getRow(), column);
         double ph2 = x.get(ph2Var.getRow(), column);
-        double a1 = a1Var != null ? x.get(a1Var.getRow(), column) : branch.getPiModel().getA1();
+        double a1 = a1Var != null && a1Var.isActive() ? x.get(a1Var.getRow(), column) : branch.getPiModel().getA1();
         return calculate(ph1, ph2, a1);
     }
 
@@ -56,12 +56,12 @@ public final class ClosedBranchSide1DcFlowEquationTerm extends AbstractClosedBra
         Objects.requireNonNull(x);
         double ph1 = x[ph1Var.getRow()];
         double ph2 = x[ph2Var.getRow()];
-        double a1 = a1Var != null ? x[a1Var.getRow()] : branch.getPiModel().getA1();
+        double a1 = a1Var != null && a1Var.isActive() ? x[a1Var.getRow()] : branch.getPiModel().getA1();
         p1 = calculate(ph1, ph2, a1);
-        if (a1Var == null) {
-            rhs = -power * (A2 - a1);
-        } else {
+        if (a1Var != null && a1Var.isActive()) {
             rhs = -power * A2;
+        } else {
+            rhs = -power * (A2 - a1);
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide1DcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide1DcFlowEquationTerm.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.openloadflow.dc.equations;
 
-import com.powsybl.math.matrix.DenseMatrix;
 import com.powsybl.openloadflow.equations.Variable;
 import com.powsybl.openloadflow.equations.VariableSet;
 import com.powsybl.openloadflow.network.LfBranch;
@@ -38,17 +37,10 @@ public final class ClosedBranchSide1DcFlowEquationTerm extends AbstractClosedBra
         return new ClosedBranchSide1DcFlowEquationTerm(branch, bus1, bus2, variableSet, deriveA1, useTransformerRatio);
     }
 
-    private double calculate(double ph1, double ph2, double a1) {
+    @Override
+    protected double calculate(double ph1, double ph2, double a1) {
         double deltaPhase =  ph2 - ph1 + A2 - a1;
         return -power * deltaPhase;
-    }
-
-    public double calculate(DenseMatrix x, int column) {
-        Objects.requireNonNull(x);
-        double ph1 = x.get(ph1Var.getRow(), column);
-        double ph2 = x.get(ph2Var.getRow(), column);
-        double a1 = a1Var != null && a1Var.isActive() ? x.get(a1Var.getRow(), column) : branch.getPiModel().getA1();
-        return calculate(ph1, ph2, a1);
     }
 
     @Override
@@ -56,7 +48,7 @@ public final class ClosedBranchSide1DcFlowEquationTerm extends AbstractClosedBra
         Objects.requireNonNull(x);
         double ph1 = x[ph1Var.getRow()];
         double ph2 = x[ph2Var.getRow()];
-        double a1 = a1Var != null && a1Var.isActive() ? x[a1Var.getRow()] : branch.getPiModel().getA1();
+        double a1 = getA1(x);
         p1 = calculate(ph1, ph2, a1);
         if (a1Var != null && a1Var.isActive()) {
             rhs = -power * A2;

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide1DcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide1DcFlowEquationTerm.java
@@ -58,7 +58,11 @@ public final class ClosedBranchSide1DcFlowEquationTerm extends AbstractClosedBra
         double ph2 = x[ph2Var.getRow()];
         double a1 = a1Var != null ? x[a1Var.getRow()] : branch.getPiModel().getA1();
         p1 = calculate(ph1, ph2, a1);
-        rhs = -power * (A2 - a1);
+        if (a1Var == null) {
+            rhs = -power * (A2 - a1);
+        } else {
+            rhs = -power * A2;
+        }
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide2DcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide2DcFlowEquationTerm.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.openloadflow.dc.equations;
 
-import com.powsybl.math.matrix.DenseMatrix;
 import com.powsybl.openloadflow.equations.Variable;
 import com.powsybl.openloadflow.equations.VariableSet;
 import com.powsybl.openloadflow.network.LfBranch;
@@ -39,17 +38,10 @@ public final class ClosedBranchSide2DcFlowEquationTerm extends AbstractClosedBra
         return new ClosedBranchSide2DcFlowEquationTerm(branch, bus1, bus2, variableSet, deriveA1, useTransformerRatio);
     }
 
-    private double calculate(double ph1, double ph2, double a1) {
+    @Override
+    protected double calculate(double ph1, double ph2, double a1) {
         double deltaPhase =  ph2 - ph1 + A2 - a1;
         return power * deltaPhase;
-    }
-
-    public double calculate(DenseMatrix x, int column) {
-        Objects.requireNonNull(x);
-        double ph1 = x.get(ph1Var.getRow(), column);
-        double ph2 = x.get(ph2Var.getRow(), column);
-        double a1 = a1Var != null && a1Var.isActive() ? x.get(a1Var.getRow(), column) : branch.getPiModel().getA1();
-        return calculate(ph1, ph2, a1);
     }
 
     @Override
@@ -57,7 +49,7 @@ public final class ClosedBranchSide2DcFlowEquationTerm extends AbstractClosedBra
         Objects.requireNonNull(x);
         double ph1 = x[ph1Var.getRow()];
         double ph2 = x[ph2Var.getRow()];
-        double a1 = a1Var != null && a1Var.isActive() ? x[a1Var.getRow()] : branch.getPiModel().getA1();
+        double a1 = getA1(x);
         p2 = calculate(ph1, ph2, a1);
         if (a1Var != null && a1Var.isActive()) {
             rhs = power * A2;

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide2DcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide2DcFlowEquationTerm.java
@@ -48,7 +48,7 @@ public final class ClosedBranchSide2DcFlowEquationTerm extends AbstractClosedBra
         Objects.requireNonNull(x);
         double ph1 = x.get(ph1Var.getRow(), column);
         double ph2 = x.get(ph2Var.getRow(), column);
-        double a1 = a1Var != null ? x.get(a1Var.getRow(), column) : branch.getPiModel().getA1();
+        double a1 = a1Var != null && a1Var.isActive() ? x.get(a1Var.getRow(), column) : branch.getPiModel().getA1();
         return calculate(ph1, ph2, a1);
     }
 
@@ -57,12 +57,12 @@ public final class ClosedBranchSide2DcFlowEquationTerm extends AbstractClosedBra
         Objects.requireNonNull(x);
         double ph1 = x[ph1Var.getRow()];
         double ph2 = x[ph2Var.getRow()];
-        double a1 = a1Var != null ? x[a1Var.getRow()] : branch.getPiModel().getA1();
+        double a1 = a1Var != null && a1Var.isActive() ? x[a1Var.getRow()] : branch.getPiModel().getA1();
         p2 = calculate(ph1, ph2, a1);
-        if (a1Var == null) {
-            rhs = power * (A2 - a1);
-        } else {
+        if (a1Var != null && a1Var.isActive()) {
             rhs = power * A2;
+        } else {
+            rhs = power * (A2 - a1);
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide2DcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide2DcFlowEquationTerm.java
@@ -59,7 +59,11 @@ public final class ClosedBranchSide2DcFlowEquationTerm extends AbstractClosedBra
         double ph2 = x[ph2Var.getRow()];
         double a1 = a1Var != null ? x[a1Var.getRow()] : branch.getPiModel().getA1();
         p2 = calculate(ph1, ph2, a1);
-        rhs = power * (A2 - a1);
+        if (a1Var == null) {
+            rhs = power * (A2 - a1);
+        } else {
+            rhs = power * A2;
+        }
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -438,7 +438,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis {
     protected void setFunctionReferenceOnFactors(List<LfNetwork> lfNetworks, List<LfSensitivityFactor> factors,
                                                  LoadFlowParameters lfParameters, OpenLoadFlowParameters lfParametersExt) {
         DcLoadFlowParameters dcLoadFlowParameters = new DcLoadFlowParameters(lfParametersExt.getSlackBusSelector(), matrixFactory,
-                true, lfParametersExt.isDcUseTransformerRatio(), lfParameters.isDistributedSlack(),  lfParameters.getBalanceType());
+                true, lfParametersExt.isDcUseTransformerRatio(), lfParameters.isDistributedSlack(),  lfParameters.getBalanceType(), true);
         DcLoadFlowResult dcLoadFlowResult = new DcLoadFlowEngine(lfNetworks, dcLoadFlowParameters).run();
         for (LfSensitivityFactor factor : factors) {
             factor.setFunctionReference(dcLoadFlowResult.getNetwork().getBranchById(factor.getFunctionLfBranchId()).getP1() * PerUnit.SB);

--- a/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowTest.java
@@ -35,6 +35,8 @@ class DcLoadFlowTest {
 
     private LoadFlowParameters parameters;
 
+    private OpenLoadFlowProvider loadFlowProvider;
+
     private LoadFlow.Runner loadFlowRunner;
 
     @BeforeEach
@@ -43,7 +45,8 @@ class DcLoadFlowTest {
                 .setDc(true);
         parameters.addExtension(OpenLoadFlowParameters.class, new OpenLoadFlowParameters()
                 .setSlackBusSelector(new FirstSlackBusSelector()));
-        loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
+        loadFlowProvider = new OpenLoadFlowProvider(new DenseMatrixFactory());
+        loadFlowRunner = new LoadFlow.Runner(loadFlowProvider);
     }
 
     /**
@@ -142,6 +145,18 @@ class DcLoadFlowTest {
         assertEquals(-50, ps1.getTerminal2().getP(), 0.01);
 
         ps1.getPhaseTapChanger().setTapPosition(2);
+
+        loadFlowRunner.run(network, parameters);
+
+        assertEquals(18.5, l1.getTerminal1().getP(), 0.01);
+        assertEquals(-18.5, l1.getTerminal2().getP(), 0.01);
+        assertEquals(81.5, l2.getTerminal1().getP(), 0.01);
+        assertEquals(-81.5, l2.getTerminal2().getP(), 0.01);
+        assertEquals(81.5, ps1.getTerminal1().getP(), 0.01);
+        assertEquals(-81.5, ps1.getTerminal2().getP(), 0.01);
+
+        // check we have same result if we consider phase shift as a variable with a fixed value
+        loadFlowProvider.setForcePhaseControlOffAndAddAngle1Var(true);
 
         loadFlowRunner.run(network, parameters);
 


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When a1 is considered as a variable the rhs, so the part of the equation which has to be moved to right hand side is not correct.


**What is the new behavior (if this is a feature change)?**
rhs has been fixed


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
