### PR TITLE
Wrong function reference for BranchFlowPerPSTAngle factor

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -220,15 +220,13 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis {
                     break;
                 }
                 double contingencySensitivity = p1.calculateSensi(contingenciesStates, contingencyElement.getContingencyIndex());
+                flowValue += contingencyElement.getAlphaForFunctionReference() * contingencySensitivity;
+                sensiValue +=  contingencyElement.getAlphaForSensitivityValue() * contingencySensitivity;
                 if (contingencyElement.getElement().getId().equals(factor.getVariableId())) {
                     // the equipment responsible for the variable is indeed in contingency, the sensitivity value equals to zero.
                     // No assumption about the reference flow on the monitored branch.
                     sensiValue = 0d;
-                    flowValue += contingencyElement.getAlphaForFunctionReference() * contingencySensitivity;
-                    break;
                 }
-                flowValue += contingencyElement.getAlphaForFunctionReference() * contingencySensitivity;
-                sensiValue +=  contingencyElement.getAlphaForSensitivityValue() * contingencySensitivity;
             }
             if (contingency != null && contingency.getHvdcIdsToOpen().contains(factor.getVariableId())) {
                 sensiValue = 0d;

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -212,14 +212,21 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis {
             sensiValue = factor.getBaseSensitivityValue();
             flowValue = factor.getFunctionReference();
             for (ComputedContingencyElement contingencyElement : contingencyElements) {
-                if (contingencyElement.getElement().getId().equals(functionBranchId)
-                        || contingencyElement.getElement().getId().equals(factor.getVariableId())) {
-                    // the sensitivity on a removed branch is 0, the sensitivity if the variable was a removed branch is 0
+                if (contingencyElement.getElement().getId().equals(functionBranchId)) {
+                    // the monitored branch is in contingency, the sensitivity value equals to zero and its post-contingency flow
+                    // equals to zero too.
                     sensiValue = 0d;
                     flowValue = 0d;
                     break;
                 }
                 double contingencySensitivity = p1.calculateSensi(contingenciesStates, contingencyElement.getContingencyIndex());
+                if (contingencyElement.getElement().getId().equals(factor.getVariableId())) {
+                    // the equipment responsible for the variable is indeed in contingency, the sensitivity value equals to zero.
+                    // No assumption about the reference flow on the monitored branch.
+                    sensiValue = 0d;
+                    flowValue += contingencyElement.getAlphaForFunctionReference() * contingencySensitivity;
+                    break;
+                }
                 flowValue += contingencyElement.getAlphaForFunctionReference() * contingencySensitivity;
                 sensiValue +=  contingencyElement.getAlphaForSensitivityValue() * contingencySensitivity;
             }

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -212,7 +212,6 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis {
             sensiValue = factor.getBaseSensitivityValue();
             flowValue = factor.getFunctionReference();
             boolean zeroSensiValue = false;
-            boolean zeroFlowValue = false;
             for (ComputedContingencyElement contingencyElement : contingencyElements) {
                 double contingencySensitivity = p1.calculateSensi(contingenciesStates, contingencyElement.getContingencyIndex());
                 flowValue += contingencyElement.getAlphaForFunctionReference() * contingencySensitivity;
@@ -220,8 +219,9 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis {
                 if (contingencyElement.getElement().getId().equals(functionBranchId)) {
                     // the monitored branch is in contingency, the sensitivity value equals to zero and its post-contingency flow
                     // equals to zero too.
-                    zeroSensiValue = true;
-                    zeroFlowValue = true;
+                    sensiValue = 0d;
+                    flowValue = 0d;
+                    break;
                 }
                 if (contingencyElement.getElement().getId().equals(factor.getVariableId())) {
                     // the equipment responsible for the variable is indeed in contingency, the sensitivity value equals to zero.
@@ -229,11 +229,8 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis {
                     zeroSensiValue = true;
                 }
             }
-            if (contingency != null && contingency.getHvdcIdsToOpen().contains(factor.getVariableId()) || zeroSensiValue) {
+            if ((contingency != null && contingency.getHvdcIdsToOpen().contains(factor.getVariableId())) || zeroSensiValue) {
                 sensiValue = 0d;
-            }
-            if (zeroFlowValue) {
-                flowValue = 0d;
             }
         }
         valueWriter.write(factor.getContext(), contingency != null ? contingency.getContingency().getId() : null, contingency != null ? contingency.getIndex() : -1,

--- a/src/test/java/com/powsybl/openloadflow/sensi/dc/DcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/dc/DcSensitivityAnalysisContingenciesTest.java
@@ -1814,6 +1814,7 @@ class DcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
         SensitivityAnalysisResult result = sensiProvider.run(network, VariantManagerConstants.INITIAL_VARIANT_ID, factorsProvider2, contingencies,
                 parameters, LocalComputationManager.getDefault())
                 .join();
-        assertEquals(0.0, getContingencyFunctionReference(result, "L1", "PS1"), LoadFlowAssert.DELTA_POWER);
+        assertEquals(100.0, getContingencyFunctionReference(result, "L1", "PS1"), LoadFlowAssert.DELTA_POWER);
+        assertEquals(0.0, getContingencyValue(result, "PS1", "PS1", "L1"), LoadFlowAssert.DELTA_POWER);
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sensi/dc/DcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/dc/DcSensitivityAnalysisContingenciesTest.java
@@ -12,6 +12,7 @@ import com.powsybl.commons.reporter.Reporter;
 import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.contingency.*;
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.test.PhaseShifterTestCaseFactory;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.openloadflow.network.*;
 import com.powsybl.openloadflow.sensi.*;
@@ -1800,5 +1801,19 @@ class DcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
         double finalP = l1.getTerminal1().getP();
         assertEquals(2.0624, finalP, LoadFlowAssert.DELTA_POWER);
         assertEquals(0.1875, finalP - initialP, LoadFlowAssert.DELTA_POWER);
+    }
+
+    @Test
+    void contingencyOnPhaseTapChangerTest() {
+        Network network = PhaseShifterTestCaseFactory.create();
+        SensitivityAnalysisParameters parameters = createParameters(true, "VL1_0", true);
+        parameters.getLoadFlowParameters().setBalanceType(LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX);
+        SensitivityFactorsProvider factorsProvider2 = n -> List.of(new BranchFlowPerPSTAngle(new BranchFlow("L1", "L1", "L1"),
+                new PhaseTapChangerAngle("PS1", "PS1", "PS1")));
+        List<Contingency> contingencies = List.of(new Contingency("PS1", new BranchContingency("PS1")));
+        SensitivityAnalysisResult result = sensiProvider.run(network, VariantManagerConstants.INITIAL_VARIANT_ID, factorsProvider2, contingencies,
+                parameters, LocalComputationManager.getDefault())
+                .join();
+        assertEquals(0.0, getContingencyFunctionReference(result, "L1", "PS1"), LoadFlowAssert.DELTA_POWER);
     }
 }


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <anne.tilloy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No, it explains the issue. We want to calculate the sensitivity of a PST angle to a monitored branch. The flow on this monitored branch is right in pre-contingency state. We simulate a contingency of this same PST: the flux on the monitored branch on post-contingency state falls to zero.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
