### PR TITLE
Implementation of PROPORTIONAL_TO_GENERATION_P balancetype

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/LfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfGenerator.java
@@ -43,7 +43,7 @@ public interface LfGenerator {
 
     boolean isParticipating();
 
-    double getParticipationFactor();
+    double getDroop();
 
     double getCalculatedQ();
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineGenerator.java
@@ -65,7 +65,7 @@ public class LfDanglingLineGenerator extends AbstractLfGenerator {
     }
 
     @Override
-    public double getParticipationFactor() {
+    public double getDroop() {
         return 0;
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
@@ -33,13 +33,13 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
 
     private boolean participating;
 
-    private double participationFactor;
+    private double droop;
 
     private LfGeneratorImpl(Generator generator, boolean breakers, LfNetworkLoadingReport report, double plausibleActivePowerLimit) {
         super(generator.getTargetP());
         this.generator = generator;
         participating = true;
-        double droop = DEFAULT_DROOP;
+        droop = DEFAULT_DROOP;
         // get participation factor from extension
         ActivePowerControl<Generator> activePowerControl = generator.getExtension(ActivePowerControl.class);
         if (activePowerControl != null) {
@@ -48,7 +48,6 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
                 droop = activePowerControl.getDroop();
             }
         }
-        participationFactor = generator.getMaxP() / droop;
         if (Math.abs(generator.getTargetP()) < TARGET_P_EPSILON) {
             LOGGER.trace("Discard generator '{}' from active power control because targetP ({}) equals 0",
                     generator.getId(), generator.getTargetP());
@@ -125,8 +124,8 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
     }
 
     @Override
-    public double getParticipationFactor() {
-        return participationFactor;
+    public double getDroop() {
+        return droop;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfStaticVarCompensatorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfStaticVarCompensatorImpl.java
@@ -93,7 +93,7 @@ public final class LfStaticVarCompensatorImpl extends AbstractLfGenerator {
     }
 
     @Override
-    public double getParticipationFactor() {
+    public double getDroop() {
         return 0;
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfVscConverterStationImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfVscConverterStationImpl.java
@@ -71,7 +71,7 @@ public final class LfVscConverterStationImpl extends AbstractLfGenerator {
     }
 
     @Override
-    public double getParticipationFactor() {
+    public double getDroop() {
         return 0;
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
@@ -97,10 +97,10 @@ public final class ActivePowerDistribution {
                 step = new LoadActivePowerDistributionStep(true, loadPowerFactorConstant);
                 break;
             case PROPORTIONAL_TO_GENERATION_P_MAX:
-                step = new GenerationActionPowerDistributionStep(GenerationActionPowerDistributionStep.ParticipationType.MAX);
+                step = new GenerationActivePowerDistributionStep(GenerationActivePowerDistributionStep.ParticipationType.MAX);
                 break;
             case PROPORTIONAL_TO_GENERATION_P:
-                step = new GenerationActionPowerDistributionStep(GenerationActionPowerDistributionStep.ParticipationType.TARGET);
+                step = new GenerationActivePowerDistributionStep(GenerationActivePowerDistributionStep.ParticipationType.TARGET);
                 break;
             default:
                 throw new UnsupportedOperationException("Unknown balance type mode: " + balanceType);

--- a/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
@@ -97,10 +97,11 @@ public final class ActivePowerDistribution {
                 step = new LoadActivePowerDistributionStep(true, loadPowerFactorConstant);
                 break;
             case PROPORTIONAL_TO_GENERATION_P_MAX:
-                step = new GenerationActionPowerDistributionStep();
+                step = new GenerationActionPowerDistributionStep(GenerationActionPowerDistributionStep.ParticipationType.MAX);
                 break;
-            case PROPORTIONAL_TO_GENERATION_P: // to be implemented.
-                throw new UnsupportedOperationException("Unsupported balance type mode: " + balanceType);
+            case PROPORTIONAL_TO_GENERATION_P:
+                step = new GenerationActionPowerDistributionStep(GenerationActionPowerDistributionStep.ParticipationType.TARGET);
+                break;
             default:
                 throw new UnsupportedOperationException("Unknown balance type mode: " + balanceType);
         }

--- a/src/main/java/com/powsybl/openloadflow/network/util/GenerationActionPowerDistributionStep.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/GenerationActionPowerDistributionStep.java
@@ -66,8 +66,6 @@ public class GenerationActionPowerDistributionStep implements ActivePowerDistrib
             LfGenerator generator = (LfGenerator) participatingGenerator.getElement();
             double factor = participatingGenerator.getFactor();
 
-            System.out.println("Factor " + factor + " for generator " + generator.getId());
-
             double minP = generator.getMinP();
             double maxP = generator.getMaxP();
             double targetP = generator.getTargetP();

--- a/src/main/java/com/powsybl/openloadflow/network/util/GenerationActivePowerDistributionStep.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/GenerationActivePowerDistributionStep.java
@@ -20,9 +20,9 @@ import java.util.stream.Collectors;
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public class GenerationActionPowerDistributionStep implements ActivePowerDistribution.Step {
+public class GenerationActivePowerDistributionStep implements ActivePowerDistribution.Step {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(GenerationActionPowerDistributionStep.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GenerationActivePowerDistributionStep.class);
 
     public enum ParticipationType {
         MAX,
@@ -31,7 +31,7 @@ public class GenerationActionPowerDistributionStep implements ActivePowerDistrib
 
     private ParticipationType participationType;
 
-    public GenerationActionPowerDistributionStep(ParticipationType pParticipationType) {
+    public GenerationActivePowerDistributionStep(ParticipationType pParticipationType) {
         this.participationType = pParticipationType;
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
@@ -79,10 +79,17 @@ class DistributedSlackOnGenerationTest {
     }
 
     @Test
-    void testUnsupportedGenerationBalanceType() {
+    void testProportionalToGenerationPBalanceType() {
+        // decrease g1 max limit power, so that distributed slack algo reach the g1 max
+        g1.setMaxP(105);
         parameters.setBalanceType(LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P);
-        assertThrows(CompletionException.class, () -> loadFlowRunner.run(network, parameters),
-                "java.lang.UnsupportedOperationException: Unsupported balance type mode: PROPORTIONAL_TO_GENERATION_P");
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+
+        assertTrue(result.isOk());
+        assertActivePowerEquals(-105, g1.getTerminal());
+        assertActivePowerEquals(-260.526, g2.getTerminal());
+        assertActivePowerEquals(-117.236, g3.getTerminal());
+        assertActivePowerEquals(-117.236, g4.getTerminal());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*


Implementation of PROPORTIONAL_TO_GENERATION_P balancetype : 

It reuses GenerationActionPowerDistributionStep class as implementation is the same, only the participation factor is computed differently.

Unsupported balance type test has been replaced by a small test of proportional to generation P balance type.


**What is the new behavior (if this is a feature change)?**


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
