### PR TITLE
Remove variable activation

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractClosedBranchAcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractClosedBranchAcFlowEquationTerm.java
@@ -73,11 +73,11 @@ public abstract class AbstractClosedBranchAcFlowEquationTerm extends AbstractBra
     }
 
     protected double getA1(DenseMatrix x, int column) {
-        return a1Var != null && a1Var.isActive() ? x.get(a1Var.getRow(), column) : branch.getPiModel().getA1();
+        return a1Var != null ? x.get(a1Var.getRow(), column) : branch.getPiModel().getA1();
     }
 
     protected double getR1(DenseMatrix x, int column) {
-        return r1Var != null && r1Var.isActive() ? x.get(r1Var.getRow(), column) : branch.getPiModel().getR1();
+        return r1Var != null ? x.get(r1Var.getRow(), column) : branch.getPiModel().getR1();
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
@@ -237,7 +237,8 @@ public final class AcEquationSystem {
                 }
                 equationSystem.createEquation(branch.getNum(), EquationType.BRANCH_P).addTerm(p);
 
-                // also create an inactive equation to have a1 variable constant
+                // we also create an equation that will be used later to maintain A1 variable constant
+                // this equation is now inactive
                 LfBranch controller = phaseControl.getController();
                 equationSystem.createEquation(controller.getNum(), EquationType.BRANCH_ALPHA1)
                         .addTerm(EquationTerm.createVariableTerm(controller, VariableType.BRANCH_ALPHA1, variableSet))
@@ -254,7 +255,8 @@ public final class AcEquationSystem {
             }
 
             for (LfBranch controllerBranch : bus.getDiscreteVoltageControl().getControllers()) {
-                // also create an inactive equation to have r1 variable constant
+                // we also create an equation that will be used later to maintain R1 variable constant
+                // this equation is now inactive
                 equationSystem.createEquation(controllerBranch.getNum(), EquationType.BRANCH_RHO1)
                         .addTerm(EquationTerm.createVariableTerm(controllerBranch, VariableType.BRANCH_RHO1, variableSet))
                         .setActive(false);

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
@@ -245,6 +245,13 @@ public final class AcEquationSystem {
             if (bus.getDiscreteVoltageControl().getControllers().size() > 1) {
                 createR1DistributionEquations(equationSystem, variableSet, bus.getDiscreteVoltageControl().getControllers());
             }
+
+            for (LfBranch controllerBranch : bus.getDiscreteVoltageControl().getControllers()) {
+                // also create an inactive equation to have r1 variable constant
+                equationSystem.createEquation(controllerBranch.getNum(), EquationType.BRANCH_RHO1)
+                        .addTerm(EquationTerm.createVariableTerm(controllerBranch, VariableType.BRANCH_RHO1, variableSet))
+                        .setActive(false);
+            }
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
@@ -221,7 +221,7 @@ public final class AcEquationSystem {
     }
 
     private static void createBranchActivePowerTargetEquation(LfBranch branch, DiscretePhaseControl.ControlledSide controlledSide,
-                                                              EquationSystem equationSystem, EquationTerm p) {
+                                                              EquationSystem equationSystem, VariableSet variableSet, EquationTerm p) {
         if (branch.isPhaseControlled(controlledSide)) {
             DiscretePhaseControl phaseControl = branch.getDiscretePhaseControl();
             if (phaseControl.getMode() == DiscretePhaseControl.Mode.CONTROLLER) {
@@ -229,6 +229,12 @@ public final class AcEquationSystem {
                     throw new PowsyblException("Phase control in A is not yet supported");
                 }
                 equationSystem.createEquation(branch.getNum(), EquationType.BRANCH_P).addTerm(p);
+
+                // also create an inactive equation to have a1 variable constant
+                LfBranch controller = phaseControl.getController();
+                equationSystem.createEquation(controller.getNum(), EquationType.BRANCH_ALPHA1)
+                        .addTerm(EquationTerm.createVariableTerm(controller, VariableType.BRANCH_ALPHA1, variableSet))
+                        .setActive(false);
             }
         }
     }
@@ -298,7 +304,7 @@ public final class AcEquationSystem {
             equationSystem.createEquation(bus1.getNum(), EquationType.BUS_P).addTerm(p1);
             branch.setP1(p1);
             if (creationParameters.isPhaseControl()) {
-                createBranchActivePowerTargetEquation(branch, DiscretePhaseControl.ControlledSide.ONE, equationSystem, p1);
+                createBranchActivePowerTargetEquation(branch, DiscretePhaseControl.ControlledSide.ONE, equationSystem, variableSet, p1);
             }
         }
         if (q1 != null) {
@@ -309,7 +315,7 @@ public final class AcEquationSystem {
             equationSystem.createEquation(bus2.getNum(), EquationType.BUS_P).addTerm(p2);
             branch.setP2(p2);
             if (creationParameters.isPhaseControl()) {
-                createBranchActivePowerTargetEquation(branch, DiscretePhaseControl.ControlledSide.TWO, equationSystem, p2);
+                createBranchActivePowerTargetEquation(branch, DiscretePhaseControl.ControlledSide.TWO, equationSystem, variableSet, p2);
             }
         }
         if (q2 != null) {

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
@@ -81,7 +81,7 @@ public class AcEquationSystemUpdater implements LfNetworkListener {
         equationSystem.createEquation(phaseControl.getControlled().getNum(), EquationType.BRANCH_P)
                 .setActive(on);
 
-        // de-activate/activate constant phase equation
+        // de-activate/activate constant A1 equation
         equationSystem.createEquation(phaseControl.getController().getNum(), EquationType.BRANCH_ALPHA1)
                 .setActive(!on);
     }
@@ -96,7 +96,7 @@ public class AcEquationSystemUpdater implements LfNetworkListener {
                     .setActive(false);
 
             for (LfBranch controllerBranch : bus.getDiscreteVoltageControl().getControllers()) {
-                // activate constant r1 equation
+                // activate constant R1 equation
                 equationSystem.createEquation(controllerBranch.getNum(), EquationType.BRANCH_RHO1)
                         .setActive(true);
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
@@ -93,9 +93,9 @@ public class AcEquationSystemUpdater implements LfNetworkListener {
             t.setActive(false);
 
             for (LfBranch controllerBranch : bus.getDiscreteVoltageControl().getControllers()) {
-                // de-activate r1 variable
-                Variable r1 = variableSet.getVariable(controllerBranch.getNum(), VariableType.BRANCH_RHO1);
-                r1.setActive(false);
+                // activate constant r1 equation
+                equationSystem.createEquation(controllerBranch.getNum(), EquationType.BRANCH_RHO1)
+                        .setActive(true);
 
                 // clean transformer distribution equations
                 equationSystem.removeEquation(controllerBranch.getNum(), EquationType.ZERO_RHO1);

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
@@ -72,17 +72,15 @@ public class AcEquationSystemUpdater implements LfNetworkListener {
 
     @Override
     public void onPhaseControlModeChange(DiscretePhaseControl phaseControl, DiscretePhaseControl.Mode oldMode, DiscretePhaseControl.Mode newMode) {
-        if (newMode == DiscretePhaseControl.Mode.OFF) {
-            // de-activate a1 variable
-            Variable a1 = variableSet.getVariable(phaseControl.getController().getNum(), VariableType.BRANCH_ALPHA1);
-            a1.setActive(false);
+        boolean on = newMode != DiscretePhaseControl.Mode.OFF;
 
-            // de-activate phase control equation
-            Equation t = equationSystem.createEquation(phaseControl.getControlled().getNum(), EquationType.BRANCH_P);
-            t.setActive(false);
-        } else {
-            throw new UnsupportedOperationException("TODO");
-        }
+        // activate/de-activate phase control equation
+        equationSystem.createEquation(phaseControl.getControlled().getNum(), EquationType.BRANCH_P)
+                .setActive(on);
+
+        // de-activate/activate constant phase equation
+        equationSystem.createEquation(phaseControl.getController().getNum(), EquationType.BRANCH_ALPHA1)
+                .setActive(!on);
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
@@ -6,7 +6,10 @@
  */
 package com.powsybl.openloadflow.ac.equations;
 
-import com.powsybl.openloadflow.equations.*;
+import com.powsybl.openloadflow.equations.Equation;
+import com.powsybl.openloadflow.equations.EquationSystem;
+import com.powsybl.openloadflow.equations.EquationType;
+import com.powsybl.openloadflow.equations.VariableSet;
 import com.powsybl.openloadflow.network.*;
 
 import java.util.List;
@@ -89,8 +92,8 @@ public class AcEquationSystemUpdater implements LfNetworkListener {
             LfBus bus = voltageControl.getControlled();
 
             // de-activate transformer voltage control equation
-            Equation t = equationSystem.createEquation(bus.getNum(), EquationType.BUS_V);
-            t.setActive(false);
+            equationSystem.createEquation(bus.getNum(), EquationType.BUS_V)
+                    .setActive(false);
 
             for (LfBranch controllerBranch : bus.getDiscreteVoltageControl().getControllers()) {
                 // activate constant r1 equation

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide1ActiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide1ActiveFlowEquationTerm.java
@@ -52,11 +52,11 @@ public class ClosedBranchSide1ActiveFlowEquationTerm extends AbstractClosedBranc
         double v2 = x[v2Var.getRow()];
         double ph1 = x[ph1Var.getRow()];
         double ph2 = x[ph2Var.getRow()];
-        double theta = ksi - (a1Var != null && a1Var.isActive() ? x[a1Var.getRow()] : branch.getPiModel().getA1())
+        double theta = ksi - (a1Var != null ? x[a1Var.getRow()] : branch.getPiModel().getA1())
                 + A2 - ph1 + ph2;
         double sinTheta = FastMath.sin(theta);
         double cosTheta = FastMath.cos(theta);
-        double r1 = r1Var != null && r1Var.isActive() ? x[r1Var.getRow()] : branch.getPiModel().getR1();
+        double r1 = r1Var != null ? x[r1Var.getRow()] : branch.getPiModel().getR1();
         p1 = r1 * v1 * (g1 * r1 * v1 + y * r1 * v1 * sinKsi - y * R2 * v2 * sinTheta);
         dp1dv1 = r1 * (2 * g1 * r1 * v1 + 2 * y * r1 * v1 * sinKsi - y * R2 * v2 * sinTheta);
         dp1dv2 = -y * r1 * R2 * v1 * sinTheta;

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide1CurrentMagnitudeEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide1CurrentMagnitudeEquationTerm.java
@@ -51,14 +51,14 @@ public class ClosedBranchSide1CurrentMagnitudeEquationTerm extends AbstractClose
         double v2 = x[v2Var.getRow()];
         double ph1 = x[ph1Var.getRow()];
         double ph2 = x[ph2Var.getRow()];
-        double r1 = r1Var != null && r1Var.isActive() ? x[r1Var.getRow()] : branch.getPiModel().getR1();
+        double r1 = r1Var != null ? x[r1Var.getRow()] : branch.getPiModel().getR1();
         double w1 = r1 * v1;
         double w2 = y * R2 * v2;
         double cosPh1 = FastMath.cos(ph1);
         double sinPh1 = FastMath.sin(ph1);
         double cosPh1Ksi = FastMath.cos(ph1 + ksi);
         double sinPh1Ksi = FastMath.sin(ph1 + ksi);
-        double theta = ksi - (a1Var != null && a1Var.isActive() ? x[a1Var.getRow()] : branch.getPiModel().getA1())
+        double theta = ksi - (a1Var != null ? x[a1Var.getRow()] : branch.getPiModel().getA1())
             + A2 + ph2;
         double sinTheta = FastMath.sin(theta);
         double cosTheta = FastMath.cos(theta);

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide1ReactiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide1ReactiveFlowEquationTerm.java
@@ -52,11 +52,11 @@ public class ClosedBranchSide1ReactiveFlowEquationTerm extends AbstractClosedBra
         double v2 = x[v2Var.getRow()];
         double ph1 = x[ph1Var.getRow()];
         double ph2 = x[ph2Var.getRow()];
-        double theta = ksi - (a1Var != null && a1Var.isActive() ? x[a1Var.getRow()] : branch.getPiModel().getA1())
+        double theta = ksi - (a1Var != null ? x[a1Var.getRow()] : branch.getPiModel().getA1())
                 + A2 - ph1 + ph2;
         double cosTheta = FastMath.cos(theta);
         double sinTheta = FastMath.sin(theta);
-        double r1 = r1Var != null && r1Var.isActive() ? x[r1Var.getRow()] : branch.getPiModel().getR1();
+        double r1 = r1Var != null ? x[r1Var.getRow()] : branch.getPiModel().getR1();
         q1 = r1 * v1 * (-b1 * r1 * v1 + y * r1 * v1 * cosKsi - y * R2 * v2 * cosTheta);
         dq1dv1 = r1 * (-2 * b1 * r1 * v1 + 2 * y * r1 * v1 * cosKsi - y * R2 * v2 * cosTheta);
         dq1dv2 = -y * r1 * R2 * v1 * cosTheta;

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide2ActiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide2ActiveFlowEquationTerm.java
@@ -52,11 +52,11 @@ public class ClosedBranchSide2ActiveFlowEquationTerm extends AbstractClosedBranc
         double v2 = x[v2Var.getRow()];
         double ph1 = x[ph1Var.getRow()];
         double ph2 = x[ph2Var.getRow()];
-        double theta = ksi + (a1Var != null && a1Var.isActive() ? x[a1Var.getRow()] : branch.getPiModel().getA1())
+        double theta = ksi + (a1Var != null ? x[a1Var.getRow()] : branch.getPiModel().getA1())
                 - A2 + ph1 - ph2;
         double sinTheta = FastMath.sin(theta);
         double cosTheta = FastMath.cos(theta);
-        double r1 = r1Var != null && r1Var.isActive() ? x[r1Var.getRow()] : branch.getPiModel().getR1();
+        double r1 = r1Var != null ? x[r1Var.getRow()] : branch.getPiModel().getR1();
         p2 = R2 * v2 * (g2 * R2 * v2 - y * r1 * v1 * sinTheta + y * R2 * v2 * sinKsi);
         dp2dv1 = -y * r1 * R2 * v2 * sinTheta;
         dp2dv2 = R2 * (2 * g2 * R2 * v2 - y * r1 * v1 * sinTheta + 2 * y * R2 * v2 * sinKsi);

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide2CurrentMagnitudeEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide2CurrentMagnitudeEquationTerm.java
@@ -51,14 +51,14 @@ public class ClosedBranchSide2CurrentMagnitudeEquationTerm extends AbstractClose
         double v1 = x[v1Var.getRow()];
         double ph2 = x[ph2Var.getRow()];
         double ph1 = x[ph1Var.getRow()];
-        double r1 = r1Var != null && r1Var.isActive() ? x[r1Var.getRow()] : branch.getPiModel().getR1();
+        double r1 = r1Var != null ? x[r1Var.getRow()] : branch.getPiModel().getR1();
         double w2 = R2 * v2;
         double w1 = y * r1 * v1;
         double cosPh2 = FastMath.cos(ph2);
         double sinPh2 = FastMath.sin(ph2);
         double cosPh2Ksi = FastMath.cos(ph2 + ksi);
         double sinPh2Ksi = FastMath.sin(ph2 + ksi);
-        double theta = ksi - (a1Var != null && a1Var.isActive() ? x[a1Var.getRow()] : branch.getPiModel().getA1())
+        double theta = ksi - (a1Var != null ? x[a1Var.getRow()] : branch.getPiModel().getA1())
             + A2 + ph1;
         double sinTheta = FastMath.sin(theta);
         double cosTheta = FastMath.cos(theta);

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide2ReactiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide2ReactiveFlowEquationTerm.java
@@ -52,11 +52,11 @@ public class ClosedBranchSide2ReactiveFlowEquationTerm extends AbstractClosedBra
         double v2 = x[v2Var.getRow()];
         double ph1 = x[ph1Var.getRow()];
         double ph2 = x[ph2Var.getRow()];
-        double theta = ksi + (a1Var != null && a1Var.isActive() ? x[a1Var.getRow()] : branch.getPiModel().getA1())
+        double theta = ksi + (a1Var != null ? x[a1Var.getRow()] : branch.getPiModel().getA1())
                 - A2 + ph1 - ph2;
         double cosTheta = FastMath.cos(theta);
         double sinTheta = FastMath.sin(theta);
-        double r1 = r1Var != null && r1Var.isActive() ? x[r1Var.getRow()] : branch.getPiModel().getR1();
+        double r1 = r1Var != null ? x[r1Var.getRow()] : branch.getPiModel().getR1();
         q2 = R2 * v2 * (-b2 * R2 * v2 - y * r1 * v1 * cosTheta + y * R2 * v2 * cosKsi);
         dq2dv1 = -y * r1 * R2 * v2 * cosTheta;
         dq2dv2 = R2 * (-2 * b2 * R2 * v2 - y * r1 * v1 * cosTheta + 2 * y * R2 * v2 * cosKsi);

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide2CurrentMagnitudeEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide2CurrentMagnitudeEquationTerm.java
@@ -45,7 +45,7 @@ public class OpenBranchSide2CurrentMagnitudeEquationTerm extends AbstractOpenSid
         Objects.requireNonNull(x);
         double v1 = x[v1Var.getRow()];
         double ph1 = x[ph1Var.getRow()];
-        double r1 = r1Var != null && r1Var.isActive() ? x[r1Var.getRow()] : branch.getPiModel().getR1();
+        double r1 = r1Var != null ? x[r1Var.getRow()] : branch.getPiModel().getR1();
         double w1 = r1 * v1;
         double cosPh1 = FastMath.cos(ph1);
         double sinPh1 = FastMath.sin(ph1);

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
@@ -63,13 +63,13 @@ public abstract class AbstractClosedBranchDcFlowEquationTerm extends AbstractNam
     }
 
     private double getA1(DenseMatrix x, int column) {
-        return a1Var != null && a1Var.isActive() ? x.get(a1Var.getRow(), column) : branch.getPiModel().getA1();
+        return a1Var != null ? x.get(a1Var.getRow(), column) : branch.getPiModel().getA1();
     }
 
     protected abstract double calculate(double ph1, double ph2, double a1);
 
     protected double getA1(double[] stateVector) {
-        return a1Var != null && a1Var.isActive() ? stateVector[a1Var.getRow()] : branch.getPiModel().getA1();
+        return a1Var != null ? stateVector[a1Var.getRow()] : branch.getPiModel().getA1();
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide1DcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide1DcFlowEquationTerm.java
@@ -50,7 +50,7 @@ public final class ClosedBranchSide1DcFlowEquationTerm extends AbstractClosedBra
         double ph2 = x[ph2Var.getRow()];
         double a1 = getA1(x);
         p1 = calculate(ph1, ph2, a1);
-        if (a1Var != null && a1Var.isActive()) {
+        if (a1Var != null) {
             rhs = -power * A2;
         } else {
             rhs = -power * (A2 - a1);

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide2DcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide2DcFlowEquationTerm.java
@@ -51,7 +51,7 @@ public final class ClosedBranchSide2DcFlowEquationTerm extends AbstractClosedBra
         double ph2 = x[ph2Var.getRow()];
         double a1 = getA1(x);
         p2 = calculate(ph1, ph2, a1);
-        if (a1Var != null && a1Var.isActive()) {
+        if (a1Var != null) {
             rhs = power * A2;
         } else {
             rhs = power * (A2 - a1);

--- a/src/main/java/com/powsybl/openloadflow/equations/Equation.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/Equation.java
@@ -201,6 +201,10 @@ public class Equation implements Evaluable, Comparable<Equation> {
                 targets[column] = network.getBranch(num).getPiModel().getA1();
                 break;
 
+            case BRANCH_RHO1:
+                targets[column] = network.getBranch(num).getPiModel().getR1();
+                break;
+
             case ZERO_Q:
                 targets[column] = getReactivePowerDistributionTarget(network, num, getData());
                 break;

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationSystem.java
@@ -79,11 +79,9 @@ public class EquationSystem {
                                 equationTermsByVariable = sortedEquationsToSolve.computeIfAbsent(equation, k -> new TreeMap<>());
                             }
                             for (Variable variable : equationTerm.getVariables()) {
-                                if (variable.isActive()) {
-                                    equationTermsByVariable.computeIfAbsent(variable, k -> new ArrayList<>())
-                                            .add(equationTerm);
-                                    variablesToFind.add(variable);
-                                }
+                                equationTermsByVariable.computeIfAbsent(variable, k -> new ArrayList<>())
+                                        .add(equationTerm);
+                                variablesToFind.add(variable);
                             }
                         }
                     }

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationType.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationType.java
@@ -20,6 +20,7 @@ public enum EquationType {
     BRANCH_P("t", ElementType.BRANCH),
     BRANCH_I("i", ElementType.BRANCH),
     BRANCH_ALPHA1("\u03B1" + "1", ElementType.BRANCH),
+    BRANCH_RHO1("\u03C1" + "1", ElementType.BRANCH),
     ZERO_Q("z_q", ElementType.BUS),
     ZERO_V("z_v", ElementType.BRANCH),
     ZERO_PHI("z_\u03C6", ElementType.BRANCH),

--- a/src/main/java/com/powsybl/openloadflow/equations/Variable.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/Variable.java
@@ -26,11 +26,6 @@ public class Variable implements Comparable<Variable> {
 
     private int row = -1;
 
-    /**
-     * true if this variable is active, false otherwise
-     */
-    private boolean active = true;
-
     Variable(int num, VariableType type) {
         this.num = num;
         this.type = Objects.requireNonNull(type);
@@ -50,15 +45,6 @@ public class Variable implements Comparable<Variable> {
 
     public void setRow(int row) {
         this.row = row;
-    }
-
-    public boolean isActive() {
-        return active;
-    }
-
-    public void setActive(boolean active) {
-        // FIXME invalidate equation system cache
-        this.active = active;
     }
 
     void initState(VoltageInitializer initializer, LfNetwork network, double[] x) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*
Variable has a active property which allows a variable considered either as a variable or as a constant in an equation term. The problem is that it is not fully implemented (see the ugly FIXME in Variable.java). By luck when we change the active status of a variable, we always also change the active status of its term, so it works but this is really fragile...



**What is the new behavior (if this is a feature change)?**
That would be hard to support a robust variable active status. Instead it is simpler to just rework the equation design by just adding a new equation v = constant when we want the variable to become constant. 


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
