### PR TITLE
Sensitivity analysis:  support of dangling line contingency

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -491,7 +491,9 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis {
         }
     }
 
-    private Map<LfBus, BusState> applyDcLineContingency(Network network, LfNetwork lfNetwork, PropagatedContingency contingency) {
+    private Map<LfBus, BusState> applyHvdcLineContingency(Network network, LfNetwork lfNetwork, PropagatedContingency contingency) {
+        // it applies on the network the loss of the HVDC lines contained in the contingency.
+        // Buses state are stored too.
         Collection<Pair<LfBus, LccConverterStation>> lccs = new HashSet<>();
         Collection<Pair<LfBus, LfVscConverterStationImpl>> vscs = new HashSet<>();
         for (String hvdcId : contingency.getHvdcIdsToOpen()) {
@@ -545,7 +547,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis {
             calculateSensitivityValues(factors, factorGroups, factorStates, contingenciesStates, flowStates, contingencyElements,
                     contingency.getContingency().getId(), contingency.getIndex(), valueWriter);
         } else { // if we have a contingency including the loss of a DC line
-            Map<LfBus, BusState> busStates = applyDcLineContingency(network, lfNetwork, contingency);
+            Map<LfBus, BusState> busStates = applyHvdcLineContingency(network, lfNetwork, contingency);
             boolean shouldChangeRhs = lfParameters.isDistributedSlack()
                     && (lfParameters.getBalanceType() == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD || lfParameters.getBalanceType() == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD);
             DenseMatrix statesWithoutDcLine = factorStates;

--- a/src/main/java/com/powsybl/openloadflow/util/ContingencyTripping.java
+++ b/src/main/java/com/powsybl/openloadflow/util/ContingencyTripping.java
@@ -36,7 +36,7 @@ public class ContingencyTripping {
 
         Branch<?> branch = network.getBranch(branchId);
         if (branch == null) {
-            throw new PowsyblException("Branch '" + branchId + "' not found");
+            throw new PowsyblException("Branch '" + branchId + "' not found in the network");
         }
 
         if (voltageLevelId != null) {
@@ -58,7 +58,7 @@ public class ContingencyTripping {
 
         DanglingLine danglingLine = network.getDanglingLine(dlId);
         if (danglingLine == null) {
-            throw new PowsyblException("Branch '" + dlId + "' not found");
+            throw new PowsyblException("Dangling line '" + dlId + "' not found in the network");
         }
 
         return new ContingencyTripping(danglingLine.getTerminal());

--- a/src/main/java/com/powsybl/openloadflow/util/PropagatedContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/util/PropagatedContingency.java
@@ -71,9 +71,18 @@ public class PropagatedContingency {
                     case HVDC_LINE:
                         HvdcLine hvdcLine = network.getHvdcLine(element.getId());
                         if (hvdcLine == null) {
-                            throw new PowsyblException("HVDC line '" + element.getId() + "' not found");
+                            throw new PowsyblException("HVDC line '" + element.getId() + "' not found in the network");
                         }
                         propagatedContingency.getHvdcIdsToOpen().add(element.getId());
+                        break;
+                    case DANGLING_LINE:
+                        DanglingLine danglingLine = network.getDanglingLine(element.getId());
+                        if (danglingLine == null) {
+                            throw new PowsyblException("Dangling line '" + element.getId() + "' not found in the network");
+                        }
+                        new BranchTripping(element.getId(), null)
+                            .traverse(network, null, switchesToOpen, terminalsToDisconnect);
+                        propagatedContingency.getBranchIdsToOpen().add(element.getId());
                         break;
                     default:
                         //TODO: support all kinds of contingencies

--- a/src/main/java/com/powsybl/openloadflow/util/PropagatedContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/util/PropagatedContingency.java
@@ -64,8 +64,8 @@ public class PropagatedContingency {
                 switch (element.getType()) {
                     case BRANCH:
                         // branch check is done inside branch tripping
-                        new BranchTripping(element.getId(), null)
-                            .traverse(network, null, switchesToOpen, terminalsToDisconnect);
+                        ContingencyTripping.createBranchTripping(network, element.getId())
+                            .traverse(switchesToOpen, terminalsToDisconnect);
                         propagatedContingency.getBranchIdsToOpen().add(element.getId());
                         break;
                     case HVDC_LINE:
@@ -80,8 +80,8 @@ public class PropagatedContingency {
                         if (danglingLine == null) {
                             throw new PowsyblException("Dangling line '" + element.getId() + "' not found in the network");
                         }
-                        new BranchTripping(element.getId(), null)
-                            .traverse(network, null, switchesToOpen, terminalsToDisconnect);
+                        ContingencyTripping.createDanglingLineTripping(network, element.getId())
+                            .traverse(switchesToOpen, terminalsToDisconnect);
                         propagatedContingency.getBranchIdsToOpen().add(element.getId());
                         break;
                     default:

--- a/src/main/java/com/powsybl/openloadflow/util/PropagatedContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/util/PropagatedContingency.java
@@ -76,10 +76,6 @@ public class PropagatedContingency {
                         propagatedContingency.getHvdcIdsToOpen().add(element.getId());
                         break;
                     case DANGLING_LINE:
-                        DanglingLine danglingLine = network.getDanglingLine(element.getId());
-                        if (danglingLine == null) {
-                            throw new PowsyblException("Dangling line '" + element.getId() + "' not found in the network");
-                        }
                         ContingencyTripping.createDanglingLineTripping(network, element.getId())
                             .traverse(switchesToOpen, terminalsToDisconnect);
                         propagatedContingency.getBranchIdsToOpen().add(element.getId());

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowDanglingLineTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowDanglingLineTest.java
@@ -13,6 +13,7 @@ import com.powsybl.loadflow.LoadFlowResult;
 import com.powsybl.math.matrix.DenseMatrixFactory;
 import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.OpenLoadFlowProvider;
+import com.powsybl.openloadflow.network.DanglingLineFactory;
 import com.powsybl.openloadflow.network.SlackBusSelectionMode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,76 +38,13 @@ class AcLoadFlowDanglingLineTest {
 
     private OpenLoadFlowParameters parametersExt;
 
-    private Network createNetwork() {
-        Network network = Network.create("dl", "test");
-        Substation s1 = network.newSubstation()
-                .setId("S1")
-                .add();
-        Substation s2 = network.newSubstation()
-                .setId("S2")
-                .add();
-        VoltageLevel vl1 = s1.newVoltageLevel()
-                .setId("vl1")
-                .setNominalV(400)
-                .setTopologyKind(TopologyKind.BUS_BREAKER)
-                .add();
-        bus1 = vl1.getBusBreakerView().newBus()
-                .setId("b1")
-                .add();
-        g1 = vl1.newGenerator()
-                .setId("g1")
-                .setConnectableBus("b1")
-                .setBus("b1")
-                .setTargetP(101.3664)
-                .setTargetV(390)
-                .setMinP(0)
-                .setMaxP(150)
-                .setVoltageRegulatorOn(true)
-                .add();
-        VoltageLevel vl2 = s2.newVoltageLevel()
-                .setId("vl2")
-                .setNominalV(400)
-                .setTopologyKind(TopologyKind.BUS_BREAKER)
-                .add();
-        bus2 = vl2.getBusBreakerView().newBus()
-                .setId("b2")
-                .add();
-        dl1 = vl2.newDanglingLine()
-                .setId("dl1")
-                .setConnectableBus("b2")
-                .setBus("b2")
-                .setR(0.7)
-                .setX(1)
-                .setG(Math.pow(10, -6))
-                .setB(3 * Math.pow(10, -6))
-                .setP0(101)
-                .setQ0(150)
-                .newGeneration()
-                    .setTargetP(0)
-                    .setTargetQ(0)
-                    .setTargetV(390)
-                    .setVoltageRegulationOn(false)
-                    .add()
-                .add();
-        network.newLine()
-                .setId("l1")
-                .setVoltageLevel1("vl1")
-                .setBus1("b1")
-                .setVoltageLevel2("vl2")
-                .setBus2("b2")
-                .setR(1)
-                .setX(3)
-                .setG1(0)
-                .setG2(0)
-                .setB1(0)
-                .setB2(0)
-                .add();
-        return network;
-    }
-
     @BeforeEach
     void setUp() {
-        network = createNetwork();
+        network = DanglingLineFactory.create();
+        bus1 = network.getBusBreakerView().getBus("b1");
+        bus2 = network.getBusBreakerView().getBus("b2");
+        dl1 = network.getDanglingLine("dl1");
+        g1 = network.getGenerator("g1");
         loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
         parameters = new LoadFlowParameters().setNoGeneratorReactiveLimits(true)
                 .setDistributedSlack(false);

--- a/src/test/java/com/powsybl/openloadflow/network/DanglingLineFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/DanglingLineFactory.java
@@ -80,4 +80,58 @@ public class DanglingLineFactory extends AbstractLoadFlowNetworkFactory {
         return network;
     }
 
+    public static Network createWithLoad() {
+
+        Network network = create();
+
+        Substation s3 = network.newSubstation()
+                .setId("S3")
+                .add();
+        VoltageLevel vl3 = s3.newVoltageLevel()
+                .setId("vl3")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl3.getBusBreakerView().newBus()
+                .setId("b3")
+                .add();
+        vl3.newLoad()
+                .setId("load3")
+                .setBus("b3")
+                .setP0(10.0)
+                .setQ0(5.0)
+                .add();
+
+        network.newLine()
+                .setId("l13")
+                .setVoltageLevel1("vl1")
+                .setBus1("b1")
+                .setVoltageLevel2("vl3")
+                .setBus2("b3")
+                .setR(10)
+                .setX(3)
+                .setG1(0)
+                .setG2(0)
+                .setB1(0)
+                .setB2(0)
+                .add();
+        network.newLine()
+                .setId("l32")
+                .setVoltageLevel1("vl3")
+                .setBus1("b3")
+                .setVoltageLevel2("vl2")
+                .setBus2("b2")
+                .setR(10)
+                .setX(10)
+                .setG1(0)
+                .setG2(0)
+                .setB1(0)
+                .setB2(0)
+                .add();
+
+        network.getDanglingLine("dl1").setP0(91);
+
+        return network;
+    }
+
 }

--- a/src/test/java/com/powsybl/openloadflow/network/DanglingLineFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/DanglingLineFactory.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.network;
+
+import com.powsybl.iidm.network.*;
+
+/**
+ * @author Anne Tilloy <anne.tilloy at artelys.com>
+ */
+public class DanglingLineFactory extends AbstractLoadFlowNetworkFactory {
+
+    public static Network create() {
+        Network network = Network.create("dl", "test");
+        Substation s1 = network.newSubstation()
+                .setId("S1")
+                .add();
+        Substation s2 = network.newSubstation()
+                .setId("S2")
+                .add();
+        VoltageLevel vl1 = s1.newVoltageLevel()
+                .setId("vl1")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl1.getBusBreakerView().newBus()
+                .setId("b1")
+                .add();
+        vl1.newGenerator()
+                .setId("g1")
+                .setConnectableBus("b1")
+                .setBus("b1")
+                .setTargetP(101.3664)
+                .setTargetV(390)
+                .setMinP(0)
+                .setMaxP(150)
+                .setVoltageRegulatorOn(true)
+                .add();
+        VoltageLevel vl2 = s2.newVoltageLevel()
+                .setId("vl2")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl2.getBusBreakerView().newBus()
+                .setId("b2")
+                .add();
+        vl2.newDanglingLine()
+                .setId("dl1")
+                .setConnectableBus("b2")
+                .setBus("b2")
+                .setR(0.7)
+                .setX(1)
+                .setG(Math.pow(10, -6))
+                .setB(3 * Math.pow(10, -6))
+                .setP0(101)
+                .setQ0(150)
+                .newGeneration()
+                .setTargetP(0)
+                .setTargetQ(0)
+                .setTargetV(390)
+                .setVoltageRegulationOn(false)
+                .add()
+                .add();
+        network.newLine()
+                .setId("l1")
+                .setVoltageLevel1("vl1")
+                .setBus1("b1")
+                .setVoltageLevel2("vl2")
+                .setBus2("b2")
+                .setR(1)
+                .setX(3)
+                .setG1(0)
+                .setG2(0)
+                .setB1(0)
+                .setB2(0)
+                .add();
+        return network;
+    }
+
+}

--- a/src/test/java/com/powsybl/openloadflow/sensi/ac/AcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/ac/AcSensitivityAnalysisContingenciesTest.java
@@ -643,12 +643,12 @@ class AcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
                 sensiParameters, LocalComputationManager.getDefault())
                 .join();
         assertEquals(1, result.getSensitivityValues().size());
-        assertEquals(0.3697, getValue(result, "g1", "l1"), LoadFlowAssert.DELTA_POWER);
+        assertEquals(0.3697, getValue(result, "g1", "l1"), LoadFlowAssert.DELTA_SENSITIVITY_VALUE);
         assertEquals(75.272, getFunctionReference(result, "l1"), LoadFlowAssert.DELTA_POWER);
-        assertEquals(0.3695, getContingencyValue(result, "dl1", "g1", "l1"), LoadFlowAssert.DELTA_POWER);
+        assertEquals(0.3695, getContingencyValue(result, "dl1", "g1", "l1"), LoadFlowAssert.DELTA_SENSITIVITY_VALUE);
         assertEquals(36.794, getContingencyFunctionReference(result, "l1", "dl1"), LoadFlowAssert.DELTA_POWER);
 
-        network.getDanglingLine("dl1").getTerminal().disconnect(); // FIXME: if I comment this line, I don't retrieve the base sensitivity value
+        network.getDanglingLine("dl1").getTerminal().disconnect();
         Line l1 = network.getLine("l1");
         LoadFlowParameters parameters = sensiParameters.getLoadFlowParameters();
         parameters.getExtension(OpenLoadFlowParameters.class).setSlackBusPMaxMismatch(0.001);
@@ -659,7 +659,7 @@ class AcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
         runLf(network, sensiParameters.getLoadFlowParameters(), Reporter.NO_OP);
         double finalP = l1.getTerminal1().getP();
         assertEquals(37.164, finalP, LoadFlowAssert.DELTA_POWER);
-        assertEquals(0.3695, finalP - initialP, LoadFlowAssert.DELTA_POWER);
+        assertEquals(0.3695, finalP - initialP, LoadFlowAssert.DELTA_SENSITIVITY_VALUE);
     }
 
     @Test
@@ -674,20 +674,22 @@ class AcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
                 sensiParameters, LocalComputationManager.getDefault())
                 .join();
         assertEquals(1, result.getSensitivityValues().size());
-        assertEquals(-0.3697, getValue(result, "load3", "l1"), LoadFlowAssert.DELTA_POWER);
+        assertEquals(-0.3704, getValue(result, "load3", "l1"), LoadFlowAssert.DELTA_SENSITIVITY_VALUE);
         assertEquals(75.336, getFunctionReference(result, "l1"), LoadFlowAssert.DELTA_POWER);
-        assertEquals(-0.3700, getContingencyValue(result, "dl1", "load3", "l1"), LoadFlowAssert.DELTA_POWER);
+        assertEquals(-0.3704, getContingencyValue(result, "dl1", "load3", "l1"), LoadFlowAssert.DELTA_SENSITIVITY_VALUE);
         assertEquals(3.0071, getContingencyFunctionReference(result, "l1", "dl1"), LoadFlowAssert.DELTA_POWER);
 
-        network.getDanglingLine("dl1").getTerminal().disconnect(); // FIXME: if I comment this line, I don't retrieve the base sensitivity value
+        network.getDanglingLine("dl1").getTerminal().disconnect();
         Line l1 = network.getLine("l1");
-        runLf(network, sensiParameters.getLoadFlowParameters(), Reporter.NO_OP);
+        LoadFlowParameters parameters = sensiParameters.getLoadFlowParameters();
+        parameters.getExtension(OpenLoadFlowParameters.class).setSlackBusPMaxMismatch(0.001);
+        runLf(network, parameters, Reporter.NO_OP);
         double initialP = l1.getTerminal1().getP();
         assertEquals(3.0071, initialP, LoadFlowAssert.DELTA_POWER);
         network.getLoad("load3").setP0(network.getLoad("load3").getP0() + 1);
         runLf(network, sensiParameters.getLoadFlowParameters(), Reporter.NO_OP);
         double finalP = l1.getTerminal1().getP();
         assertEquals(3.3775, finalP, LoadFlowAssert.DELTA_POWER);
-        assertEquals(-0.3700, initialP - finalP, LoadFlowAssert.DELTA_POWER);
+        assertEquals(-0.3704, initialP - finalP, LoadFlowAssert.DELTA_SENSITIVITY_VALUE);
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/util/ContingencyTrippingTest.java
+++ b/src/test/java/com/powsybl/openloadflow/util/ContingencyTrippingTest.java
@@ -7,7 +7,6 @@
 package com.powsybl.openloadflow.util;
 
 import com.powsybl.commons.PowsyblException;
-import com.powsybl.contingency.tasks.AbstractTrippingTask;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.FictitiousSwitchFactory;
@@ -24,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
-class BranchTrippingTest {
+class ContingencyTrippingTest {
 
     @Test
     void testLineTripping() {
@@ -32,13 +31,13 @@ class BranchTrippingTest {
 
         Set<Switch> switchesToOpen = new HashSet<>();
         Set<Terminal> terminalsToDisconnect = new HashSet<>();
-        new BranchTripping("L1").traverse(network, null, switchesToOpen, terminalsToDisconnect);
+        ContingencyTripping.createBranchTripping(network, "L1").traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen, "C");
         checkTerminalIds(terminalsToDisconnect, "BBS1", "L1");
 
         switchesToOpen.clear();
         terminalsToDisconnect.clear();
-        new BranchTripping("L2").traverse(network, null, switchesToOpen, terminalsToDisconnect);
+        ContingencyTripping.createBranchTripping(network, "L2").traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen);
         checkTerminalIds(terminalsToDisconnect, "L2");
     }
@@ -46,22 +45,16 @@ class BranchTrippingTest {
     @Test
     void testUnknownLineTripping() {
         Network network = NodeBreakerNetworkFactory.create();
-        AbstractTrippingTask trippingTaskUnknownBranch = new BranchTripping("L9");
-        Set<Switch> switchesToOpen = new HashSet<>();
-        Set<Terminal> terminalsToDisconnect = new HashSet<>();
         Exception unknownBranch = assertThrows(PowsyblException.class,
-            () -> trippingTaskUnknownBranch.traverse(network, null, switchesToOpen, terminalsToDisconnect));
+            () -> ContingencyTripping.createBranchTripping(network, "L9"));
         assertEquals("Branch 'L9' not found", unknownBranch.getMessage());
     }
 
     @Test
     void testUnconnectedVoltageLevel() {
         Network network = NodeBreakerNetworkFactory.create();
-        AbstractTrippingTask trippingTaskUnconnectedVl = new BranchTripping("L1", "VL3");
-        Set<Switch> switchesToOpen = new HashSet<>();
-        Set<Terminal> terminalsToDisconnect = new HashSet<>();
         Exception unknownVl = assertThrows(PowsyblException.class,
-            () -> trippingTaskUnconnectedVl.traverse(network, null, switchesToOpen, terminalsToDisconnect));
+            () -> ContingencyTripping.createBranchTripping(network, "L1", "VL3"));
         assertEquals("VoltageLevel 'VL3' not connected to branch 'L1'", unknownVl.getMessage());
     }
 
@@ -69,17 +62,17 @@ class BranchTrippingTest {
     void testVoltageLevelFilter() {
         Network network = NodeBreakerNetworkFactory.create();
 
-        AbstractTrippingTask trippingTaskVl1 = new BranchTripping("L1", "VL1");
+        ContingencyTripping trippingTaskVl1 = ContingencyTripping.createBranchTripping(network, "L1", "VL1");
         Set<Switch> switchesToOpen = new HashSet<>();
         Set<Terminal> terminalsToDisconnect = new HashSet<>();
-        trippingTaskVl1.traverse(network, null, switchesToOpen, terminalsToDisconnect);
+        trippingTaskVl1.traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen, "C");
         checkTerminalIds(terminalsToDisconnect, "BBS1", "L1");
 
-        AbstractTrippingTask trippingTaskVl2 = new BranchTripping("L1", "VL2");
+        ContingencyTripping trippingTaskVl2 = ContingencyTripping.createBranchTripping(network, "L1", "VL2");
         switchesToOpen.clear();
         terminalsToDisconnect.clear();
-        trippingTaskVl2.traverse(network, null, switchesToOpen, terminalsToDisconnect);
+        trippingTaskVl2.traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen);
         checkTerminalIds(terminalsToDisconnect, "L1");
     }
@@ -90,7 +83,7 @@ class BranchTrippingTest {
 
         Set<Switch> switchesToOpen = new HashSet<>();
         Set<Terminal> terminalsToDisconnect = new HashSet<>();
-        new BranchTripping("CJ").traverse(network, null, switchesToOpen, terminalsToDisconnect);
+        ContingencyTripping.createBranchTripping(network, "CJ").traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen);
         checkTerminalIds(terminalsToDisconnect, "D", "CI", "CJ");
     }
@@ -104,10 +97,10 @@ class BranchTrippingTest {
         network.getSwitch("AZ").setOpen(false);
 
         // First without opening disconnector
-        BranchTripping lbt1 = new BranchTripping("CJ");
+        ContingencyTripping lbt1 = ContingencyTripping.createBranchTripping(network, "CJ");
         Set<Switch> switchesToOpen = new HashSet<>();
         Set<Terminal> terminalsToDisconnect = new HashSet<>();
-        lbt1.traverse(network, null, switchesToOpen, terminalsToDisconnect);
+        lbt1.traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen, "BL", "BJ");
         checkTerminalIds(terminalsToDisconnect, "D", "CI", "P", "CJ");
 
@@ -115,7 +108,7 @@ class BranchTrippingTest {
         network.getSwitch("AH").setOpen(true);
         switchesToOpen.clear();
         terminalsToDisconnect.clear();
-        lbt1.traverse(network, null, switchesToOpen, terminalsToDisconnect);
+        lbt1.traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen, "BL");
         checkTerminalIds(terminalsToDisconnect, "D", "CI", "P", "CJ");
     }
@@ -129,7 +122,7 @@ class BranchTrippingTest {
 
         Set<Switch> switchesToOpen = new HashSet<>();
         Set<Terminal> terminalsToDisconnect = new HashSet<>();
-        new BranchTripping("CJ").traverse(network, null, switchesToOpen, terminalsToDisconnect);
+        ContingencyTripping.createBranchTripping(network, "CJ").traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen);
         checkTerminalIds(terminalsToDisconnect, "CJ");
     }
@@ -165,10 +158,10 @@ class BranchTrippingTest {
             .setNode2(18)
             .add();
 
-        BranchTripping lbt1 = new BranchTripping("CJ");
+        ContingencyTripping lbt1 = ContingencyTripping.createBranchTripping(network, "CJ");
         Set<Switch> switchesToOpen = new HashSet<>();
         Set<Terminal> terminalsToDisconnect = new HashSet<>();
-        lbt1.traverse(network, null, switchesToOpen, terminalsToDisconnect);
+        lbt1.traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen, "BJ", "BL", "BV", "BX");
         checkTerminalIds(terminalsToDisconnect, "D", "CI", "P", "O", "CJ");
 
@@ -180,7 +173,7 @@ class BranchTrippingTest {
             .add();
         switchesToOpen.clear();
         terminalsToDisconnect.clear();
-        lbt1.traverse(network, null, switchesToOpen, terminalsToDisconnect);
+        lbt1.traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen, "BJ", "BL", "BV", "BX");
         checkTerminalIds(terminalsToDisconnect, "D", "CI", "P", "O", "CJ");
     }
@@ -201,7 +194,7 @@ class BranchTrippingTest {
 
         Set<Switch> switchesToOpen = new HashSet<>();
         Set<Terminal> terminalsToDisconnect = new HashSet<>();
-        new BranchTripping("CJ").traverse(network, null, switchesToOpen, terminalsToDisconnect);
+        ContingencyTripping.createBranchTripping(network, "CJ").traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen, "BL");
         checkTerminalIds(terminalsToDisconnect, "D", "CI", "CJ");
     }
@@ -225,17 +218,17 @@ class BranchTrippingTest {
             .setNode2(4)
             .add();
 
-        BranchTripping lbt1 = new BranchTripping("CJ");
+        ContingencyTripping lbt1 = ContingencyTripping.createBranchTripping(network, "CJ");
         Set<Switch> switchesToOpen = new HashSet<>();
         Set<Terminal> terminalsToDisconnect = new HashSet<>();
-        lbt1.traverse(network, null, switchesToOpen, terminalsToDisconnect);
+        lbt1.traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen, "ZY");
         checkTerminalIds(terminalsToDisconnect, "D", "CI", "CJ");
 
         network.getSwitch("ZY").setOpen(true);
         switchesToOpen.clear();
         terminalsToDisconnect.clear();
-        lbt1.traverse(network, null, switchesToOpen, terminalsToDisconnect);
+        lbt1.traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen);
         checkTerminalIds(terminalsToDisconnect, "D", "CI", "CJ");
     }
@@ -247,8 +240,8 @@ class BranchTrippingTest {
         Set<Switch> switchesToOpen = new HashSet<>();
         Set<Terminal> terminalsToDisconnect = new HashSet<>();
 
-        BranchTripping trippingTask = new BranchTripping("NHV1_NHV2_1");
-        trippingTask.traverse(network, null, switchesToOpen, terminalsToDisconnect);
+        ContingencyTripping trippingTask = ContingencyTripping.createBranchTripping(network, "NHV1_NHV2_1");
+        trippingTask.traverse(switchesToOpen, terminalsToDisconnect);
 
         assertTrue(switchesToOpen.isEmpty());
         assertEquals(2, terminalsToDisconnect.size());
@@ -258,7 +251,7 @@ class BranchTrippingTest {
         line.getTerminal1().disconnect();
 
         terminalsToDisconnect.clear();
-        trippingTask.traverse(network, null, switchesToOpen, terminalsToDisconnect);
+        trippingTask.traverse(switchesToOpen, terminalsToDisconnect);
 
         assertTrue(switchesToOpen.isEmpty());
         assertEquals(1, terminalsToDisconnect.size());

--- a/src/test/java/com/powsybl/openloadflow/util/ContingencyTrippingTest.java
+++ b/src/test/java/com/powsybl/openloadflow/util/ContingencyTrippingTest.java
@@ -47,7 +47,15 @@ class ContingencyTrippingTest {
         Network network = NodeBreakerNetworkFactory.create();
         Exception unknownBranch = assertThrows(PowsyblException.class,
             () -> ContingencyTripping.createBranchTripping(network, "L9"));
-        assertEquals("Branch 'L9' not found", unknownBranch.getMessage());
+        assertEquals("Branch 'L9' not found in the network", unknownBranch.getMessage());
+    }
+
+    @Test
+    void testUnknownDanglingLineTripping() {
+        Network network = NodeBreakerNetworkFactory.create();
+        Exception unknownBranch = assertThrows(PowsyblException.class,
+            () -> ContingencyTripping.createDanglingLineTripping(network, "DL0"));
+        assertEquals("Dangling line 'DL0' not found in the network", unknownBranch.getMessage());
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/util/LoadFlowAssert.java
+++ b/src/test/java/com/powsybl/openloadflow/util/LoadFlowAssert.java
@@ -25,6 +25,7 @@ public final class LoadFlowAssert {
     public static final double DELTA_POWER = 1E-3d;
     public static final double DELTA_I = 1000 * DELTA_POWER / Math.sqrt(3);
     public static final double DELTA_MISMATCH = 1E-4d;
+    public static final double DELTA_SENSITIVITY_VALUE = 1E-4d;
 
     private LoadFlowAssert() {
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No but we know that the feature is missing.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Now, you can simulate the loss of a dangling line in AC and DC sensitivity analysis. TODO: branch tripping does not support dangling lines. 

**What is the current behavior?** *(You can also link to an open issue here)*

It is not supported. 

**What is the new behavior (if this is a feature change)?**

We loose a line and a fictitious bus. 

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
