### PR TITLE
Sensitivity analysis: fix voltage reference values for BusVoltagePerTargetV factor

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
@@ -75,7 +75,6 @@ public class AcSensitivityAnalysis extends AbstractSensitivityAnalysis {
                 }
 
                 if (SensitivityFunctionType.BUS_VOLTAGE.equals(factor.getFunctionType())) {
-
                     sensi *= ((LfBus) factor.getFunctionElement()).getNominalV();
                 }
                 valueWriter.write(factor.getContext(), contingencyId, contingencyIndex, sensi * PerUnit.SB, factor.getFunctionReference() * PerUnit.SB);

--- a/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
@@ -87,8 +87,8 @@ public class AcSensitivityAnalysis extends AbstractSensitivityAnalysis {
         for (LfSensitivityFactor factor : factors) {
             double functionRef = factor.getEquationTerm().eval();
             if (factor.getFunctionType() == SensitivityFunctionType.BUS_VOLTAGE) {
-                LfBus bus = (LfBus)factor.getFunctionElement();
-                factor.setFunctionReference(functionRef * bus.getNominalV()/ PerUnit.SB);
+                LfBus bus = (LfBus) factor.getFunctionElement();
+                factor.setFunctionReference(functionRef * bus.getNominalV() / PerUnit.SB);
             } else {
                 factor.setFunctionReference(functionRef);
             }

--- a/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
@@ -75,6 +75,7 @@ public class AcSensitivityAnalysis extends AbstractSensitivityAnalysis {
                 }
 
                 if (SensitivityFunctionType.BUS_VOLTAGE.equals(factor.getFunctionType())) {
+
                     sensi *= ((LfBus) factor.getFunctionElement()).getNominalV();
                 }
                 valueWriter.write(factor.getContext(), contingencyId, contingencyIndex, sensi * PerUnit.SB, factor.getFunctionReference() * PerUnit.SB);
@@ -86,7 +87,8 @@ public class AcSensitivityAnalysis extends AbstractSensitivityAnalysis {
         for (LfSensitivityFactor factor : factors) {
             double functionRef = factor.getEquationTerm().eval();
             if (factor.getFunctionType() == SensitivityFunctionType.BUS_VOLTAGE) {
-                factor.setFunctionReference(functionRef / PerUnit.SB);
+                LfBus bus = (LfBus)factor.getFunctionElement();
+                factor.setFunctionReference(functionRef * bus.getNominalV()/ PerUnit.SB);
             } else {
                 factor.setFunctionReference(functionRef);
             }

--- a/src/test/java/com/powsybl/openloadflow/sensi/ac/AcSensitivityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/ac/AcSensitivityAnalysisTest.java
@@ -404,11 +404,11 @@ class AcSensitivityAnalysisTest extends AbstractSensitivityAnalysisTest {
 
     @Test
     void testBusVoltagePerTargetVFunctionRef() {
-        Network network = FourBusNetworkFactory.create();
-        SensitivityAnalysisParameters sensiParameters = createParameters(false, "b1_vl_0", true);
+        Network network = EurostagTutorialExample1Factory.create();
+        SensitivityAnalysisParameters sensiParameters = createParameters(false, "VLGEN_0", true);
         sensiParameters.getLoadFlowParameters().setBalanceType(LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX);
 
-        TargetVoltage targetVoltage = new TargetVoltage("g2", "g2", "g2");
+        TargetVoltage targetVoltage = new TargetVoltage("GEN", "GEN", "GEN");
         SensitivityFactorsProvider factorsProvider = n -> network.getBusBreakerView().getBusStream()
             .map(bus -> new BusVoltage(bus.getId(), bus.getId(), new IdBasedBusRef(bus.getId())))
             .map(busVoltage -> new BusVoltagePerTargetV(busVoltage, targetVoltage))
@@ -419,10 +419,10 @@ class AcSensitivityAnalysisTest extends AbstractSensitivityAnalysisTest {
             .join();
         runLf(network, sensiParameters.getLoadFlowParameters());
         Function<String, Double> getV = busId -> network.getBusView().getBus(busId).getV();
-        assertEquals(getV.apply("b1_vl_0"), getFunctionReference(result, "b1"), LoadFlowAssert.DELTA_V);
-        assertEquals(getV.apply("b2_vl_0"), getFunctionReference(result, "b2"), LoadFlowAssert.DELTA_V);
-        assertEquals(getV.apply("b3_vl_0"), getFunctionReference(result, "b3"), LoadFlowAssert.DELTA_V);
-        assertEquals(getV.apply("b4_vl_0"), getFunctionReference(result, "b4"), LoadFlowAssert.DELTA_V);
+        assertEquals(getV.apply("VLGEN_0"), getFunctionReference(result, "NGEN"), LoadFlowAssert.DELTA_V);
+        assertEquals(getV.apply("VLHV1_0"), getFunctionReference(result, "NHV1"), LoadFlowAssert.DELTA_V);
+        assertEquals(getV.apply("VLHV2_0"), getFunctionReference(result, "NHV2"), LoadFlowAssert.DELTA_V);
+        assertEquals(getV.apply("VLLOAD_0"), getFunctionReference(result, "NLOAD"), LoadFlowAssert.DELTA_V);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bug

**What is the current behavior?** *(You can also link to an open issue here)*

Reference values of voltages are not correctly transformed from per-unit back to kV.

**What is the new behavior (if this is a feature change)?**

We use nominal voltage to correctly transform back the voltage value.

**Other information**:

This is a quick fix, but I guess that those scaling logics could be shared more with other places in the code (loadflow, security analysis).
Also, it's not very safe to have unit tests with nominal voltage all equal to 1 kV, to identify that kind of issues.
