### PR TITLE
Use new parameters isDcUseTransformerRatio and countriesToBalance

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
@@ -38,8 +38,6 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
 
     private boolean loadPowerFactorConstant = LOAD_POWER_FACTOR_CONSTANT_DEFAULT_VALUE;
 
-    private boolean dcUseTransformerRatio = DC_USE_TRANSFORMER_RATIO_DEFAULT_VALUE;
-
     private double plausibleActivePowerLimit = PLAUSIBLE_ACTIVE_POWER_LIMIT_DEFAULT_VALUE;
 
     private boolean addRatioToLinesWithDifferentNominalVoltageAtBothEnds = ADD_RATIO_TO_LINES_WITH_DIFFERENT_NOMINAL_VOLTAGE_AT_BOTH_ENDS_DEFAULT_VALUE;
@@ -105,15 +103,6 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
         return this;
     }
 
-    public boolean isDcUseTransformerRatio() {
-        return dcUseTransformerRatio;
-    }
-
-    public OpenLoadFlowParameters setDcUseTransformerRatio(boolean dcUseTransformerRatio) {
-        this.dcUseTransformerRatio = dcUseTransformerRatio;
-        return this;
-    }
-
     public double getPlausibleActivePowerLimit() {
         return plausibleActivePowerLimit;
     }
@@ -157,7 +146,6 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
                 ", voltageRemoteControl=" + voltageRemoteControl +
                 ", lowImpedanceBranchMode=" + lowImpedanceBranchMode +
                 ", loadPowerFactorConstant=" + loadPowerFactorConstant +
-                ", dcUseTransformerRatio=" + dcUseTransformerRatio +
                 ", plausibleActivePowerLimit=" + plausibleActivePowerLimit +
                 ", addRatioToLinesWithDifferentNominalVoltageAtBothEnds=" + addRatioToLinesWithDifferentNominalVoltageAtBothEnds +
                 ", slackBusPMaxMismatch=" + slackBusPMaxMismatch +
@@ -181,7 +169,6 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
                                 config.getBooleanProperty(THROWS_EXCEPTION_IN_CASE_OF_SLACK_DISTRIBUTION_FAILURE_PARAM_NAME, THROWS_EXCEPTION_IN_CASE_OF_SLACK_DISTRIBUTION_FAILURE_DEFAULT_VALUE)
                         )
                         .setLoadPowerFactorConstant(config.getBooleanProperty(LOAD_POWER_FACTOR_CONSTANT_PARAM_NAME, LOAD_POWER_FACTOR_CONSTANT_DEFAULT_VALUE))
-                        .setDcUseTransformerRatio(config.getBooleanProperty(DC_USE_TRANSFORMER_RATIO_PARAM_NAME, DC_USE_TRANSFORMER_RATIO_DEFAULT_VALUE))
                         .setPlausibleActivePowerLimit(config.getDoubleProperty(PLAUSIBLE_ACTIVE_POWER_LIMIT_PARAM_NAME, PLAUSIBLE_ACTIVE_POWER_LIMIT_DEFAULT_VALUE))
                         .setAddRatioToLinesWithDifferentNominalVoltageAtBothEnds(config.getBooleanProperty(ADD_RATIO_TO_LINES_WITH_DIFFERENT_NOMINAL_VOLTAGE_AT_BOTH_ENDS_NAME, ADD_RATIO_TO_LINES_WITH_DIFFERENT_NOMINAL_VOLTAGE_AT_BOTH_ENDS_DEFAULT_VALUE))
                         .setSlackBusPMaxMismatch(config.getDoubleProperty(SLACK_BUS_P_MAX_MISMATCH_NAME, SLACK_BUS_P_MAX_MISMATCH_DEFAULT_VALUE))

--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
@@ -265,9 +265,10 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
                                                                      parametersExt.getPlausibleActivePowerLimit(),
                                                                      parametersExt.isAddRatioToLinesWithDifferentNominalVoltageAtBothEnds(),
                                                                      true,
-                                                                     parameters.getConnectedComponentMode() == LoadFlowParameters.ConnectedComponentMode.MAIN);
+                                                                     parameters.getConnectedComponentMode() == LoadFlowParameters.ConnectedComponentMode.MAIN,
+                                                                      parameters.getCountriesToBalance());
 
-        List<DcLoadFlowResult> results = new DcLoadFlowEngine(network, dcParameters, reporter, parameters.getCountriesToBalance())
+        List<DcLoadFlowResult> results = new DcLoadFlowEngine(network, dcParameters, reporter)
                 .run(reporter);
 
         Networks.resetState(network);

--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
@@ -181,7 +181,8 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
                                         forceA1Var,
                                         parametersExt.isAddRatioToLinesWithDifferentNominalVoltageAtBothEnds(),
                                         branchesWithCurrent,
-                                        parameters.getConnectedComponentMode() == LoadFlowParameters.ConnectedComponentMode.MAIN);
+                                        parameters.getConnectedComponentMode() == LoadFlowParameters.ConnectedComponentMode.MAIN,
+                                        parameters.getCountriesToBalance());
     }
 
     private LoadFlowResult runAc(Network network, LoadFlowParameters parameters, OpenLoadFlowParameters parametersExt, Reporter reporter) {
@@ -247,7 +248,7 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
         SlackBusSelector slackBusSelector = getSlackBusSelector(network, parameters, parametersExt);
 
         LOGGER.info("Slack bus selector: {}", slackBusSelector.getClass().getSimpleName());
-        LOGGER.info("Use transformer ratio: {}", parametersExt.isDcUseTransformerRatio());
+        LOGGER.info("Use transformer ratio: {}", parameters.isDcUseTransformerRatio());
         LOGGER.info("Distributed slack: {}", parameters.isDistributedSlack());
         LOGGER.info("Balance type: {}", parameters.getBalanceType());
         LOGGER.info("Plausible active power limit: {}", parametersExt.getPlausibleActivePowerLimit());
@@ -257,7 +258,7 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
         DcLoadFlowParameters dcParameters = new DcLoadFlowParameters(slackBusSelector,
                                                                      matrixFactory,
                                                                      true,
-                                                                     parametersExt.isDcUseTransformerRatio(),
+                                                                     parameters.isDcUseTransformerRatio(),
                                                                      parameters.isDistributedSlack(),
                                                                      parameters.getBalanceType(),
                                                                      forcePhaseControlOffAndAddAngle1Var,
@@ -266,7 +267,7 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
                                                                      true,
                                                                      parameters.getConnectedComponentMode() == LoadFlowParameters.ConnectedComponentMode.MAIN);
 
-        List<DcLoadFlowResult> results = new DcLoadFlowEngine(network, dcParameters, reporter)
+        List<DcLoadFlowResult> results = new DcLoadFlowEngine(network, dcParameters, reporter, parameters.getCountriesToBalance())
                 .run(reporter);
 
         Networks.resetState(network);

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcLoadFlowParameters.java
@@ -12,6 +12,7 @@ import com.powsybl.openloadflow.ac.nr.NewtonRaphsonStoppingCriteria;
 import com.powsybl.openloadflow.equations.VoltageInitializer;
 import com.powsybl.openloadflow.network.SlackBusSelector;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -151,7 +152,7 @@ public class AcLoadFlowParameters {
     }
 
     public Set<Country> getCountriesToBalance() {
-        return countriesToBalance;
+        return Collections.unmodifiableSet(countriesToBalance);
     }
 
 }

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcLoadFlowParameters.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.openloadflow.ac.outerloop;
 
+import com.powsybl.iidm.network.Country;
 import com.powsybl.math.matrix.MatrixFactory;
 import com.powsybl.openloadflow.ac.nr.NewtonRaphsonStoppingCriteria;
 import com.powsybl.openloadflow.equations.VoltageInitializer;
@@ -52,13 +53,16 @@ public class AcLoadFlowParameters {
 
     private final boolean computeMainConnectedComponentOnly;
 
+    private final Set<Country> countriesToBalance;
+
     public AcLoadFlowParameters(SlackBusSelector slackBusSelector, VoltageInitializer voltageInitializer,
                                 NewtonRaphsonStoppingCriteria stoppingCriteria, List<OuterLoop> outerLoops,
                                 MatrixFactory matrixFactory, boolean voltageRemoteControl,
                                 boolean phaseControl, boolean transformerVoltageControlOn, boolean minImpedance,
                                 boolean twtSplitShuntAdmittance, boolean breakers, double plausibleActivePowerLimit,
                                 boolean forceA1Var, boolean addRatioToLinesWithDifferentNominalVoltageAtBothEnds,
-                                Set<String> branchesWithCurrent, boolean computeMainConnectedComponentOnly) {
+                                Set<String> branchesWithCurrent, boolean computeMainConnectedComponentOnly,
+                                Set<Country> countriesToBalance) {
         this.slackBusSelector = Objects.requireNonNull(slackBusSelector);
         this.voltageInitializer = Objects.requireNonNull(voltageInitializer);
         this.stoppingCriteria = Objects.requireNonNull(stoppingCriteria);
@@ -75,6 +79,7 @@ public class AcLoadFlowParameters {
         this.addRatioToLinesWithDifferentNominalVoltageAtBothEnds = addRatioToLinesWithDifferentNominalVoltageAtBothEnds;
         this.branchesWithCurrent = branchesWithCurrent;
         this.computeMainConnectedComponentOnly = computeMainConnectedComponentOnly;
+        this.countriesToBalance = countriesToBalance;
     }
 
     public SlackBusSelector getSlackBusSelector() {
@@ -143,6 +148,10 @@ public class AcLoadFlowParameters {
 
     public boolean isComputeMainConnectedComponentOnly() {
         return computeMainConnectedComponentOnly;
+    }
+
+    public Set<Country> getCountriesToBalance() {
+        return countriesToBalance;
     }
 
 }

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcloadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcloadFlowEngine.java
@@ -21,10 +21,7 @@ import org.apache.commons.lang3.mutable.MutableInt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -59,7 +56,8 @@ public class AcloadFlowEngine implements AutoCloseable {
                                                                         parameters.isBreakers(),
                                                                         parameters.getPlausibleActivePowerLimit(),
                                                                         parameters.isAddRatioToLinesWithDifferentNominalVoltageAtBothEnds(),
-                                                                        parameters.isComputeMainConnectedComponentOnly());
+                                                                        parameters.isComputeMainConnectedComponentOnly(),
+                                                                        parameters.getCountriesToBalance());
         return LfNetwork.load(network, networkParameters, reporter);
     }
 

--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
@@ -8,6 +8,7 @@ package com.powsybl.openloadflow.dc;
 
 import com.powsybl.commons.reporter.Report;
 import com.powsybl.commons.reporter.Reporter;
+import com.powsybl.iidm.network.Country;
 import com.powsybl.loadflow.LoadFlowResult;
 import com.powsybl.math.matrix.MatrixFactory;
 import com.powsybl.openloadflow.OpenLoadFlowReportConstants;
@@ -42,9 +43,9 @@ public class DcLoadFlowEngine {
         parameters = new DcLoadFlowParameters(new FirstSlackBusSelector(), matrixFactory, setVToNan);
     }
 
-    public DcLoadFlowEngine(Object network, DcLoadFlowParameters parameters, Reporter reporter) {
+    public DcLoadFlowEngine(Object network, DcLoadFlowParameters parameters, Reporter reporter, Set<Country> countriesToBalance) {
         LfNetworkParameters lfNetworkParameters = new LfNetworkParameters(parameters.getSlackBusSelector(), false, false, false, false,
-                parameters.getPlausibleActivePowerLimit(), false, parameters.isComputeMainConnectedComponentOnly());
+                parameters.getPlausibleActivePowerLimit(), false, parameters.isComputeMainConnectedComponentOnly(), countriesToBalance);
         this.networks = LfNetwork.load(network, lfNetworkParameters, reporter);
         this.parameters = Objects.requireNonNull(parameters);
     }

--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
@@ -40,12 +40,12 @@ public class DcLoadFlowEngine {
 
     public DcLoadFlowEngine(LfNetwork network, MatrixFactory matrixFactory, boolean setVToNan) {
         this.networks = Collections.singletonList(network);
-        parameters = new DcLoadFlowParameters(new FirstSlackBusSelector(), matrixFactory, setVToNan);
+        parameters = new DcLoadFlowParameters(new FirstSlackBusSelector(), matrixFactory, setVToNan, EnumSet.noneOf(Country.class));
     }
 
-    public DcLoadFlowEngine(Object network, DcLoadFlowParameters parameters, Reporter reporter, Set<Country> countriesToBalance) {
+    public DcLoadFlowEngine(Object network, DcLoadFlowParameters parameters, Reporter reporter) {
         LfNetworkParameters lfNetworkParameters = new LfNetworkParameters(parameters.getSlackBusSelector(), false, false, false, false,
-                parameters.getPlausibleActivePowerLimit(), false, parameters.isComputeMainConnectedComponentOnly(), countriesToBalance);
+                parameters.getPlausibleActivePowerLimit(), false, parameters.isComputeMainConnectedComponentOnly(), parameters.getCountriesToBalance());
         this.networks = LfNetwork.load(network, lfNetworkParameters, reporter);
         this.parameters = Objects.requireNonNull(parameters);
     }

--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
@@ -8,7 +8,6 @@ package com.powsybl.openloadflow.dc;
 
 import com.powsybl.commons.reporter.Report;
 import com.powsybl.commons.reporter.Reporter;
-import com.powsybl.iidm.network.Country;
 import com.powsybl.loadflow.LoadFlowResult;
 import com.powsybl.math.matrix.MatrixFactory;
 import com.powsybl.openloadflow.OpenLoadFlowReportConstants;
@@ -40,7 +39,7 @@ public class DcLoadFlowEngine {
 
     public DcLoadFlowEngine(LfNetwork network, MatrixFactory matrixFactory, boolean setVToNan) {
         this.networks = Collections.singletonList(network);
-        parameters = new DcLoadFlowParameters(new FirstSlackBusSelector(), matrixFactory, setVToNan, EnumSet.noneOf(Country.class));
+        parameters = new DcLoadFlowParameters(new FirstSlackBusSelector(), matrixFactory, setVToNan);
     }
 
     public DcLoadFlowEngine(Object network, DcLoadFlowParameters parameters, Reporter reporter) {

--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowParameters.java
@@ -45,9 +45,9 @@ public class DcLoadFlowParameters {
 
     private final Set<Country> countriesToBalance;
 
-    public DcLoadFlowParameters(SlackBusSelector slackBusSelector, MatrixFactory matrixFactory, boolean setVToNan, Set<Country> countriesToBalance) {
+    public DcLoadFlowParameters(SlackBusSelector slackBusSelector, MatrixFactory matrixFactory, boolean setVToNan) {
         this(slackBusSelector, matrixFactory, false, true, false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX, false,
-                ParameterConstants.PLAUSIBLE_ACTIVE_POWER_LIMIT_DEFAULT_VALUE, false, setVToNan, true, countriesToBalance);
+                ParameterConstants.PLAUSIBLE_ACTIVE_POWER_LIMIT_DEFAULT_VALUE, false, setVToNan, true, LoadFlowParameters.DEFAULT_COUNTRIES_TO_BALANCE);
     }
 
     public DcLoadFlowParameters(SlackBusSelector slackBusSelector, MatrixFactory matrixFactory, boolean updateFlows,

--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowParameters.java
@@ -6,12 +6,15 @@
  */
 package com.powsybl.openloadflow.dc;
 
+import com.powsybl.iidm.network.Country;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.math.matrix.MatrixFactory;
 import com.powsybl.openloadflow.network.SlackBusSelector;
 import com.powsybl.openloadflow.util.ParameterConstants;
 
+import java.util.Collections;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -40,15 +43,18 @@ public class DcLoadFlowParameters {
 
     private final boolean computeMainConnectedComponentOnly;
 
-    public DcLoadFlowParameters(SlackBusSelector slackBusSelector, MatrixFactory matrixFactory, boolean setVToNan) {
+    private final Set<Country> countriesToBalance;
+
+    public DcLoadFlowParameters(SlackBusSelector slackBusSelector, MatrixFactory matrixFactory, boolean setVToNan, Set<Country> countriesToBalance) {
         this(slackBusSelector, matrixFactory, false, true, false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX, false,
-                ParameterConstants.PLAUSIBLE_ACTIVE_POWER_LIMIT_DEFAULT_VALUE, false, setVToNan, true);
+                ParameterConstants.PLAUSIBLE_ACTIVE_POWER_LIMIT_DEFAULT_VALUE, false, setVToNan, true, countriesToBalance);
     }
 
     public DcLoadFlowParameters(SlackBusSelector slackBusSelector, MatrixFactory matrixFactory, boolean updateFlows,
                                 boolean useTransformerRatio, boolean distributedSlack, LoadFlowParameters.BalanceType balanceType,
                                 boolean forcePhaseControlOffAndAddAngle1Var, double plausibleActivePowerLimit,
-                                boolean addRatioToLinesWithDifferentNominalVoltageAtBothEnds, boolean setVToNan, boolean computeMainConnectedComponentOnly) {
+                                boolean addRatioToLinesWithDifferentNominalVoltageAtBothEnds, boolean setVToNan, boolean computeMainConnectedComponentOnly,
+                                Set<Country> countriesToBalance) {
         this.slackBusSelector = Objects.requireNonNull(slackBusSelector);
         this.matrixFactory = Objects.requireNonNull(matrixFactory);
         this.updateFlows = updateFlows;
@@ -60,6 +66,7 @@ public class DcLoadFlowParameters {
         this.addRatioToLinesWithDifferentNominalVoltageAtBothEnds = addRatioToLinesWithDifferentNominalVoltageAtBothEnds;
         this.setVToNan = setVToNan;
         this.computeMainConnectedComponentOnly = computeMainConnectedComponentOnly;
+        this.countriesToBalance = countriesToBalance;
     }
 
     public SlackBusSelector getSlackBusSelector() {
@@ -104,6 +111,10 @@ public class DcLoadFlowParameters {
 
     public boolean isComputeMainConnectedComponentOnly() {
         return computeMainConnectedComponentOnly;
+    }
+
+    public Set<Country> getCountriesToBalance() {
+        return Collections.unmodifiableSet(countriesToBalance);
     }
 
 }

--- a/src/main/java/com/powsybl/openloadflow/network/LfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBus.java
@@ -122,4 +122,6 @@ public interface LfBus extends LfElement {
     void setQ(Evaluable q);
 
     Evaluable getQ();
+
+    boolean isParticipating();
 }

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetworkParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetworkParameters.java
@@ -6,7 +6,11 @@
  */
 package com.powsybl.openloadflow.network;
 
+import com.powsybl.iidm.network.Country;
 import com.powsybl.openloadflow.util.ParameterConstants;
+
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -29,16 +33,18 @@ public class LfNetworkParameters {
 
     private final boolean computeMainConnectedComponentOnly;
 
+    private final Set<Country> countriesToBalance;
+
     public LfNetworkParameters(SlackBusSelector slackBusSelector) {
         this(slackBusSelector, false, false, false, false,
                 ParameterConstants.PLAUSIBLE_ACTIVE_POWER_LIMIT_DEFAULT_VALUE, false,
-                true);
+                true, Collections.emptySet());
     }
 
     public LfNetworkParameters(SlackBusSelector slackBusSelector, boolean generatorVoltageRemoteControl,
                                boolean minImpedance, boolean twtSplitShuntAdmittance, boolean breakers,
                                double plausibleActivePowerLimit, boolean addRatioToLinesWithDifferentNominalVoltageAtBothEnds,
-                               boolean computeMainConnectedComponentOnly) {
+                               boolean computeMainConnectedComponentOnly, Set<Country> countriesToBalance) {
         this.slackBusSelector = slackBusSelector;
         this.generatorVoltageRemoteControl = generatorVoltageRemoteControl;
         this.minImpedance = minImpedance;
@@ -47,6 +53,7 @@ public class LfNetworkParameters {
         this.plausibleActivePowerLimit = plausibleActivePowerLimit;
         this.addRatioToLinesWithDifferentNominalVoltageAtBothEnds = addRatioToLinesWithDifferentNominalVoltageAtBothEnds;
         this.computeMainConnectedComponentOnly = computeMainConnectedComponentOnly;
+        this.countriesToBalance = countriesToBalance;
     }
 
     public SlackBusSelector getSlackBusSelector() {
@@ -79,5 +86,9 @@ public class LfNetworkParameters {
 
     public boolean isComputeMainConnectedComponentOnly() {
         return computeMainConnectedComponentOnly;
+    }
+
+    public Set<Country> getCountriesToBalance() {
+        return countriesToBalance;
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetworkParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetworkParameters.java
@@ -89,6 +89,6 @@ public class LfNetworkParameters {
     }
 
     public Set<Country> getCountriesToBalance() {
-        return countriesToBalance;
+        return Collections.unmodifiableSet(countriesToBalance);
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
@@ -25,17 +25,20 @@ public class LfBusImpl extends AbstractLfBus {
 
     private final double highVoltageLimit;
 
-    protected LfBusImpl(Bus bus, LfNetwork network, double v, double angle) {
+    private final boolean participating;
+
+    protected LfBusImpl(Bus bus, LfNetwork network, double v, double angle, boolean participating) {
         super(network, v, angle);
         this.bus = bus;
         nominalV = bus.getVoltageLevel().getNominalV();
         lowVoltageLimit = bus.getVoltageLevel().getLowVoltageLimit();
         highVoltageLimit = bus.getVoltageLevel().getHighVoltageLimit();
+        this.participating = participating;
     }
 
-    public static LfBusImpl create(Bus bus, LfNetwork network) {
+    public static LfBusImpl create(Bus bus, LfNetwork network, boolean participating) {
         Objects.requireNonNull(bus);
-        return new LfBusImpl(bus, network, bus.getV(), bus.getAngle());
+        return new LfBusImpl(bus, network, bus.getV(), bus.getAngle(), participating);
     }
 
     @Override
@@ -78,5 +81,10 @@ public class LfBusImpl extends AbstractLfBus {
         }
 
         super.updateState(reactiveLimits, writeSlackBus);
+    }
+
+    @Override
+    public boolean isParticipating() {
+        return participating;
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBus.java
@@ -72,6 +72,6 @@ public class LfDanglingLineBus extends AbstractLfBus {
 
     @Override
     public boolean isParticipating() {
-        return true;
+        return false;
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBus.java
@@ -69,4 +69,9 @@ public class LfDanglingLineBus extends AbstractLfBus {
 
         super.updateState(reactiveLimits, writeSlackBus);
     }
+
+    @Override
+    public boolean isParticipating() {
+        return true;
+    }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -130,7 +130,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
 
     private static LfBusImpl createBus(Bus bus, LfNetworkParameters parameters, LfNetwork lfNetwork, LoadingContext loadingContext,
                                        LfNetworkLoadingReport report) {
-        LfBusImpl lfBus = LfBusImpl.create(bus, lfNetwork, participateToBalance(parameters, bus));
+        LfBusImpl lfBus = LfBusImpl.create(bus, lfNetwork, participateToSlackDistribution(parameters, bus));
 
         bus.visitConnectedEquipments(new DefaultTopologyVisitor() {
 
@@ -567,7 +567,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
         return Optional.empty();
     }
 
-    static boolean participateToBalance(LfNetworkParameters parameters, Bus b) {
+    static boolean participateToSlackDistribution(LfNetworkParameters parameters, Bus b) {
         return parameters.getCountriesToBalance().isEmpty()
                || b.getVoltageLevel().getSubstation().getCountry()
                    .map(country -> parameters.getCountriesToBalance().contains(country))

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -49,7 +49,6 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
                                     LoadingContext loadingContext, LfNetworkLoadingReport report) {
         for (Bus bus : buses) {
             LfBusImpl lfBus = createBus(bus, parameters, lfNetwork, loadingContext, report);
-            lfBus.setDisabled(lfBus.isDisabled() || !participateToBalance(parameters, bus));
             lfNetwork.addBus(lfBus);
             lfBuses.add(lfBus);
         }
@@ -131,7 +130,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
 
     private static LfBusImpl createBus(Bus bus, LfNetworkParameters parameters, LfNetwork lfNetwork, LoadingContext loadingContext,
                                        LfNetworkLoadingReport report) {
-        LfBusImpl lfBus = LfBusImpl.create(bus, lfNetwork);
+        LfBusImpl lfBus = LfBusImpl.create(bus, lfNetwork, participateToBalance(parameters, bus));
 
         bus.visitConnectedEquipments(new DefaultTopologyVisitor() {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -49,6 +49,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
                                     LoadingContext loadingContext, LfNetworkLoadingReport report) {
         for (Bus bus : buses) {
             LfBusImpl lfBus = createBus(bus, parameters, lfNetwork, loadingContext, report);
+            lfBus.setDisabled(lfBus.isDisabled() || !participateToBalance(parameters, bus));
             lfNetwork.addBus(lfBus);
             lfBuses.add(lfBus);
         }
@@ -565,5 +566,12 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
         }
 
         return Optional.empty();
+    }
+
+    static boolean participateToBalance(LfNetworkParameters parameters, Bus b) {
+        return parameters.getCountriesToBalance().isEmpty()
+               || b.getVoltageLevel().getSubstation().getCountry()
+                   .map(country -> parameters.getCountriesToBalance().contains(country))
+                   .orElse(false);
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfStarBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfStarBus.java
@@ -61,4 +61,9 @@ public class LfStarBus extends AbstractLfBus {
 
         super.updateState(reactiveLimits, writeSlackBus);
     }
+
+    @Override
+    public boolean isParticipating() {
+        return true;
+    }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfStarBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfStarBus.java
@@ -64,6 +64,6 @@ public class LfStarBus extends AbstractLfBus {
 
     @Override
     public boolean isParticipating() {
-        return true;
+        return false;
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/util/GenerationActivePowerDistributionStep.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/GenerationActivePowerDistributionStep.java
@@ -43,7 +43,7 @@ public class GenerationActivePowerDistributionStep implements ActivePowerDistrib
     @Override
     public List<ParticipatingElement> getParticipatingElements(Collection<LfBus> buses) {
         return buses.stream()
-                .filter(bus -> !(bus.isDisabled() || bus.isFictitious() || !bus.isParticipating()))
+                .filter(bus -> bus.isParticipating() && !bus.isDisabled() && !bus.isFictitious())
                 .flatMap(bus -> bus.getGenerators().stream())
                 .filter(generator -> generator.isParticipating() && getParticipationFactor(generator) != 0)
                 .map(generator -> new ParticipatingElement(generator, getParticipationFactor(generator)))

--- a/src/main/java/com/powsybl/openloadflow/network/util/GenerationActivePowerDistributionStep.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/GenerationActivePowerDistributionStep.java
@@ -43,7 +43,7 @@ public class GenerationActivePowerDistributionStep implements ActivePowerDistrib
     @Override
     public List<ParticipatingElement> getParticipatingElements(Collection<LfBus> buses) {
         return buses.stream()
-                .filter(bus -> !(bus.isDisabled() || bus.isFictitious()))
+                .filter(bus -> !(bus.isDisabled() || bus.isFictitious() || !bus.isParticipating()))
                 .flatMap(bus -> bus.getGenerators().stream())
                 .filter(generator -> generator.isParticipating() && getParticipationFactor(generator) != 0)
                 .map(generator -> new ParticipatingElement(generator, getParticipationFactor(generator)))

--- a/src/main/java/com/powsybl/openloadflow/network/util/LoadActivePowerDistributionStep.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/LoadActivePowerDistributionStep.java
@@ -40,7 +40,7 @@ public class LoadActivePowerDistributionStep implements ActivePowerDistribution.
     @Override
     public List<ParticipatingElement> getParticipatingElements(Collection<LfBus> buses) {
         return buses.stream()
-                .filter(bus -> bus.getPositiveLoadCount() > 0 && getVariableLoadTargetP(bus) > 0 && !(bus.isFictitious() || bus.isDisabled() || !bus.isParticipating()))
+                .filter(bus -> bus.getPositiveLoadCount() > 0 && getVariableLoadTargetP(bus) > 0 && bus.isParticipating() && !bus.isDisabled() && !bus.isFictitious())
                 .map(bus -> new ParticipatingElement(bus, getVariableLoadTargetP(bus)))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/powsybl/openloadflow/network/util/LoadActivePowerDistributionStep.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/LoadActivePowerDistributionStep.java
@@ -40,7 +40,7 @@ public class LoadActivePowerDistributionStep implements ActivePowerDistribution.
     @Override
     public List<ParticipatingElement> getParticipatingElements(Collection<LfBus> buses) {
         return buses.stream()
-                .filter(bus -> bus.getPositiveLoadCount() > 0 && getVariableLoadTargetP(bus) > 0 && !(bus.isFictitious() || bus.isDisabled()))
+                .filter(bus -> bus.getPositiveLoadCount() > 0 && getVariableLoadTargetP(bus) > 0 && !(bus.isFictitious() || bus.isDisabled() || !bus.isParticipating()))
                 .map(bus -> new ParticipatingElement(bus, getVariableLoadTargetP(bus)))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
@@ -159,7 +159,7 @@ public class AcSensitivityAnalysis extends AbstractSensitivityAnalysis {
         SlackBusSelector slackBusSelector = SlackBusSelector.fromMode(lfParametersExt.getSlackBusSelectionMode(), lfParametersExt.getSlackBusId());
         LfNetworkParameters lfNetworkParameters = new LfNetworkParameters(slackBusSelector, lfParametersExt.hasVoltageRemoteControl(),
                 true, lfParameters.isTwtSplitShuntAdmittance(), false, lfParametersExt.getPlausibleActivePowerLimit(),
-                false, true);
+                false, true, lfParameters.getCountriesToBalance());
         List<LfNetwork> lfNetworks = LfNetwork.load(network, lfNetworkParameters, reporter);
         LfNetwork lfNetwork = lfNetworks.get(0);
         checkContingencies(network, lfNetwork, contingencies);

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -623,7 +623,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis {
         // create DC load flow engine for setting the function reference
         DcLoadFlowParameters dcLoadFlowParameters = new DcLoadFlowParameters(slackBusSelector, matrixFactory,
             true, lfParameters.isDcUseTransformerRatio(), lfParameters.isDistributedSlack(), lfParameters.getBalanceType(), true,
-            lfParametersExt.getPlausibleActivePowerLimit(), lfParametersExt.isAddRatioToLinesWithDifferentNominalVoltageAtBothEnds(), true, true);
+            lfParametersExt.getPlausibleActivePowerLimit(), lfParametersExt.isAddRatioToLinesWithDifferentNominalVoltageAtBothEnds(), true, true, lfParameters.getCountriesToBalance());
         DcLoadFlowEngine dcLoadFlowEngine = new DcLoadFlowEngine(lfNetworks, dcLoadFlowParameters);
 
         // create DC equation system for sensitivity analysis

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -598,7 +598,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis {
         // create the network (we only manage main connected component)
         SlackBusSelector slackBusSelector = SlackBusSelector.fromMode(lfParametersExt.getSlackBusSelectionMode(), lfParametersExt.getSlackBusId());
         LfNetworkParameters lfNetworkParameters = new LfNetworkParameters(slackBusSelector, false, true, lfParameters.isTwtSplitShuntAdmittance(),
-                false, lfParametersExt.getPlausibleActivePowerLimit(), false, true);
+                false, lfParametersExt.getPlausibleActivePowerLimit(), false, true, lfParameters.getCountriesToBalance());
         List<LfNetwork> lfNetworks = LfNetwork.load(network, lfNetworkParameters, reporter);
         LfNetwork lfNetwork = lfNetworks.get(0);
         checkContingencies(network, lfNetwork, contingencies);
@@ -622,13 +622,13 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis {
 
         // create DC load flow engine for setting the function reference
         DcLoadFlowParameters dcLoadFlowParameters = new DcLoadFlowParameters(slackBusSelector, matrixFactory,
-            true, lfParametersExt.isDcUseTransformerRatio(), lfParameters.isDistributedSlack(), lfParameters.getBalanceType(), true,
+            true, lfParameters.isDcUseTransformerRatio(), lfParameters.isDistributedSlack(), lfParameters.getBalanceType(), true,
             lfParametersExt.getPlausibleActivePowerLimit(), lfParametersExt.isAddRatioToLinesWithDifferentNominalVoltageAtBothEnds(), true, true);
         DcLoadFlowEngine dcLoadFlowEngine = new DcLoadFlowEngine(lfNetworks, dcLoadFlowParameters);
 
         // create DC equation system for sensitivity analysis
         DcEquationSystemCreationParameters dcEquationSystemCreationParameters = new DcEquationSystemCreationParameters(dcLoadFlowParameters.isUpdateFlows(), true,
-            dcLoadFlowParameters.isForcePhaseControlOffAndAddAngle1Var(), lfParametersExt.isDcUseTransformerRatio());
+            dcLoadFlowParameters.isForcePhaseControlOffAndAddAngle1Var(), lfParameters.isDcUseTransformerRatio());
         EquationSystem equationSystem = DcEquationSystem.create(lfNetwork, new VariableSet(), dcEquationSystemCreationParameters);
 
         // we wrap the factor into a class that allows us to have access to their branch and EquationTerm instantly

--- a/src/main/java/com/powsybl/openloadflow/util/ParameterConstants.java
+++ b/src/main/java/com/powsybl/openloadflow/util/ParameterConstants.java
@@ -32,9 +32,6 @@ public final class ParameterConstants {
     public static final String LOAD_POWER_FACTOR_CONSTANT_PARAM_NAME = "loadPowerFactorConstant";
     public static final boolean LOAD_POWER_FACTOR_CONSTANT_DEFAULT_VALUE = false;
 
-    public static final String DC_USE_TRANSFORMER_RATIO_PARAM_NAME = "dcUseTransformerRatio";
-    public static final boolean DC_USE_TRANSFORMER_RATIO_DEFAULT_VALUE = true;
-
     public static final String PLAUSIBLE_ACTIVE_POWER_LIMIT_PARAM_NAME = "plausibleActivePowerLimit";
     public static final double PLAUSIBLE_ACTIVE_POWER_LIMIT_DEFAULT_VALUE = 10000;
 

--- a/src/test/java/com/powsybl/openloadflow/OpenLoadFlowParametersTest.java
+++ b/src/test/java/com/powsybl/openloadflow/OpenLoadFlowParametersTest.java
@@ -101,7 +101,6 @@ class OpenLoadFlowParametersTest {
         assertEquals(LOW_IMPEDANCE_BRANCH_MODE_DEFAULT_VALUE, olfParameters.getLowImpedanceBranchMode());
         assertEquals(THROWS_EXCEPTION_IN_CASE_OF_SLACK_DISTRIBUTION_FAILURE_DEFAULT_VALUE, olfParameters.isThrowsExceptionInCaseOfSlackDistributionFailure());
 
-        assertEquals(DC_USE_TRANSFORMER_RATIO_DEFAULT_VALUE, olfParameters.isDcUseTransformerRatio());
         assertEquals(SLACK_BUS_P_MAX_MISMATCH_DEFAULT_VALUE, olfParameters.getSlackBusPMaxMismatch(), 0.0);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/GeneratorTargetVoltageInconsistencyTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/GeneratorTargetVoltageInconsistencyTest.java
@@ -11,6 +11,7 @@ import com.powsybl.openloadflow.network.*;
 import com.powsybl.openloadflow.util.ParameterConstants;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -201,7 +202,7 @@ class GeneratorTargetVoltageInconsistencyTest {
         FirstSlackBusSelector slackBusSelector = new FirstSlackBusSelector();
         LfNetworkParameters parameters = new LfNetworkParameters(slackBusSelector, true, false, false, false,
                 ParameterConstants.PLAUSIBLE_ACTIVE_POWER_LIMIT_DEFAULT_VALUE, false,
-                true);
+                true, Collections.emptySet());
 
         Generator g = network.getGenerator("g2");
         assertEquals(0.5625, g.getTargetV() / g.getTerminal().getVoltageLevel().getNominalV());
@@ -312,7 +313,7 @@ class GeneratorTargetVoltageInconsistencyTest {
         FirstSlackBusSelector slackBusSelector = new FirstSlackBusSelector();
         LfNetworkParameters parameters = new LfNetworkParameters(slackBusSelector, true, false, false, false,
                 ParameterConstants.PLAUSIBLE_ACTIVE_POWER_LIMIT_DEFAULT_VALUE, false,
-                true);
+                true, Collections.emptySet());
 
         assertEquals(412, network.getGenerator("g1").getTargetV());
         assertEquals(413, g2.getTargetV());

--- a/src/test/java/com/powsybl/openloadflow/network/impl/LfBusImplTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/impl/LfBusImplTest.java
@@ -129,7 +129,7 @@ class LfBusImplTest {
         List<LfNetwork> networks = LfNetwork.load(EurostagTutorialExample1Factory.create(), new MostMeshedSlackBusSelector());
         LfNetwork mainNetwork = networks.get(0);
 
-        LfBusImpl lfBus = new LfBusImpl(bus1, mainNetwork, 385, 0);
+        LfBusImpl lfBus = new LfBusImpl(bus1, mainNetwork, 385, 0, true);
         LfNetworkLoadingReport lfNetworkLoadingReport = new LfNetworkLoadingReport();
         lfBus.addStaticVarCompensator(svc1, true, lfNetworkLoadingReport);
         lfBus.addStaticVarCompensator(svc2, true, lfNetworkLoadingReport);

--- a/src/test/resources/debug-parameters.json
+++ b/src/test/resources/debug-parameters.json
@@ -23,7 +23,6 @@
         "throwsExceptionInCaseOfSlackDistributionFailure" : false,
         "lowImpedanceBranchMode" : "REPLACE_BY_ZERO_IMPEDANCE_LINE",
         "loadPowerFactorConstant" : false,
-        "dcUseTransformerRatio" : true,
         "plausibleActivePowerLimit" : 10000.0,
         "addRatioToLinesWithDifferentNominalVoltageAtBothEnds" : false,
         "slackBusPMaxMismatch" : 1.0


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Use the two new parameters available in powsybl-core isDcUseTransformerRatio and countriesToBalance. The branch for this PR is based on the branch from the PR https://github.com/powsybl/powsybl-open-loadflow/pull/295 to use the compatibility work already done for 4.2.0 release candidate.
Thus it is to be rebased and merged after this PR.


**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
