### PR TITLE
Fixes in branch results of security analysis

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
@@ -41,10 +41,6 @@ public class LfBranchImpl extends AbstractLfBranch {
 
     private Evaluable i2 = NAN;
 
-    private static double nominalV1;
-
-    private static double nominalV2;
-
     protected LfBranchImpl(LfNetwork network, LfBus bus1, LfBus bus2, PiModel piModel, Branch<?> branch) {
         super(network, bus1, bus2, piModel);
         this.branch = branch;
@@ -52,8 +48,8 @@ public class LfBranchImpl extends AbstractLfBranch {
 
     private static LfBranchImpl createLine(Line line, LfNetwork network, LfBus bus1, LfBus bus2, double zb, boolean addRatioToLinesWithDifferentNominalVoltageAtBothEnds,
                                            LfNetworkLoadingReport report) {
-        nominalV1 = line.getTerminal1().getVoltageLevel().getNominalV();
-        nominalV2 = line.getTerminal2().getVoltageLevel().getNominalV();
+        double nominalV1 = line.getTerminal1().getVoltageLevel().getNominalV();
+        double nominalV2 = line.getTerminal2().getVoltageLevel().getNominalV();
         double r1 = 1;
         if (addRatioToLinesWithDifferentNominalVoltageAtBothEnds && nominalV1 != nominalV2) {
             LOGGER.trace("Line '{}' has a different nominal voltage at both ends ({} and {}): add a ration", line.getId(), nominalV1, nominalV2);
@@ -207,10 +203,10 @@ public class LfBranchImpl extends AbstractLfBranch {
 
     @Override
     public BranchResult createBranchResult() {
-        double currentScale1 = PerUnit.SB / nominalV1;
-        double currentScale2 = PerUnit.SB / nominalV2;
-        return new BranchResult(getId(), p1.eval() * PerUnit.SB, q1.eval(), i1.eval() * currentScale1,
-                p2.eval() * PerUnit.SB, q2.eval() * PerUnit.SB, i2.eval() * currentScale2);
+        double currentScale1 = PerUnit.SB / branch.getTerminal1().getVoltageLevel().getNominalV();
+        double currentScale2 = PerUnit.SB / branch.getTerminal2().getVoltageLevel().getNominalV();
+        return new BranchResult(getId(), p1.eval() * PerUnit.SB, q1.eval() * PerUnit.SB, currentScale1 * i1.eval(),
+                                p2.eval() * PerUnit.SB, q2.eval() * PerUnit.SB, currentScale2 * i2.eval());
     }
 
     @Override

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -25,24 +25,19 @@ import com.powsybl.openloadflow.network.*;
 import com.powsybl.security.*;
 import com.powsybl.security.detectors.DefaultLimitViolationDetector;
 import com.powsybl.security.monitor.StateMonitor;
-import com.powsybl.security.results.BranchResult;
-import com.powsybl.security.results.BusResults;
-import com.powsybl.security.results.PostContingencyResult;
-import com.powsybl.security.results.ThreeWindingsTransformerResult;
+import com.powsybl.security.results.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.lang.Double.NaN;
+import static java.util.Collections.emptySet;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -463,61 +458,51 @@ class OpenSecurityAnalysisTest {
 
     @Test
     void testSAWithStateMonitor() {
-        Network network = DistributedSlackNetworkFactory.create();
-        SecurityAnalysisParameters saParameters = new SecurityAnalysisParameters();
-        LoadFlowParameters lfParameters = new LoadFlowParameters();
-        OpenLoadFlowParameters olfParameters = new OpenLoadFlowParameters()
-                .setSlackBusSelectionMode(SlackBusSelectionMode.MOST_MESHED);
-        lfParameters.addExtension(OpenLoadFlowParameters.class, olfParameters);
-        saParameters.setLoadFlowParameters(lfParameters);
+        Network network = EurostagTutorialExample1Factory.create();
 
-        // Testing all contingencies at once
-        ContingenciesProvider contingenciesProvider = n -> n.getBranchStream()
-                .map(b -> new Contingency(b.getId(), new BranchContingency(b.getId())))
-                .collect(Collectors.toList());
+        // 2 N-1 on the 2 lines
+        List<Contingency> contingencies = List.of(
+            new Contingency("NHV1_NHV2_1", new BranchContingency("NHV1_NHV2_1")),
+            new Contingency("NHV1_NHV2_2", new BranchContingency("NHV1_NHV2_2"))
+        );
 
-        List<StateMonitor> monitors = new ArrayList<>();
-        monitors.add(new StateMonitor(ContingencyContext.all(), Collections.singleton("l24"), Collections.singleton("b1_vl"), Collections.emptySet()));
+        // Monitor on branch and step-up transformer for all states
+        List<StateMonitor> monitors = List.of(
+            new StateMonitor(ContingencyContext.all(), Set.of("NHV1_NHV2_1", "NGEN_NHV1"), Set.of("VLLOAD"), emptySet())
+        );
 
-        OpenSecurityAnalysisProvider osaProvider = new OpenSecurityAnalysisProvider(new DenseMatrixFactory(), EvenShiloachGraphDecrementalConnectivity::new);
-        CompletableFuture<SecurityAnalysisReport> futureResult = osaProvider.run(network, network.getVariantManager().getWorkingVariantId(),
-                new DefaultLimitViolationDetector(), new LimitViolationFilter(), null, saParameters,
-                contingenciesProvider, Collections.emptyList(), monitors);
-        SecurityAnalysisResult result = futureResult.join().getResult();
+        SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies, monitors);
 
-        assertEquals(1, result.getPreContingencyResult().getPreContingencyBusResults().size());
-        assertEquals(new BusResults("b1_vl", "b1", 400, 0.00411772307613007), result.getPreContingencyResult().getPreContingencyBusResults().get(0));
-        assertEquals(1, result.getPreContingencyResult().getPreContingencyBranchResults().size());
-        assertEquals(new BranchResult("l24", 244.9999975189166, 3.0000094876289114, 558.8517346879828, -244.9999975189166, -299.86040688975567, 558.8517346881861),
-                result.getPreContingencyResult().getPreContingencyBranchResults().get(0));
+        PreContingencyResult preContingencyResult = result.getPreContingencyResult();
+        List<BusResults> busResults = preContingencyResult.getPreContingencyBusResults();
+        BusResults expectedBus = new BusResults("VLLOAD", "NLOAD", 147.6, -9.6);
+        assertEquals(1, busResults.size());
+        assertAlmostEquals(expectedBus, busResults.get(0), 0.1);
 
-        assertEquals(new BranchResult("l24", 300.0000316340358, 2.999999961752837, 14224.917799052932, -300.00003163403585, -208.94326368159844, 14224.917799052939),
-                result.getPostContingencyResults().get(0).getBranchResult("l24"));
+        assertEquals(2, preContingencyResult.getPreContingencyBranchResults().size());
+        assertAlmostEquals(new BranchResult("NHV1_NHV2_1", 302, 99, 457, -300, -137.2, 489),
+                           preContingencyResult.getPreContingencyBranchResult("NHV1_NHV2_1"), 1);
+        assertAlmostEquals(new BranchResult("NGEN_NHV1", 606, 225, 15226, -605, -198, 914),
+                           preContingencyResult.getPreContingencyBranchResult("NGEN_NHV1"), 1);
+
+        //No result when the branch itself is disconnected
+        assertNull(result.getPostContingencyResults().get(0).getBranchResult("NHV1_NHV2_1"));
+
+        assertAlmostEquals(new BranchResult("NHV1_NHV2_1", 611, 334, 1009, -601, -285, 1048),
+                result.getPostContingencyResults().get(1).getBranchResult("NHV1_NHV2_1"), 1);
+        assertAlmostEquals(new BranchResult("NGEN_NHV1", 611, 368, 16815, -611, -334, 1009),
+                           result.getPostContingencyResults().get(1).getBranchResult("NGEN_NHV1"), 1);
     }
 
     @Test
     void testSAWithStateMonitorNotExistingBranchBus() {
         Network network = DistributedSlackNetworkFactory.create();
-        SecurityAnalysisParameters saParameters = new SecurityAnalysisParameters();
-        LoadFlowParameters lfParameters = new LoadFlowParameters();
-        OpenLoadFlowParameters olfParameters = new OpenLoadFlowParameters()
-                .setSlackBusSelectionMode(SlackBusSelectionMode.MOST_MESHED);
-        lfParameters.addExtension(OpenLoadFlowParameters.class, olfParameters);
-        saParameters.setLoadFlowParameters(lfParameters);
 
-        // Testing all contingencies at once
-        ContingenciesProvider contingenciesProvider = n -> n.getBranchStream()
-                .map(b -> new Contingency(b.getId(), new BranchContingency(b.getId())))
-                .collect(Collectors.toList());
+        List<StateMonitor> monitors = List.of(
+            new StateMonitor(ContingencyContext.all(), Collections.singleton("l1"), Collections.singleton("bus"), Collections.singleton("three windings"))
+        );
 
-        List<StateMonitor> monitors = new ArrayList<>();
-        monitors.add(new StateMonitor(ContingencyContext.all(), Collections.singleton("l1"), Collections.singleton("bus"), Collections.singleton("three windings")));
-
-        OpenSecurityAnalysisProvider osaProvider = new OpenSecurityAnalysisProvider(new DenseMatrixFactory(), EvenShiloachGraphDecrementalConnectivity::new);
-        CompletableFuture<SecurityAnalysisReport> futureResult = osaProvider.run(network, network.getVariantManager().getWorkingVariantId(),
-                new DefaultLimitViolationDetector(), new LimitViolationFilter(), null, saParameters,
-                contingenciesProvider, Collections.emptyList(), monitors);
-        SecurityAnalysisResult result = futureResult.join().getResult();
+        SecurityAnalysisResult result = runSecurityAnalysis(network, allBranches(network), monitors);
 
         assertEquals(0, result.getPreContingencyResult().getPreContingencyBusResults().size());
         assertEquals(0, result.getPreContingencyResult().getPreContingencyBranchResults().size());
@@ -527,106 +512,62 @@ class OpenSecurityAnalysisTest {
     void testSAWithStateMonitorDisconnectBranch() {
         Network network = DistributedSlackNetworkFactory.create();
         network.getBranch("l24").getTerminal1().disconnect();
-        SecurityAnalysisParameters saParameters = new SecurityAnalysisParameters();
-        LoadFlowParameters lfParameters = new LoadFlowParameters();
-        OpenLoadFlowParameters olfParameters = new OpenLoadFlowParameters()
-                .setSlackBusSelectionMode(SlackBusSelectionMode.MOST_MESHED);
-        lfParameters.addExtension(OpenLoadFlowParameters.class, olfParameters);
-        saParameters.setLoadFlowParameters(lfParameters);
-
-        // Testing all contingencies at once
-        ContingenciesProvider contingenciesProvider = n -> n.getBranchStream()
-                                                            .map(b -> new Contingency(b.getId(), new BranchContingency(b.getId())))
-                                                            .collect(Collectors.toList());
 
         List<StateMonitor> monitors = new ArrayList<>();
-        monitors.add(new StateMonitor(ContingencyContext.all(), Collections.singleton("l24"), Collections.singleton("b1_vl"), Collections.emptySet()));
+        monitors.add(new StateMonitor(ContingencyContext.all(), Collections.singleton("l24"), Collections.singleton("b1_vl"), emptySet()));
 
-        OpenSecurityAnalysisProvider osaProvider = new OpenSecurityAnalysisProvider(new DenseMatrixFactory(), EvenShiloachGraphDecrementalConnectivity::new);
-        CompletableFuture<SecurityAnalysisReport> futureResult = osaProvider.run(network, network.getVariantManager().getWorkingVariantId(),
-                new DefaultLimitViolationDetector(), new LimitViolationFilter(), null, saParameters,
-                contingenciesProvider, Collections.emptyList(), monitors);
-        SecurityAnalysisReport report = futureResult.join();
+        SecurityAnalysisResult result = runSecurityAnalysis(network, allBranches(network), monitors);
 
-        assertEquals(1, report.getResult().getPreContingencyResult().getPreContingencyBusResults().size());
+        assertEquals(1, result.getPreContingencyResult().getPreContingencyBusResults().size());
 
-        assertEquals(new BusResults("b1_vl", "b1", 400, 0.003581299841270782), report.getResult().getPreContingencyResult().getPreContingencyBusResults().get(0));
-        assertEquals(1, report.getResult().getPreContingencyResult().getPreContingencyBusResults().size());
+        assertEquals(new BusResults("b1_vl", "b1", 400, 0.003581299841270782), result.getPreContingencyResult().getPreContingencyBusResults().get(0));
+        assertEquals(1, result.getPreContingencyResult().getPreContingencyBusResults().size());
         assertEquals(new BranchResult("l24", NaN, NaN, NaN, 0.0, -0.0, 0.0),
-                report.getResult().getPreContingencyResult().getPreContingencyBranchResults().get(0));
+                     result.getPreContingencyResult().getPreContingencyBranchResults().get(0));
 
         network = DistributedSlackNetworkFactory.create();
         network.getBranch("l24").getTerminal2().disconnect();
 
-        futureResult = osaProvider.run(network, network.getVariantManager().getWorkingVariantId(),
-                new DefaultLimitViolationDetector(), new LimitViolationFilter(), null, saParameters,
-                contingenciesProvider, Collections.emptyList(), monitors);
-        report = futureResult.join();
+        result = runSecurityAnalysis(network, allBranches(network), monitors);
 
-        assertEquals(0, report.getResult().getPreContingencyResult().getPreContingencyBranchResults().size());
+        assertEquals(0, result.getPreContingencyResult().getPreContingencyBranchResults().size());
 
         network = DistributedSlackNetworkFactory.create();
         network.getBranch("l24").getTerminal2().disconnect();
         network.getBranch("l24").getTerminal1().disconnect();
 
-        futureResult = osaProvider.run(network, network.getVariantManager().getWorkingVariantId(),
-                new DefaultLimitViolationDetector(), new LimitViolationFilter(), null, saParameters,
-                contingenciesProvider, Collections.emptyList(), monitors);
-        report = futureResult.join();
+        result = runSecurityAnalysis(network, allBranches(network), monitors);
 
-        assertEquals(0, report.getResult().getPreContingencyResult().getPreContingencyBranchResults().size());
+        assertEquals(0, result.getPreContingencyResult().getPreContingencyBranchResults().size());
     }
 
     @Test
     void testSAWithStateMonitorDanglingLine() {
         Network network = DanglingLineFactory.create();
-        SecurityAnalysisParameters saParameters = new SecurityAnalysisParameters();
-        LoadFlowParameters lfParameters = new LoadFlowParameters();
-        OpenLoadFlowParameters olfParameters = new OpenLoadFlowParameters()
-                .setSlackBusSelectionMode(SlackBusSelectionMode.MOST_MESHED);
-        lfParameters.addExtension(OpenLoadFlowParameters.class, olfParameters);
-        saParameters.setLoadFlowParameters(lfParameters);
-
-        // Testing all contingencies at once
-        ContingenciesProvider contingenciesProvider = n -> n.getBranchStream()
-                .map(b -> new Contingency(b.getId(), new BranchContingency(b.getId())))
-                .collect(Collectors.toList());
 
         List<StateMonitor> monitors = new ArrayList<>();
-        monitors.add(new StateMonitor(ContingencyContext.all(), Collections.singleton("dl1"), Collections.singleton("vl1"), Collections.emptySet()));
+        monitors.add(new StateMonitor(ContingencyContext.all(), Collections.singleton("dl1"), Collections.singleton("vl1"), emptySet()));
 
-        OpenSecurityAnalysisProvider osaProvider = new OpenSecurityAnalysisProvider(new DenseMatrixFactory(), EvenShiloachGraphDecrementalConnectivity::new);
-        CompletableFuture<SecurityAnalysisReport> futureResult = osaProvider.run(network, network.getVariantManager().getWorkingVariantId(),
-                new DefaultLimitViolationDetector(), new LimitViolationFilter(), null, saParameters,
-                contingenciesProvider, Collections.emptyList(), monitors);
-
-        CompletionException exception = assertThrows(CompletionException.class, futureResult::join);
+        CompletionException exception = assertThrows(CompletionException.class, () -> runSecurityAnalysis(network, allBranches(network), monitors));
         assertEquals("Unsupported type of branch for branch result: dl1", exception.getCause().getMessage());
+    }
+
+    private static List<Contingency> allBranches(Network network) {
+        return network.getBranchStream()
+            .map(b -> new Contingency(b.getId(), new BranchContingency(b.getId())))
+            .collect(Collectors.toList());
     }
 
     @Test
     void testSAWithStateMonitorLfLeg() {
         Network network = T3wtFactory.create();
-        SecurityAnalysisParameters saParameters = new SecurityAnalysisParameters();
-        LoadFlowParameters lfParameters = new LoadFlowParameters();
-        OpenLoadFlowParameters olfParameters = new OpenLoadFlowParameters()
-                .setSlackBusSelectionMode(SlackBusSelectionMode.MOST_MESHED);
-        lfParameters.addExtension(OpenLoadFlowParameters.class, olfParameters);
-        saParameters.setLoadFlowParameters(lfParameters);
 
         // Testing all contingencies at once
-        ContingenciesProvider contingenciesProvider = n -> n.getBranchStream()
-                .map(b -> new Contingency(b.getId(), new BranchContingency(b.getId())))
-                .collect(Collectors.toList());
+        List<StateMonitor> monitors = List.of(
+            new StateMonitor(ContingencyContext.all(), emptySet(), emptySet(), Collections.singleton("3wt"))
+        );
 
-        List<StateMonitor> monitors = new ArrayList<>();
-        monitors.add(new StateMonitor(ContingencyContext.all(), Collections.emptySet(), Collections.emptySet(), Collections.singleton("3wt")));
-
-        OpenSecurityAnalysisProvider osaProvider = new OpenSecurityAnalysisProvider(new DenseMatrixFactory(), EvenShiloachGraphDecrementalConnectivity::new);
-        CompletableFuture<SecurityAnalysisReport> futureResult = osaProvider.run(network, network.getVariantManager().getWorkingVariantId(),
-                new DefaultLimitViolationDetector(), new LimitViolationFilter(), null, saParameters,
-                contingenciesProvider, Collections.emptyList(), monitors);
-        SecurityAnalysisResult result = futureResult.join().getResult();
+        SecurityAnalysisResult result = runSecurityAnalysis(network, allBranches(network), monitors);
 
         assertEquals(1, result.getPreContingencyResult().getPreContingencyThreeWindingsTransformerResults().size());
         assertEquals(new ThreeWindingsTransformerResult("3wt", 1.6109556638123288,
@@ -674,5 +615,48 @@ class OpenSecurityAnalysisTest {
 
         StringWriter writer = new StringWriter();
         Security.print(result, fourBusNetwork, writer, new AsciiTableFormatterFactory(), new TableFormatterConfig());
+    }
+
+    private static void assertAlmostEquals(BusResults expected, BusResults actual, double epsilon) {
+        assertEquals(expected.getVoltageLevelId(), actual.getVoltageLevelId());
+        assertEquals(expected.getBusId(), actual.getBusId());
+        assertEquals(expected.getV(), actual.getV(), epsilon);
+        assertEquals(expected.getAngle(), actual.getAngle(), epsilon);
+    }
+
+    private static void assertAlmostEquals(BranchResult expected, BranchResult actual, double epsilon) {
+        assertEquals(expected.getBranchId(), actual.getBranchId());
+        assertEquals(expected.getP1(), actual.getP1(), epsilon);
+        assertEquals(expected.getQ1(), actual.getQ1(), epsilon);
+        assertEquals(expected.getI1(), actual.getI1(), epsilon);
+        assertEquals(expected.getP2(), actual.getP2(), epsilon);
+        assertEquals(expected.getQ2(), actual.getQ2(), epsilon);
+        assertEquals(expected.getI2(), actual.getI2(), epsilon);
+    }
+
+    /**
+     * Runs a security analysis with default parameters + most meshed slack bus selection
+     */
+    private static SecurityAnalysisResult runSecurityAnalysis(Network network, List<Contingency> contingencies, List<StateMonitor> monitors) {
+
+        SecurityAnalysisParameters saParameters = new SecurityAnalysisParameters();
+        LoadFlowParameters lfParameters = new LoadFlowParameters();
+        OpenLoadFlowParameters olfParameters = new OpenLoadFlowParameters()
+            .setSlackBusSelectionMode(SlackBusSelectionMode.MOST_MESHED);
+        lfParameters.addExtension(OpenLoadFlowParameters.class, olfParameters);
+        saParameters.setLoadFlowParameters(lfParameters);
+
+        ContingenciesProvider provider = n -> contingencies;
+        OpenSecurityAnalysisProvider osaProvider = new OpenSecurityAnalysisProvider(new DenseMatrixFactory(), EvenShiloachGraphDecrementalConnectivity::new);
+        CompletableFuture<SecurityAnalysisReport> futureResult = osaProvider.run(network,
+                                                                                 network.getVariantManager().getWorkingVariantId(),
+                                                                                 new DefaultLimitViolationDetector(),
+                                                                                 new LimitViolationFilter(),
+                                                                                 null,
+                                                                                 saParameters,
+                                                                                 provider,
+                                                                                 Collections.emptyList(),
+                                                                                 monitors);
+        return futureResult.join().getResult();
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -548,7 +548,8 @@ class OpenSecurityAnalysisTest {
         List<StateMonitor> monitors = new ArrayList<>();
         monitors.add(new StateMonitor(ContingencyContext.all(), Collections.singleton("dl1"), Collections.singleton("vl1"), emptySet()));
 
-        CompletionException exception = assertThrows(CompletionException.class, () -> runSecurityAnalysis(network, allBranches(network), monitors));
+        List<Contingency> contingencies = allBranches(network);
+        CompletionException exception = assertThrows(CompletionException.class, () -> runSecurityAnalysis(network, contingencies, monitors));
         assertEquals("Unsupported type of branch for branch result: dl1", exception.getCause().getMessage());
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

#327 

In addition, the value of `q1` was not correctly unscaled.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bug

**What is the current behavior?** *(You can also link to an open issue here)*

Static variables are used for the nominal voltages of branches, which leads to using the same nominal voltage to unscale the currents of all branches of the network.
In addition, the value of `q1` was not correctly unscaled.

**What is the new behavior (if this is a feature change)?**

Current values and q1 are correctly unscaled. Unit tests are adapted in order to go over that kind of case.
