### PR TITLE
Use absolute value for balancetype using targetP

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/util/GenerationActivePowerDistributionStep.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/GenerationActivePowerDistributionStep.java
@@ -111,7 +111,7 @@ public class GenerationActivePowerDistributionStep implements ActivePowerDistrib
                 factor = generator.getMaxP() / generator.getDroop();
                 break;
             case TARGET:
-                factor = generator.getTargetP();
+                factor = Math.abs(generator.getTargetP());
                 break;
             default:
                 throw new UnsupportedOperationException("Unknown balance type mode: " + participationType);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Following discussion with @annetill we should make sure factor is an absolute value when using proportional_to_generation_p balance type. This did not make it in the original PR.


**What is the current behavior?** *(You can also link to an open issue here)*

No absolute value factor for proportional_to_generation_p balancetype.

**What is the new behavior (if this is a feature change)?**

Factor value is now absolute for proportional_to_generation_p balancetype.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


