### PR TITLE
Fix NPE on disconnected generator, in sensitivity analysis

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
@@ -772,7 +772,8 @@ public abstract class AbstractSensitivityAnalysis {
                         checkRegulatingTerminal(network, variableId);
                         Terminal regulatingTerminal = getEquipmentRegulatingTerminal(network, variableId);
                         assert regulatingTerminal != null; // this cannot fail because it is checked in checkRegulatingTerminal
-                        variableElement = lfNetwork.getBusById(regulatingTerminal.getBusView().getBus().getId());
+                        Bus regulatedBus = regulatingTerminal.getBusView().getBus();
+                        variableElement = regulatedBus != null ? lfNetwork.getBusById(regulatedBus.getId()) : null;
                     } else {
                         throw new PowsyblException("Variable type " + variableType + " not supported with function type " + functionType);
                     }

--- a/src/test/java/com/powsybl/openloadflow/sensi/ac/AcSensitivityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/ac/AcSensitivityAnalysisTest.java
@@ -543,6 +543,23 @@ class AcSensitivityAnalysisTest extends AbstractSensitivityAnalysisTest {
     }
 
     @Test
+    void disconnectedGeneratorShouldBeSkipped() {
+        Network network = FourBusNetworkFactory.create();
+        SensitivityAnalysisParameters sensiParameters = createParameters(false, "b1_vl_0", true);
+        sensiParameters.getLoadFlowParameters().setBalanceType(LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX);
+        //Disconnect g4 generator
+        network.getGenerator("g4").getTerminal().disconnect();
+
+        TargetVoltage targetVoltage = new TargetVoltage("g4", "g4", "g4");
+        BusVoltage busVoltage = new BusVoltage("b1", "b1", new IdBasedBusRef("b1"));
+        SensitivityFactorsProvider factorsProvider = n -> Collections.singletonList(new BusVoltagePerTargetV(busVoltage, targetVoltage));
+        SensitivityAnalysisResult result = sensiProvider.run(network, VariantManagerConstants.INITIAL_VARIANT_ID, factorsProvider, Collections.emptyList(),
+            sensiParameters, LocalComputationManager.getDefault())
+            .join();
+        assertTrue(result.getSensitivityValues().isEmpty());
+    }
+
+    @Test
     void testBranchFunctionOutsideMainComponent() {
         testBranchFunctionOutsideMainComponent(false);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*

When running a voltage sensisitivyt analysis on a disconnected generator, we get a null pointer exception.

**What is the new behavior (if this is a feature change)?**

The sensitivity factors for that generator are skipped.

