### PR TITLE
Security analysis: disconnect terminals of isolated end nodes

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/util/NodeBreakerTraverser.java
+++ b/src/main/java/com/powsybl/openloadflow/util/NodeBreakerTraverser.java
@@ -57,9 +57,7 @@ public class NodeBreakerTraverser implements VoltageLevel.NodeBreakerView.Traver
                     return true;
                 }
                 if (isEquivalentToStopAfterSwitch(sw, nodeAfter)) {
-                    // Retaining the switch is equivalent to stop at the node after
-                    // - if the node after the switch is an end node (e.g. load or generator)
-                    // - if the node after the switch is a line
+                    // Retaining the switch is equivalent to stop at the node after if the node after the switch is an end node (e.g. load or generator)
                     sw.getVoltageLevel().getNodeBreakerView().getOptionalTerminal(nodeAfter).ifPresent(traversedTerminals::add);
                     return false;
                 }

--- a/src/main/java/com/powsybl/openloadflow/util/NodeBreakerTraverser.java
+++ b/src/main/java/com/powsybl/openloadflow/util/NodeBreakerTraverser.java
@@ -80,8 +80,6 @@ public class NodeBreakerTraverser implements VoltageLevel.NodeBreakerView.Traver
             boolean endNodeAfter = connectableAfter == ConnectableType.GENERATOR
                 || connectableAfter == ConnectableType.LOAD
                 || connectableAfter == ConnectableType.DANGLING_LINE
-                || connectableAfter == ConnectableType.TWO_WINDINGS_TRANSFORMER
-                || connectableAfter == ConnectableType.LINE
                 || connectableAfter == ConnectableType.STATIC_VAR_COMPENSATOR
                 || connectableAfter == ConnectableType.SHUNT_COMPENSATOR;
 

--- a/src/main/java/com/powsybl/openloadflow/util/NodeBreakerTraverser.java
+++ b/src/main/java/com/powsybl/openloadflow/util/NodeBreakerTraverser.java
@@ -56,8 +56,11 @@ public class NodeBreakerTraverser implements VoltageLevel.NodeBreakerView.Traver
                     // switches after are often opened and sometimes followed by an end node
                     return true;
                 }
-                if (isEndNodeAfterSwitch(sw, nodeAfter)) {
-                    // No need to retain switch if the node after the switch is an end node (e.g. load or generator)
+                if (isEquivalentToStopAfterSwitch(sw, nodeAfter)) {
+                    // Retaining the switch is equivalent to stop at the node after
+                    // - if the node after the switch is an end node (e.g. load or generator)
+                    // - if the node after the switch is a line
+                    sw.getVoltageLevel().getNodeBreakerView().getOptionalTerminal(nodeAfter).ifPresent(traversedTerminals::add);
                     return false;
                 }
                 switchesToOpen.add(sw);
@@ -70,13 +73,15 @@ public class NodeBreakerTraverser implements VoltageLevel.NodeBreakerView.Traver
         return true;
     }
 
-    private static boolean isEndNodeAfterSwitch(Switch sw, int nodeAfter) {
+    private static boolean isEquivalentToStopAfterSwitch(Switch sw, int nodeAfter) {
         Terminal terminal2 = sw.getVoltageLevel().getNodeBreakerView().getTerminal(nodeAfter);
         if (terminal2 != null) {
             ConnectableType connectableAfter = terminal2.getConnectable().getType();
             boolean endNodeAfter = connectableAfter == ConnectableType.GENERATOR
                 || connectableAfter == ConnectableType.LOAD
                 || connectableAfter == ConnectableType.DANGLING_LINE
+                || connectableAfter == ConnectableType.TWO_WINDINGS_TRANSFORMER
+                || connectableAfter == ConnectableType.LINE
                 || connectableAfter == ConnectableType.STATIC_VAR_COMPENSATOR
                 || connectableAfter == ConnectableType.SHUNT_COMPENSATOR;
 

--- a/src/test/java/com/powsybl/openloadflow/util/ContingencyTrippingTest.java
+++ b/src/test/java/com/powsybl/openloadflow/util/ContingencyTrippingTest.java
@@ -110,7 +110,7 @@ class ContingencyTrippingTest {
         Set<Terminal> terminalsToDisconnect = new HashSet<>();
         lbt1.traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen, "BL", "BJ");
-        checkTerminalIds(terminalsToDisconnect, "D", "CI", "P", "CJ");
+        checkTerminalIds(terminalsToDisconnect, "D", "CE", "CF", "CG", "CH", "CI", "P", "CJ");
 
         // Then with the opened disconnector
         network.getSwitch("AH").setOpen(true);
@@ -118,7 +118,7 @@ class ContingencyTrippingTest {
         terminalsToDisconnect.clear();
         lbt1.traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen, "BL");
-        checkTerminalIds(terminalsToDisconnect, "D", "CI", "P", "CJ");
+        checkTerminalIds(terminalsToDisconnect, "D", "CE", "CF", "CG", "CH", "CI", "P", "CJ");
     }
 
     @Test
@@ -142,7 +142,7 @@ class ContingencyTrippingTest {
         // Close switches to traverse the voltage level until encountering generator/loads
         network.getSwitch("BB").setOpen(false); // BB fictitious breaker
         network.getSwitch("AZ").setOpen(false); // AZ disconnector to BBS1
-        network.getSwitch("AV").setOpen(false); // AR disconnector to generator CD
+        network.getSwitch("AV").setOpen(false); // AV disconnector to generator CD
 
         // Adding breakers between two loads to simulate the case of a branching of two switches at an end node
         network.getVoltageLevel("N").getNodeBreakerView().newSwitch()
@@ -171,7 +171,7 @@ class ContingencyTrippingTest {
         Set<Terminal> terminalsToDisconnect = new HashSet<>();
         lbt1.traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen, "BJ", "BL", "BV", "BX");
-        checkTerminalIds(terminalsToDisconnect, "D", "CI", "P", "O", "CJ");
+        checkTerminalIds(terminalsToDisconnect, "D", "CD", "CE", "CH", "CI", "P", "O", "CJ");
 
         // Adding an internal connection and open the ZW switch
         network.getSwitch("ZY").setOpen(true);
@@ -183,7 +183,7 @@ class ContingencyTrippingTest {
         terminalsToDisconnect.clear();
         lbt1.traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen, "BJ", "BL", "BV", "BX");
-        checkTerminalIds(terminalsToDisconnect, "D", "CI", "P", "O", "CJ");
+        checkTerminalIds(terminalsToDisconnect, "D", "CD", "CE", "CH", "CI", "P", "O", "CJ");
     }
 
     @Test
@@ -204,7 +204,7 @@ class ContingencyTrippingTest {
         Set<Terminal> terminalsToDisconnect = new HashSet<>();
         ContingencyTripping.createBranchTripping(network, "CJ").traverse(switchesToOpen, terminalsToDisconnect);
         checkSwitches(switchesToOpen, "BL");
-        checkTerminalIds(terminalsToDisconnect, "D", "CI", "CJ");
+        checkTerminalIds(terminalsToDisconnect, "D", "CE", "CI", "CJ");
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?**
Feature


**What is the current behavior?** 
In security analysis, switches are retained even if they are encountered just before encountering a line / a 2wt while propagating the contingency.


**What is the new behavior (if this is a feature change)?**
Those switches are not retained anymore, leading to a simplified bus breaker view.



**Does this PR introduce a breaking change or deprecate an API?**
No