### PR TITLE
Slack bus selector type config should not be mandatory

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
@@ -153,7 +153,7 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
         }
 
         private SlackBusSelector getSlackBusSelector(ModuleConfig config) {
-            String type = config.getStringProperty("slackBusSelectorType");
+            String type = config.getStringProperty("slackBusSelectorType", SLACK_BUS_SELECTOR_DEFAULT_TYPE);
             SlackBusSelector slackBusSelector = null;
             for (SlackBusSelectorParametersReader reader : ServiceLoader.load(SlackBusSelectorParametersReader.class)) {
                 if (type.equals(reader.getName())) {

--- a/src/main/java/com/powsybl/openloadflow/network/FirstSlackBusSelectorParametersReader.java
+++ b/src/main/java/com/powsybl/openloadflow/network/FirstSlackBusSelectorParametersReader.java
@@ -13,11 +13,13 @@ import com.powsybl.commons.config.ModuleConfig;
  * @author Thomas Adam <tadam at silicom.fr>
  */
 @AutoService(SlackBusSelectorParametersReader.class)
-public class FirstSlackBusSelectorParametersReaderImpl implements SlackBusSelectorParametersReader {
+public class FirstSlackBusSelectorParametersReader implements SlackBusSelectorParametersReader {
+
+    public static final String NAME = "First";
 
     @Override
     public String getName() {
-        return "First";
+        return NAME;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelectorParametersReader.java
+++ b/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelectorParametersReader.java
@@ -13,16 +13,17 @@ import com.powsybl.commons.config.ModuleConfig;
  * @author Thomas Adam <tadam at silicom.fr>
  */
 @AutoService(SlackBusSelectorParametersReader.class)
-public class NameSlackBusSelectorParametersReaderImpl implements SlackBusSelectorParametersReader {
+public class MostMeshedSlackBusSelectorParametersReader implements SlackBusSelectorParametersReader {
+
+    public static final String NAME = "MostMeshed";
 
     @Override
     public String getName() {
-        return "Name";
+        return NAME;
     }
 
     @Override
     public SlackBusSelector read(ModuleConfig moduleConfig) {
-        String busId = moduleConfig.getStringProperty("nameSlackBusSelectorBusId");
-        return new NameSlackBusSelector(busId);
+        return new MostMeshedSlackBusSelector();
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/NameSlackBusSelectorParametersReader.java
+++ b/src/main/java/com/powsybl/openloadflow/network/NameSlackBusSelectorParametersReader.java
@@ -13,15 +13,18 @@ import com.powsybl.commons.config.ModuleConfig;
  * @author Thomas Adam <tadam at silicom.fr>
  */
 @AutoService(SlackBusSelectorParametersReader.class)
-public class MostMeshedSlackBusSelectorParametersReaderImpl implements SlackBusSelectorParametersReader {
+public class NameSlackBusSelectorParametersReader implements SlackBusSelectorParametersReader {
+
+    public static final String NAME = "Name";
 
     @Override
     public String getName() {
-        return "MostMeshed";
+        return "Name";
     }
 
     @Override
     public SlackBusSelector read(ModuleConfig moduleConfig) {
-        return new MostMeshedSlackBusSelector();
+        String busId = moduleConfig.getStringProperty("nameSlackBusSelectorBusId");
+        return new NameSlackBusSelector(busId);
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/util/ParameterConstants.java
+++ b/src/main/java/com/powsybl/openloadflow/util/ParameterConstants.java
@@ -7,6 +7,7 @@
 package com.powsybl.openloadflow.util;
 
 import com.powsybl.openloadflow.network.MostMeshedSlackBusSelector;
+import com.powsybl.openloadflow.network.MostMeshedSlackBusSelectorParametersReader;
 import com.powsybl.openloadflow.network.SlackBusSelector;
 
 import static com.powsybl.openloadflow.OpenLoadFlowParameters.*;
@@ -16,7 +17,7 @@ import static com.powsybl.openloadflow.OpenLoadFlowParameters.*;
  */
 public final class ParameterConstants {
 
-    public static final String SLACK_BUS_SELECTOR_PARAM_NAME = "slackBusSelector";
+    public static final String SLACK_BUS_SELECTOR_DEFAULT_TYPE = MostMeshedSlackBusSelectorParametersReader.NAME;
     public static final SlackBusSelector SLACK_BUS_SELECTOR_DEFAULT_VALUE = new MostMeshedSlackBusSelector();
 
     public static final String THROWS_EXCEPTION_IN_CASE_OF_SLACK_DISTRIBUTION_FAILURE_PARAM_NAME = "throwsExceptionInCaseOfSlackDistributionFailure";


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
As far as open-loadflow-default-parameters section is defined in the config.yml, we need to define slackBusSelectorType even if we are interested to just set another parameter, otherwise we get an exception.



**What is the new behavior (if this is a feature change)?**
slackBusSelectorType has a default value and is not mandatory anymore.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
