### PR TITLE
Fix disconnected branch issue in sensitivity analysis

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
@@ -584,8 +584,8 @@ public abstract class AbstractSensitivityAnalysis {
 
     public void checkContingencies(Network network, LfNetwork lfNetwork, List<PropagatedContingency> contingencies) {
         for (PropagatedContingency contingency : contingencies) {
-            // Element have already been checked and found in PropagatedContingency, so there is no need to
-            // check it again
+            // Elements have already been checked and found in PropagatedContingency, so there is no need to
+            // check them again
             Set<String> branchesToRemove = new HashSet<>(); // branches connected to one side, or switches
             for (String branchId : contingency.getBranchIdsToOpen()) {
                 LfBranch lfBranch = lfNetwork.getBranchById(branchId);

--- a/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
@@ -584,27 +584,17 @@ public abstract class AbstractSensitivityAnalysis {
 
     public void checkContingencies(Network network, LfNetwork lfNetwork, List<PropagatedContingency> contingencies) {
         for (PropagatedContingency contingency : contingencies) {
-            for (String branchId : contingency.getBranchIdsToOpen()) {
-                LfBranch lfBranch = lfNetwork.getBranchById(branchId);
-                if (lfBranch == null) {
-                    throw new PowsyblException("The contingency on the branch " + branchId + " not found in the network");
-                }
-            }
-            for (String hvdcId : contingency.getHvdcIdsToOpen()) {
-                HvdcLine hvdcLine = network.getHvdcLine(hvdcId);
-                if (hvdcLine == null) {
-                    throw new PowsyblException("The DC line '" + hvdcId + "' does not exist in the network");
-                }
-            }
+            // Element have already been checked and found in PropagatedContingency, so there is no need to
+            // check it again
             Set<String> branchesToRemove = new HashSet<>(); // branches connected to one side, or switches
             for (String branchId : contingency.getBranchIdsToOpen()) {
                 LfBranch lfBranch = lfNetwork.getBranchById(branchId);
                 if (lfBranch == null) {
-                    branchesToRemove.add(branchId); // this is certainly a switch
+                    branchesToRemove.add(branchId); // disconnected branch
                     continue;
                 }
                 if (lfBranch.getBus2() == null || lfBranch.getBus1() == null) {
-                    branchesToRemove.add(branchId); // contains the branches that are connected only on one side
+                    branchesToRemove.add(branchId); // branch connected only on one side
                 }
             }
             contingency.getBranchIdsToOpen().removeAll(branchesToRemove);
@@ -723,7 +713,8 @@ public abstract class AbstractSensitivityAnalysis {
                 LfElement variableElement;
                 if (functionType == SensitivityFunctionType.BRANCH_ACTIVE_POWER) {
                     checkBranch(network, functionId);
-                    functionElement = lfNetwork.getBranchById(functionId);
+                    LfBranch branch = lfNetwork.getBranchById(functionId);
+                    functionElement = branch != null && branch.getBus1() != null && branch.getBus2() != null ? branch : null;
                     if (variableType == SensitivityVariableType.INJECTION_ACTIVE_POWER) {
                         Bus injectionBus = getInjectionBus(network, variableId);
                         variableElement = injectionBus != null ? lfNetwork.getBusById(injectionBus.getId()) : null;
@@ -735,7 +726,8 @@ public abstract class AbstractSensitivityAnalysis {
                     }
                 } else if (functionType == SensitivityFunctionType.BRANCH_CURRENT) {
                     checkBranch(network, functionId);
-                    functionElement = lfNetwork.getBranchById(functionId);
+                    LfBranch branch = lfNetwork.getBranchById(functionId);
+                    functionElement = branch != null && branch.getBus1() != null && branch.getBus2() != null ? branch : null;
                     if (variableType == SensitivityVariableType.TRANSFORMER_PHASE) {
                         checkPhaseShifter(network, variableId);
                         variableElement = lfNetwork.getBranchById(variableId);

--- a/src/main/java/com/powsybl/openloadflow/util/PropagatedContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/util/PropagatedContingency.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.openloadflow.util;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.contingency.Contingency;
 import com.powsybl.contingency.ContingencyElement;
 import com.powsybl.iidm.network.*;
@@ -62,11 +63,16 @@ public class PropagatedContingency {
             for (ContingencyElement element : contingency.getElements()) {
                 switch (element.getType()) {
                     case BRANCH:
-                        propagatedContingency.getBranchIdsToOpen().add(element.getId());
+                        // branch check is done inside branch tripping
                         new BranchTripping(element.getId(), null)
                             .traverse(network, null, switchesToOpen, terminalsToDisconnect);
+                        propagatedContingency.getBranchIdsToOpen().add(element.getId());
                         break;
                     case HVDC_LINE:
+                        HvdcLine hvdcLine = network.getHvdcLine(element.getId());
+                        if (hvdcLine == null) {
+                            throw new PowsyblException("HVDC line '" + element.getId() + "' not found");
+                        }
                         propagatedContingency.getHvdcIdsToOpen().add(element.getId());
                         break;
                     default:


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
There is 2 not supported cases in sensitivity analysis:
 - Branch contingency, open at both sides on base case
 - Factor with a branch function, open at one or two sides 


**What is the new behavior (if this is a feature change)?**
 - There is no error and all sensitivities are the same than in base case
 - Sensitivity is zero.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
