### PR TITLE
Sensitivity analysis: add a bus cache to improve input handling perfomance

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
@@ -642,8 +642,8 @@ public abstract class AbstractSensitivityAnalysis {
         }
     }
 
-    private static void checkBus(Network network, String busId) {
-        Bus bus = network.getBusView().getBus(busId);
+    private static void checkBus(Network network, String busId, Map<String, Bus> busCache) {
+        Bus bus = busCache.computeIfAbsent(busId, id -> network.getBusView().getBus(busId));
         if (bus == null) {
             throw new PowsyblException("Bus '" + busId + "' not found");
         }
@@ -707,6 +707,7 @@ public abstract class AbstractSensitivityAnalysis {
                                                        SensitivityFactorReader factorReader, LfNetwork lfNetwork) {
         final SensitivityFactorHolder factorHolder = new SensitivityFactorHolder();
 
+        final Map<String, Bus> busCache = new HashMap<>();
         factorReader.read((factorContext, functionType, functionId, variableType, variableId, variableSet, contingencyContext) -> {
             if (variableSet) {
                 if (functionType == SensitivityFunctionType.BRANCH_ACTIVE_POWER
@@ -766,7 +767,7 @@ public abstract class AbstractSensitivityAnalysis {
                         throw new PowsyblException("Variable type " + variableType + " not supported with function type " + functionType);
                     }
                 } else if (functionType == SensitivityFunctionType.BUS_VOLTAGE) {
-                    checkBus(network, functionId);
+                    checkBus(network, functionId, busCache);
                     functionElement = lfNetwork.getBusById(functionId);
                     if (variableType == SensitivityVariableType.BUS_TARGET_VOLTAGE) {
                         checkRegulatingTerminal(network, variableId);

--- a/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
@@ -643,7 +643,12 @@ public abstract class AbstractSensitivityAnalysis {
     }
 
     private static void checkBus(Network network, String busId, Map<String, Bus> busCache) {
-        Bus bus = busCache.computeIfAbsent(busId, id -> network.getBusView().getBus(busId));
+        if (busCache.isEmpty()) {
+            network.getBusView()
+                .getBusStream()
+                .forEach(bus -> busCache.put(bus.getId(), bus));
+        }
+        Bus bus = busCache.get(busId);
         if (bus == null) {
             throw new PowsyblException("Bus '" + busId + "' not found");
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

Quck win for https://github.com/powsybl/powsybl-open-loadflow/issues/296

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Perf improvement

**What is the current behavior?** *(You can also link to an open issue here)*

Buses may be searched for multiple times in the network.

**What is the new behavior (if this is a feature change)?**

Buses are searched only once and cached.

On the use case described in the issue, the computation time reduces from ~25s to ~8s
