### PR TITLE
Detects coupler when propagating contingency in sensitivity analysis

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysis.java
@@ -112,7 +112,7 @@ public class OpenSecurityAnalysis implements SecurityAnalysis {
 
         // try to find all switches impacted by at least one contingency and for each contingency the branches impacted
         Set<Switch> allSwitchesToOpen = new HashSet<>();
-        List<PropagatedContingency> propagatedContingencies = PropagatedContingency.create(network, contingencies, allSwitchesToOpen);
+        List<PropagatedContingency> propagatedContingencies = PropagatedContingency.create(network, contingencies, allSwitchesToOpen, false);
 
         AcLoadFlowParameters acParameters = OpenLoadFlowProvider.createAcParameters(network, matrixFactory, lfParameters, lfParametersExt, true);
 

--- a/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysis.java
@@ -112,7 +112,7 @@ public class OpenSecurityAnalysis implements SecurityAnalysis {
 
         // try to find all switches impacted by at least one contingency and for each contingency the branches impacted
         Set<Switch> allSwitchesToOpen = new HashSet<>();
-        List<PropagatedContingency> propagatedContingencies = PropagatedContingency.create(network, contingencies, allSwitchesToOpen, false);
+        List<PropagatedContingency> propagatedContingencies = PropagatedContingency.createListForSecurityAnalysis(network, contingencies, allSwitchesToOpen);
 
         AcLoadFlowParameters acParameters = OpenLoadFlowProvider.createAcParameters(network, matrixFactory, lfParameters, lfParametersExt, true);
 

--- a/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProvider.java
@@ -205,7 +205,8 @@ public class OpenSensitivityAnalysisProvider implements SensitivityAnalysisProvi
         Objects.requireNonNull(valueWriter);
         Objects.requireNonNull(reporter);
 
-        List<PropagatedContingency> propagatedContingencies = PropagatedContingency.create(network, contingencies, new HashSet<>());
+        List<PropagatedContingency> propagatedContingencies = PropagatedContingency.create(network, contingencies, new HashSet<>(),
+            true);
 
         LoadFlowParameters lfParameters = sensitivityAnalysisParameters.getLoadFlowParameters();
         OpenLoadFlowParameters lfParametersExt = getLoadFlowParametersExtension(lfParameters);

--- a/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProvider.java
@@ -205,8 +205,7 @@ public class OpenSensitivityAnalysisProvider implements SensitivityAnalysisProvi
         Objects.requireNonNull(valueWriter);
         Objects.requireNonNull(reporter);
 
-        List<PropagatedContingency> propagatedContingencies = PropagatedContingency.create(network, contingencies, new HashSet<>(),
-            true);
+        List<PropagatedContingency> propagatedContingencies = PropagatedContingency.createListForSensitivityAnalysis(network, contingencies);
 
         LoadFlowParameters lfParameters = sensitivityAnalysisParameters.getLoadFlowParameters();
         OpenLoadFlowParameters lfParametersExt = getLoadFlowParametersExtension(lfParameters);

--- a/src/main/java/com/powsybl/openloadflow/util/PropagatedContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/util/PropagatedContingency.java
@@ -55,8 +55,20 @@ public class PropagatedContingency {
         this.index = index;
     }
 
-    public static List<PropagatedContingency> create(Network network, List<Contingency> contingencies, Set<Switch> allSwitchesToOpen,
-                                                     boolean removeContingenciesEncounteringCouplers) {
+    public static List<PropagatedContingency> createListForSensitivityAnalysis(Network network, List<Contingency> contingencies) {
+        // Sensitivity analysis works in bus view, hence
+        //   - it cannot deal with contingencies whose propagation encounters a coupler
+        //   - it does not need the set of switches to open
+        return createList(network, contingencies, new HashSet<>(), true);
+    }
+
+    public static List<PropagatedContingency> createListForSecurityAnalysis(Network network, List<Contingency> contingencies, Set<Switch> allSwitchesToOpen) {
+        // Security analysis works in bus breaker view, hence needs to know all switches to retain. Couplers are not a problem.
+        return createList(network, contingencies, allSwitchesToOpen, false);
+    }
+
+    private static List<PropagatedContingency> createList(Network network, List<Contingency> contingencies, Set<Switch> allSwitchesToOpen,
+                                                         boolean removeContingenciesEncounteringCouplers) {
         List<PropagatedContingency> propagatedContingencies = new ArrayList<>();
         for (int index = 0; index < contingencies.size(); index++) {
             Contingency contingency = contingencies.get(index);

--- a/src/test/java/com/powsybl/openloadflow/network/NodeBreakerNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/NodeBreakerNetworkFactory.java
@@ -253,7 +253,6 @@ public class NodeBreakerNetworkFactory extends AbstractLoadFlowNetworkFactory {
         createGenerator(vl1, "G2", 4, 400, 200, 0);
         createConnection(vl1, 2, 4);
 
-
         VoltageLevel vl2 = s.newVoltageLevel()
             .setId("VL2")
             .setNominalV(400)

--- a/src/test/java/com/powsybl/openloadflow/network/NodeBreakerNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/NodeBreakerNetworkFactory.java
@@ -32,7 +32,7 @@ public class NodeBreakerNetworkFactory extends AbstractLoadFlowNetworkFactory {
      *            |
      *      o--C--o
      *      |     |
-     *      |     B2
+     *      |     B1
      *      |     |
      *      |     o
      *      |     |

--- a/src/test/java/com/powsybl/openloadflow/sa/LfContingencyTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/LfContingencyTest.java
@@ -59,7 +59,7 @@ class LfContingencyTest extends AbstractConverterTest {
         String branchId = "LINE_S3S4";
         Contingency contingency = new Contingency(branchId, new BranchContingency(branchId));
         List<PropagatedContingency> propagatedContingencies =
-            PropagatedContingency.create(network, Collections.singletonList(contingency), new HashSet<>());
+            PropagatedContingency.create(network, Collections.singletonList(contingency), new HashSet<>(), false);
 
         List<LfContingency> lfContingencies = sa.createContingencies(propagatedContingencies, lfNetworks.get(0));
         assertEquals(1, lfContingencies.size());

--- a/src/test/java/com/powsybl/openloadflow/sa/LfContingencyTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/LfContingencyTest.java
@@ -59,7 +59,7 @@ class LfContingencyTest extends AbstractConverterTest {
         String branchId = "LINE_S3S4";
         Contingency contingency = new Contingency(branchId, new BranchContingency(branchId));
         List<PropagatedContingency> propagatedContingencies =
-            PropagatedContingency.create(network, Collections.singletonList(contingency), new HashSet<>(), false);
+            PropagatedContingency.createListForSecurityAnalysis(network, Collections.singletonList(contingency), new HashSet<>());
 
         List<LfContingency> lfContingencies = sa.createContingencies(propagatedContingencies, lfNetworks.get(0));
         assertEquals(1, lfContingencies.size());

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisGraphTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisGraphTest.java
@@ -152,7 +152,7 @@ class OpenSecurityAnalysisGraphTest {
         // try to find all switches impacted by at least one contingency
         long start = System.currentTimeMillis();
         Set<Switch> allSwitchesToOpen = new HashSet<>();
-        List<PropagatedContingency> propagatedContingencies = PropagatedContingency.create(network, contingencies, allSwitchesToOpen, false);
+        List<PropagatedContingency> propagatedContingencies = PropagatedContingency.createListForSecurityAnalysis(network, contingencies, allSwitchesToOpen);
         LOGGER.info("Contingencies contexts calculated from contingencies in {} ms", System.currentTimeMillis() - start);
 
         AcLoadFlowParameters acParameters = OpenLoadFlowProvider.createAcParameters(network,

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisGraphTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisGraphTest.java
@@ -152,7 +152,7 @@ class OpenSecurityAnalysisGraphTest {
         // try to find all switches impacted by at least one contingency
         long start = System.currentTimeMillis();
         Set<Switch> allSwitchesToOpen = new HashSet<>();
-        List<PropagatedContingency> propagatedContingencies = PropagatedContingency.create(network, contingencies, allSwitchesToOpen);
+        List<PropagatedContingency> propagatedContingencies = PropagatedContingency.create(network, contingencies, allSwitchesToOpen, false);
         LOGGER.info("Contingencies contexts calculated from contingencies in {} ms", System.currentTimeMillis() - start);
 
         AcLoadFlowParameters acParameters = OpenLoadFlowProvider.createAcParameters(network,

--- a/src/test/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysisTest.java
@@ -64,6 +64,17 @@ public abstract class AbstractSensitivityAnalysisTest extends AbstractConverterT
         return createParameters(dc, slackBusId, false);
     }
 
+    protected static SensitivityAnalysisParameters createParameters(boolean dc) {
+        SensitivityAnalysisParameters sensiParameters = new SensitivityAnalysisParameters();
+        LoadFlowParameters lfParameters = sensiParameters.getLoadFlowParameters();
+        lfParameters.setDc(dc);
+        lfParameters.setDistributedSlack(true);
+        OpenLoadFlowParameters lfParametersExt = new OpenLoadFlowParameters()
+                .setSlackBusSelectionMode(SlackBusSelectionMode.MOST_MESHED);
+        lfParameters.addExtension(OpenLoadFlowParameters.class, lfParametersExt);
+        return sensiParameters;
+    }
+
     protected static <T extends Injection<T>> InjectionIncrease createInjectionIncrease(T injection) {
         return new InjectionIncrease(injection.getId(), injection.getId(), injection.getId());
     }

--- a/src/test/java/com/powsybl/openloadflow/sensi/ac/AcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/ac/AcSensitivityAnalysisContingenciesTest.java
@@ -642,17 +642,10 @@ class AcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
                 .join();
 
         //Flow is around 200 on all lines
-        result.getSensitivityValues().stream()
+        result.getSensitivityValues()
             .forEach(v -> assertEquals(200, v.getFunctionReference(), 5));
 
-        //Flow should be around 400 on L1, around 200 on L3
-        List<SensitivityValue> postContingencySensitivities = result.getSensitivityValuesContingencies().get("L2");
-        //TODO: fails, flows are 300, because the 2 buses are still seen as connected
-        postContingencySensitivities.stream()
-            .filter(v -> v.getFactor().getFunction().getId().equals("L1"))
-            .forEach(v -> assertEquals(400, v.getFunctionReference(), 5));
-        postContingencySensitivities.stream()
-            .filter(v -> v.getFactor().getFunction().getId().equals("L3"))
-            .forEach(v -> assertEquals(200, v.getFunctionReference(), 5));
+        // Propagating contingency on L2 encounters a coupler, which is not (yet) supported in sensitivity analysis
+        assertTrue(result.getSensitivityValuesContingencies().isEmpty());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
Yes, first step to solve issue #289. This doesn't fix that issue, but detects the problematic contingency, gives a warning and does not add it to the propagated contingencies to avoid giving wrong results.

