### PR TITLE
Clean up per-uniting

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractBranchAcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractBranchAcFlowEquationTerm.java
@@ -19,8 +19,6 @@ import java.util.Objects;
  */
 abstract class AbstractBranchAcFlowEquationTerm extends AbstractNamedEquationTerm {
 
-    public static final double CURRENT_NORMALIZATION_FACTOR = 1000d / Math.sqrt(3d);
-
     protected final LfBranch branch;
 
     protected final double b1;

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide1CurrentMagnitudeEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide1CurrentMagnitudeEquationTerm.java
@@ -66,19 +66,19 @@ public class ClosedBranchSide1CurrentMagnitudeEquationTerm extends AbstractClose
         double interReI1 = g1 * cosPh1 - b1 * sinPh1 + y * sinPh1Ksi;
         double interImI1 = g1 * sinPh1 + b1 * cosPh1 - y * cosPh1Ksi;
 
-        double reI1 = r1 * (w1 * interReI1 - w2 * sinTheta) * CURRENT_NORMALIZATION_FACTOR;
-        double imI1 = r1 * (w1 * interImI1 + w2 * cosTheta) * CURRENT_NORMALIZATION_FACTOR;
+        double reI1 = r1 * (w1 * interReI1 - w2 * sinTheta);
+        double imI1 = r1 * (w1 * interImI1 + w2 * cosTheta);
         i1 = Math.hypot(reI1, imI1);
 
-        double dreI1dv1 = r1 * r1 * interReI1 * CURRENT_NORMALIZATION_FACTOR;
-        double dreI1dv2 = r1 * (-y * R2 * sinTheta) * CURRENT_NORMALIZATION_FACTOR;
-        double dreI1dph1 = r1 * w1 * (-g1 * sinPh1 - b1 * cosPh1 + y * cosPh1Ksi) * CURRENT_NORMALIZATION_FACTOR;
-        double dreI1dph2 = r1 * (-w2 * cosTheta) * CURRENT_NORMALIZATION_FACTOR;
+        double dreI1dv1 = r1 * r1 * interReI1;
+        double dreI1dv2 = r1 * (-y * R2 * sinTheta);
+        double dreI1dph1 = r1 * w1 * (-g1 * sinPh1 - b1 * cosPh1 + y * cosPh1Ksi);
+        double dreI1dph2 = r1 * (-w2 * cosTheta);
 
-        double dimI1dv1 = r1 * r1 * interImI1 * CURRENT_NORMALIZATION_FACTOR;
-        double dimI1dv2 = r1 * (y * R2 * cosTheta) * CURRENT_NORMALIZATION_FACTOR;
-        double dimI1dph1 = r1 * w1 * interReI1 * CURRENT_NORMALIZATION_FACTOR;
-        double dimI1dph2 = r1 * (-w2 * sinTheta) * CURRENT_NORMALIZATION_FACTOR;
+        double dimI1dv1 = r1 * r1 * interImI1;
+        double dimI1dv2 = r1 * (y * R2 * cosTheta);
+        double dimI1dph1 = r1 * w1 * interReI1;
+        double dimI1dph2 = r1 * (-w2 * sinTheta);
 
         di1dv1 = (reI1 * dreI1dv1 + imI1 * dimI1dv1) / i1;
         di1dv2 = (reI1 * dreI1dv2 + imI1 * dimI1dv2) / i1;

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide2CurrentMagnitudeEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide2CurrentMagnitudeEquationTerm.java
@@ -66,19 +66,19 @@ public class ClosedBranchSide2CurrentMagnitudeEquationTerm extends AbstractClose
         double interReI2 = g2 * cosPh2 - b2 * sinPh2 + y * sinPh2Ksi;
         double interImI2 = g2 * sinPh2 + b2 * cosPh2 - y * cosPh2Ksi;
 
-        double reI2 = R2 * (w2 * interReI2 - w1 * sinTheta) * CURRENT_NORMALIZATION_FACTOR;
-        double imI2 = R2 * (w2 * interImI2 + w1 * cosTheta) * CURRENT_NORMALIZATION_FACTOR;
+        double reI2 = R2 * (w2 * interReI2 - w1 * sinTheta);
+        double imI2 = R2 * (w2 * interImI2 + w1 * cosTheta);
         i2 = Math.hypot(reI2, imI2);
 
-        double dreI2dv2 = R2 * R2 * interReI2 * CURRENT_NORMALIZATION_FACTOR;
-        double dreI2dv1 = R2 * (-y * r1 * sinTheta) * CURRENT_NORMALIZATION_FACTOR;
-        double dreI2dph2 = R2 * w2 * (-g2 * sinPh2 - b2 * cosPh2 + y * cosPh2Ksi) * CURRENT_NORMALIZATION_FACTOR;
-        double dreI2dph1 = R2 * (-w1 * cosTheta) * CURRENT_NORMALIZATION_FACTOR;
+        double dreI2dv2 = R2 * R2 * interReI2;
+        double dreI2dv1 = R2 * (-y * r1 * sinTheta);
+        double dreI2dph2 = R2 * w2 * (-g2 * sinPh2 - b2 * cosPh2 + y * cosPh2Ksi);
+        double dreI2dph1 = R2 * (-w1 * cosTheta);
 
-        double dimI2dv2 = R2 * R2 * interImI2 * CURRENT_NORMALIZATION_FACTOR;
-        double dimI2dv1 = R2 * (y * r1 * cosTheta) * CURRENT_NORMALIZATION_FACTOR;
-        double dimI2dph2 = R2 * w2 * interReI2 * CURRENT_NORMALIZATION_FACTOR;
-        double dimI2dph1 = R2 * (-w1 * sinTheta) * CURRENT_NORMALIZATION_FACTOR;
+        double dimI2dv2 = R2 * R2 * interImI2;
+        double dimI2dv1 = R2 * (y * r1 * cosTheta);
+        double dimI2dph2 = R2 * w2 * interReI2;
+        double dimI2dph1 = R2 * (-w1 * sinTheta);
 
         di2dv2 = (reI2 * dreI2dv2 + imI2 * dimI2dv2) / i2;
         di2dv1 = (reI2 * dreI2dv1 + imI2 * dimI2dv1) / i2;

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide1CurrentMagnitudeEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide1CurrentMagnitudeEquationTerm.java
@@ -49,13 +49,13 @@ public class OpenBranchSide1CurrentMagnitudeEquationTerm extends AbstractOpenSid
         double gres = g2 + (y * y * g1 + (b1 * b1 + g1 * g1) * y * sinKsi) / shunt;
         double bres = b2 + (y * y * b1 - (b1 * b1 + g1 * g1) * y * cosKsi) / shunt;
 
-        double reI2 = R2 * w2 * (gres * cosPh2 - bres * sinPh2) * CURRENT_NORMALIZATION_FACTOR;
-        double imI2 = R2 * w2 * (gres * sinPh2 + bres * cosPh2) * CURRENT_NORMALIZATION_FACTOR;
+        double reI2 = R2 * w2 * (gres * cosPh2 - bres * sinPh2);
+        double imI2 = R2 * w2 * (gres * sinPh2 + bres * cosPh2);
         i2 = Math.hypot(reI2, imI2);
 
-        double dreI2dv2 = R2 * R2 * (gres * cosPh2 - bres * sinPh2) * CURRENT_NORMALIZATION_FACTOR;
+        double dreI2dv2 = R2 * R2 * (gres * cosPh2 - bres * sinPh2);
 
-        double dimI2dv2 = R2 * R2 * (gres * sinPh2 + bres * cosPh2) * CURRENT_NORMALIZATION_FACTOR;
+        double dimI2dv2 = R2 * R2 * (gres * sinPh2 + bres * cosPh2);
         di2dv2 = (reI2 * dreI2dv2 + imI2 * dimI2dv2) / i2;
     }
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide2CurrentMagnitudeEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide2CurrentMagnitudeEquationTerm.java
@@ -53,13 +53,13 @@ public class OpenBranchSide2CurrentMagnitudeEquationTerm extends AbstractOpenSid
         double gres = g1 + (y * y * g2 + (b2 * b2 + g2 * g2) * y * sinKsi) / shunt;
         double bres = b1 + (y * y * b2 - (b2 * b2 + g2 * g2) * y * cosKsi) / shunt;
 
-        double reI1 = r1 * w1 * (gres * cosPh1 - bres * sinPh1) * CURRENT_NORMALIZATION_FACTOR;
-        double imI1 = r1 * w1 * (gres * sinPh1 + bres * cosPh1) * CURRENT_NORMALIZATION_FACTOR;
+        double reI1 = r1 * w1 * (gres * cosPh1 - bres * sinPh1);
+        double imI1 = r1 * w1 * (gres * sinPh1 + bres * cosPh1);
         i1 = Math.hypot(reI1, imI1);
 
-        double dreI1dv1 = r1 * r1 * (gres * cosPh1 - bres * sinPh1) * CURRENT_NORMALIZATION_FACTOR;
+        double dreI1dv1 = r1 * r1 * (gres * cosPh1 - bres * sinPh1);
 
-        double dimI1dv1 = r1 * r1 * (gres * sinPh1 + bres * cosPh1) * CURRENT_NORMALIZATION_FACTOR;
+        double dimI1dv1 = r1 * r1 * (gres * sinPh1 + bres * cosPh1);
         di1dv1 = (reI1 * dreI1dv1 + imI1 * dimI1dv1) / i1;
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/AbstractLfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractLfBranch.java
@@ -192,7 +192,7 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
             case APPARENT_POWER:
                 return 1.0 / PerUnit.SB;
             case CURRENT:
-                return bus.getNominalV() / PerUnit.SB;
+                return 1.0 / PerUnit.ib(bus.getNominalV());
             case VOLTAGE:
             default:
                 throw new UnsupportedOperationException(String.format("Getting scale for limit type %s is not supported.", type));

--- a/src/main/java/com/powsybl/openloadflow/network/PerUnit.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PerUnit.java
@@ -12,6 +12,15 @@ package com.powsybl.openloadflow.network;
 public final class PerUnit {
 
     public static final double SB = 100d;
+    public static final double SQRT_3 = Math.sqrt(3);
+    public static final double BASE_CURRENT_FACTOR = (1000d * SB) / SQRT_3;
+
+    /**
+     * Base current value for a given nominal voltage.
+     */
+    public static double ib(double nominalV) {
+        return BASE_CURRENT_FACTOR / nominalV;
+    }
 
     private PerUnit() {
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -200,21 +200,27 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
         // note that LCC converter station are out of the slack distribution.
         lccCss.add(lccCs);
         HvdcLine line = lccCs.getHvdcLine();
-        double targetP = getLccConverterStationLoadTargetP(lccCs, line);
+        double targetP = PerUnit.SB * getLccConverterStationLoadTargetP(lccCs, line);
         loadTargetP += targetP;
         initialLoadTargetP += targetP;
-        loadTargetQ += getLccConverterStationLoadTargetQ(lccCs, line);
+        loadTargetQ += PerUnit.SB * getLccConverterStationLoadTargetQ(lccCs, line);
     }
 
+    /**
+     * Gets active power for an LCC station in per-unit.
+     */
     public static double getLccConverterStationLoadTargetP(LccConverterStation lccCs, HvdcLine line) {
         // The active power setpoint is always positive.
         // If the converter station is at side 1 and is rectifier, p should be positive.
         // If the converter station is at side 1 and is inverter, p should be negative.
         // If the converter station is at side 2 and is rectifier, p should be positive.
         // If the converter station is at side 2 and is inverter, p should be negative.
-        return line.getActivePowerSetpoint() * HvdcConverterStations.getActivePowerSetpointMultiplier(lccCs); // A LCC station has active losses.
+        return line.getActivePowerSetpoint() / PerUnit.SB * HvdcConverterStations.getActivePowerSetpointMultiplier(lccCs); // A LCC station has active losses.
     }
 
+    /**
+     * Gets reactive power for an LCC station in per-unit.
+     */
     public static double getLccConverterStationLoadTargetQ(LccConverterStation lccCs, HvdcLine line) {
         // The active power setpoint is always positive.
         // If the converter station is at side 1 and is rectifier, p should be positive.

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
@@ -203,8 +203,8 @@ public class LfBranchImpl extends AbstractLfBranch {
 
     @Override
     public BranchResult createBranchResult() {
-        double currentScale1 = PerUnit.SB / branch.getTerminal1().getVoltageLevel().getNominalV();
-        double currentScale2 = PerUnit.SB / branch.getTerminal2().getVoltageLevel().getNominalV();
+        double currentScale1 = PerUnit.ib(branch.getTerminal1().getVoltageLevel().getNominalV());
+        double currentScale2 = PerUnit.ib(branch.getTerminal2().getVoltageLevel().getNominalV());
         return new BranchResult(getId(), p1.eval() * PerUnit.SB, q1.eval() * PerUnit.SB, currentScale1 * i1.eval(),
                                 p2.eval() * PerUnit.SB, q2.eval() * PerUnit.SB, currentScale2 * i2.eval());
     }

--- a/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
@@ -117,7 +117,7 @@ public abstract class AbstractSecurityAnalysis {
             branch.getLimits1(LimitType.CURRENT).stream()
                 .filter(temporaryLimit1 -> branch.getI1().eval() > temporaryLimit1.getValue())
                 .findFirst()
-                .map(temporaryLimit1 -> createLimitViolation1(branch, temporaryLimit1, LimitViolationType.CURRENT, PerUnit.SB / branch.getBus1().getNominalV(), branch.getI1().eval()))
+                .map(temporaryLimit1 -> createLimitViolation1(branch, temporaryLimit1, LimitViolationType.CURRENT, PerUnit.ib(branch.getBus1().getNominalV()), branch.getI1().eval()))
                 .ifPresent(limitViolation -> violations.put(getSubjectSideId(limitViolation), limitViolation));
 
             branch.getLimits1(LimitType.ACTIVE_POWER).stream()
@@ -141,7 +141,7 @@ public abstract class AbstractSecurityAnalysis {
             branch.getLimits2(LimitType.CURRENT).stream()
                 .filter(temporaryLimit2 -> branch.getI2().eval() > temporaryLimit2.getValue())
                 .findFirst() // only the most serious violation is added (the limits are sorted in descending gravity)
-                .map(temporaryLimit2 -> createLimitViolation2(branch, temporaryLimit2, LimitViolationType.CURRENT, PerUnit.SB / branch.getBus2().getNominalV(), branch.getI2().eval()))
+                .map(temporaryLimit2 -> createLimitViolation2(branch, temporaryLimit2, LimitViolationType.CURRENT, PerUnit.ib(branch.getBus2().getNominalV()), branch.getI2().eval()))
                 .ifPresent(limitViolation -> violations.put(getSubjectSideId(limitViolation), limitViolation));
 
             branch.getLimits2(LimitType.ACTIVE_POWER).stream()
@@ -248,8 +248,12 @@ public abstract class AbstractSecurityAnalysis {
         LfBranch leg1 = network.getBranchById(threeWindingsTransformerId + "_leg_1");
         LfBranch leg2 = network.getBranchById(threeWindingsTransformerId + "_leg_2");
         LfBranch leg3 = network.getBranchById(threeWindingsTransformerId + "_leg_3");
-        return new ThreeWindingsTransformerResult(threeWindingsTransformerId, leg1.getP1().eval(), leg1.getQ1().eval(), leg1.getI1().eval(),
-                leg2.getP1().eval(), leg2.getQ1().eval(), leg2.getI1().eval(),
-                leg3.getP1().eval(), leg3.getQ1().eval(), leg3.getI1().eval());
+        double i1Base = PerUnit.ib(leg1.getBus1().getNominalV());
+        double i2Base = PerUnit.ib(leg2.getBus1().getNominalV());
+        double i3Base = PerUnit.ib(leg3.getBus1().getNominalV());
+        return new ThreeWindingsTransformerResult(threeWindingsTransformerId,
+                leg1.getP1().eval() * PerUnit.SB, leg1.getQ1().eval() * PerUnit.SB, leg1.getI1().eval() * i1Base,
+                leg2.getP1().eval() * PerUnit.SB, leg2.getQ1().eval() * PerUnit.SB, leg2.getI1().eval() * i2Base,
+                leg3.getP1().eval() * PerUnit.SB, leg3.getQ1().eval() * PerUnit.SB, leg3.getI1().eval() * i3Base);
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
@@ -472,7 +472,7 @@ public abstract class AbstractSensitivityAnalysis {
                     if (!v.isActive()) {
                         return;
                     }
-                    rhs.set(v.getColumn(), getIndex(), 1d / ((LfBus) variableElement).getNominalV() / PerUnit.SB);
+                    rhs.set(v.getColumn(), getIndex(), 1d);
                     break;
                 default:
                     throw new NotImplementedException("Variable type " + variableType + " is not implemented");

--- a/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
@@ -75,43 +75,15 @@ public class AcSensitivityAnalysis extends AbstractSensitivityAnalysis {
                     sensi += Math.toRadians(factor.getEquationTerm().der(phi1Var));
                 }
 
-                if (SensitivityFunctionType.BUS_VOLTAGE.equals(factor.getFunctionType())) {
-                    sensi *= ((LfBus) factor.getFunctionElement()).getNominalV();
-                } else if (SensitivityFunctionType.BRANCH_CURRENT.equals(factor.getFunctionType())) {
-                    sensi *= PerUnit.ib(((LfBranch) factor.getFunctionElement()).getBus1().getNominalV());
-                } else if (SensitivityFunctionType.BRANCH_ACTIVE_POWER.equals(factor.getFunctionType())) {
-                    sensi *= PerUnit.SB;
-                }
-
-                if (SensitivityVariableType.BUS_TARGET_VOLTAGE.equals(factor.getVariableType())) {
-                    LfBus bus = (LfBus) ((SingleVariableLfSensitivityFactor) factor).getVariableElement();
-                    sensi /= bus.getNominalV();
-                }
-                valueWriter.write(factor.getContext(), contingencyId, contingencyIndex, sensi, factor.getFunctionReference());
+                valueWriter.write(factor.getContext(), contingencyId, contingencyIndex,
+                                  unscaleSensitivity(factor, sensi), unscaleFunction(factor, factor.getFunctionReference()));
             }
         }
     }
 
     protected void setFunctionReferences(List<LfSensitivityFactor> factors) {
         for (LfSensitivityFactor factor : factors) {
-            double functionRef = factor.getEquationTerm().eval();
-            double baseValue;
-            switch (factor.getFunctionType()) {
-                case BRANCH_ACTIVE_POWER:
-                    baseValue = PerUnit.SB;
-                    break;
-                case BRANCH_CURRENT:
-                    LfBranch branch = (LfBranch) factor.getFunctionElement();
-                    baseValue = PerUnit.ib(branch.getBus1().getNominalV());
-                    break;
-                case BUS_VOLTAGE:
-                    LfBus bus = (LfBus) factor.getFunctionElement();
-                    baseValue = bus.getNominalV();
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unknown function type " + factor.getFunctionType());
-            }
-            factor.setFunctionReference(baseValue * functionRef);
+            factor.setFunctionReference(factor.getEquationTerm().eval());
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -233,8 +233,9 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis {
                 sensiValue = 0d;
             }
         }
+
         valueWriter.write(factor.getContext(), contingency != null ? contingency.getContingency().getId() : null, contingency != null ? contingency.getIndex() : -1,
-                sensiValue * PerUnit.SB, flowValue * PerUnit.SB);
+                          unscaleSensitivity(factor, sensiValue), unscaleFunction(factor, flowValue));
     }
 
     protected void setBaseCaseSensitivityValues(List<SensitivityFactorGroup> factorGroups, DenseMatrix factorsState) {
@@ -275,7 +276,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis {
             LfBranch lfBranch = element.getLfBranch();
             ClosedBranchSide1DcFlowEquationTerm p1 = element.getLfBranchEquation();
             // we solve a*alpha = b
-            double a = lfBranch.getPiModel().getX() / PerUnit.SB - (contingenciesStates.get(p1.getVariables().get(0).getRow(), element.getContingencyIndex())
+            double a = lfBranch.getPiModel().getX() - (contingenciesStates.get(p1.getVariables().get(0).getRow(), element.getContingencyIndex())
                     - contingenciesStates.get(p1.getVariables().get(1).getRow(), element.getContingencyIndex()));
             double b = states.get(p1.getVariables().get(0).getRow(), columnState) - states.get(p1.getVariables().get(1).getRow(), columnState);
             setValue.accept(element, b / a);
@@ -293,7 +294,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis {
                 for (ComputedContingencyElement element2 : contingencyElements) {
                     double value = 0d;
                     if (element.equals(element2)) {
-                        value = lfBranch.getPiModel().getX() / PerUnit.SB;
+                        value = lfBranch.getPiModel().getX();
                     }
                     value = value - (contingenciesStates.get(p1.getVariables().get(0).getRow(), element2.getContingencyIndex())
                             - contingenciesStates.get(p1.getVariables().get(1).getRow(), element2.getContingencyIndex()));
@@ -326,7 +327,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis {
                 }
                 sum += value;
             }
-            if (sum * PerUnit.SB > 1d - CONNECTIVITY_LOSS_THRESHOLD) {
+            if (sum > 1d - CONNECTIVITY_LOSS_THRESHOLD) {
                 // all lines that have a non-0 sensitivity associated to "element" breaks the connectivity
                 groupOfElementsBreakingConnectivity.addAll(responsibleElements);
             }
@@ -345,15 +346,15 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis {
             LfBus bus2 = lfBranch.getBus2();
             if (bus1.isSlack()) {
                 Equation p = equationSystem.getEquation(bus2.getNum(), EquationType.BUS_P).orElseThrow(IllegalStateException::new);
-                rhs.set(p.getColumn(), element.getContingencyIndex(), -1 / PerUnit.SB);
+                rhs.set(p.getColumn(), element.getContingencyIndex(), -1);
             } else if (bus2.isSlack()) {
                 Equation p = equationSystem.getEquation(bus1.getNum(), EquationType.BUS_P).orElseThrow(IllegalStateException::new);
-                rhs.set(p.getColumn(), element.getContingencyIndex(), 1 / PerUnit.SB);
+                rhs.set(p.getColumn(), element.getContingencyIndex(), 1);
             } else {
                 Equation p1 = equationSystem.getEquation(bus1.getNum(), EquationType.BUS_P).orElseThrow(IllegalStateException::new);
                 Equation p2 = equationSystem.getEquation(bus2.getNum(), EquationType.BUS_P).orElseThrow(IllegalStateException::new);
-                rhs.set(p1.getColumn(), element.getContingencyIndex(), 1 / PerUnit.SB);
-                rhs.set(p2.getColumn(), element.getContingencyIndex(), -1 / PerUnit.SB);
+                rhs.set(p1.getColumn(), element.getContingencyIndex(), 1);
+                rhs.set(p2.getColumn(), element.getContingencyIndex(), -1);
             }
         }
     }
@@ -561,7 +562,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis {
             LfBus bus = busAndlcc.getKey();
             LccConverterStation lcc = busAndlcc.getValue();
             HvdcLine line = lcc.getHvdcLine();
-            bus.setLoadTargetP(bus.getLoadTargetP() - AbstractLfBus.getLccConverterStationLoadTargetP(lcc, line) / PerUnit.SB);
+            bus.setLoadTargetP(bus.getLoadTargetP() - AbstractLfBus.getLccConverterStationLoadTargetP(lcc, line));
         }
 
         for (LfVscConverterStationImpl vsc : vscs) {

--- a/src/test/java/com/powsybl/openloadflow/OperationalLimitsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/OperationalLimitsTest.java
@@ -58,16 +58,16 @@ class OperationalLimitsTest extends AbstractLoadFlowNetworkFactory {
         assertTrue(branch2.getI2().eval() < getLimitValueFromAcceptableDuration(branch2, Integer.MAX_VALUE, Branch.Side.TWO, LimitType.CURRENT));
         LfBranch branch3 = lfNetwork.getBranchById("NGEN_NHV1");
         assertEquals(Double.NaN, getLimitValueFromAcceptableDuration(branch3, Integer.MAX_VALUE, Branch.Side.ONE, LimitType.CURRENT));
-        assertEquals(3654.18, branch3.getI1().eval(), DELTA);
+        assertEquals(6.329, branch3.getI1().eval(), DELTA);
         LfBranch branch4 = lfNetwork.getBranchById("NHV2_NLOAD");
         assertEquals(Double.NaN, getLimitValueFromAcceptableDuration(branch4, Integer.MAX_VALUE, Branch.Side.TWO, LimitType.CURRENT));
-        assertEquals(3711.395, branch4.getI2().eval(), DELTA);
-        assertEquals(4180.0, getLimitValueFromAcceptableDuration(branch2, 1200, Branch.Side.ONE, LimitType.CURRENT), DELTA);
-        assertEquals(4560.0, getLimitValueFromAcceptableDuration(branch2, 60, Branch.Side.ONE, LimitType.CURRENT), DELTA);
-        assertEquals(5700.0, getLimitValueFromAcceptableDuration(branch1, 0, Branch.Side.TWO, LimitType.CURRENT), DELTA);
-        assertEquals(4180.0, getLimitValueFromAcceptableDuration(branch1, 600, Branch.Side.TWO, LimitType.CURRENT), DELTA);
-        assertEquals(4560.0, getLimitValueFromAcceptableDuration(branch1, 60, Branch.Side.TWO, LimitType.CURRENT), DELTA);
-        assertEquals(5700.0, getLimitValueFromAcceptableDuration(branch1, 0, Branch.Side.TWO, LimitType.CURRENT), DELTA);
+        assertEquals(6.428324, branch4.getI2().eval(), DELTA);
+        assertEquals(7.239972, getLimitValueFromAcceptableDuration(branch2, 1200, Branch.Side.ONE, LimitType.CURRENT), DELTA);
+        assertEquals(7.898151, getLimitValueFromAcceptableDuration(branch2, 60, Branch.Side.ONE, LimitType.CURRENT), DELTA);
+        assertEquals(9.872689, getLimitValueFromAcceptableDuration(branch1, 0, Branch.Side.TWO, LimitType.CURRENT), DELTA);
+        assertEquals(7.239972, getLimitValueFromAcceptableDuration(branch1, 600, Branch.Side.TWO, LimitType.CURRENT), DELTA);
+        assertEquals(7.898151, getLimitValueFromAcceptableDuration(branch1, 60, Branch.Side.TWO, LimitType.CURRENT), DELTA);
+        assertEquals(9.872689, getLimitValueFromAcceptableDuration(branch1, 0, Branch.Side.TWO, LimitType.CURRENT), DELTA);
     }
 
     private double getLimitValueFromAcceptableDuration(LfBranch branch, int acceptableDuration, Branch.Side side, LimitType type) {
@@ -87,12 +87,12 @@ class OperationalLimitsTest extends AbstractLoadFlowNetworkFactory {
         AcloadFlowEngine engine = new AcloadFlowEngine(lfNetwork, acParameters);
         engine.run();
         LfBranch branch = lfNetwork.getBranchById("DL");
-        assertEquals(361.588, branch.getI1().eval(), DELTA);
+        assertEquals(0.626, branch.getI1().eval(), DELTA);
         assertTrue(Double.isNaN(branch.getI2().eval()));
         assertEquals(Double.NaN, getLimitValueFromAcceptableDuration(branch, Integer.MAX_VALUE, Branch.Side.TWO, LimitType.CURRENT), DELTA);
-        assertEquals(100, getLimitValueFromAcceptableDuration(branch, 1200, Branch.Side.ONE, LimitType.CURRENT), DELTA);
-        assertEquals(120, getLimitValueFromAcceptableDuration(branch, 600, Branch.Side.ONE, LimitType.CURRENT), DELTA);
-        assertEquals(140, getLimitValueFromAcceptableDuration(branch, 0, Branch.Side.ONE, LimitType.CURRENT), DELTA);
+        assertEquals(0.173205, getLimitValueFromAcceptableDuration(branch, 1200, Branch.Side.ONE, LimitType.CURRENT), DELTA);
+        assertEquals(0.207846, getLimitValueFromAcceptableDuration(branch, 600, Branch.Side.ONE, LimitType.CURRENT), DELTA);
+        assertEquals(0.242487, getLimitValueFromAcceptableDuration(branch, 0, Branch.Side.ONE, LimitType.CURRENT), DELTA);
         assertTrue(branch.getLimits2(LimitType.CURRENT).isEmpty());
     }
 
@@ -106,7 +106,7 @@ class OperationalLimitsTest extends AbstractLoadFlowNetworkFactory {
         AcloadFlowEngine engine = new AcloadFlowEngine(lfNetwork, acParameters);
         engine.run();
         LfBranch branch1 = lfNetwork.getBranchById("3WT_leg_1");
-        assertEquals(660.702, branch1.getI1().eval(), DELTA);
+        assertEquals(1.144, branch1.getI1().eval(), DELTA);
         assertTrue(Double.isNaN(branch1.getI2().eval()));
         assertEquals(Double.NaN, getLimitValueFromAcceptableDuration(branch1, Integer.MAX_VALUE, Branch.Side.ONE, LimitType.CURRENT), DELTA);
         assertEquals(Double.NaN, getLimitValueFromAcceptableDuration(branch1, Integer.MAX_VALUE, Branch.Side.TWO, LimitType.CURRENT), DELTA);

--- a/src/test/java/com/powsybl/openloadflow/equations/EquationSystemTest.java
+++ b/src/test/java/com/powsybl/openloadflow/equations/EquationSystemTest.java
@@ -199,14 +199,14 @@ class EquationSystemTest {
         Variable v2var = variableSet.getVariable(branch.getBus2().getNum(), VariableType.BUS_V);
         Variable ph1var = variableSet.getVariable(branch.getBus1().getNum(), VariableType.BUS_PHI);
         Variable ph2var = variableSet.getVariable(branch.getBus2().getNum(), VariableType.BUS_PHI);
-        assertEquals(-24895.468, i1.der(v1var), 10E-3);
-        assertEquals(25056.371, i1.der(v2var), 10E-3);
-        assertEquals(2277.852, i1.der(ph1var), 10E-3);
-        assertEquals(-2277.852, i1.der(ph2var), 10E-3);
-        assertEquals(25056.371, i2.der(v1var), 10E-3);
-        assertEquals(-24895.468, i2.der(v2var), 10E-3);
-        assertEquals(-2277.852, i2.der(ph1var), 10E-3);
-        assertEquals(2277.852, i2.der(ph2var), 10E-3);
+        assertEquals(-43.120215, i1.der(v1var), 10E-6);
+        assertEquals(43.398907, i1.der(v2var), 10E-6);
+        assertEquals(3.945355, i1.der(ph1var), 10E-6);
+        assertEquals(-3.945355, i1.der(ph2var), 10E-6);
+        assertEquals(43.398907, i2.der(v1var), 10E-6);
+        assertEquals(-43.120215, i2.der(v2var), 10E-6);
+        assertEquals(-3.945355, i2.der(ph1var), 10E-6);
+        assertEquals(3.945355, i2.der(ph2var), 10E-6);
     }
 
     @Test
@@ -226,7 +226,7 @@ class EquationSystemTest {
         EquationTerm i1 = equationSystem.getEquation(branch.getBus1().getNum(), EquationType.BUS_I).orElse(null).getTerms().stream().filter(OpenBranchSide2CurrentMagnitudeEquationTerm.class::isInstance).findAny().get();
         Variable v1var = variableSet.getVariable(branch.getBus1().getNum(), VariableType.BUS_V);
         Variable ph1var = variableSet.getVariable(branch.getBus1().getNum(), VariableType.BUS_PHI);
-        assertEquals(322.837, i1.der(v1var), 10E-3);
+        assertEquals(0.559170, i1.der(v1var), 10E-6);
         assertThrows(IllegalStateException.class, () -> i1.der(ph1var));
     }
 
@@ -246,7 +246,7 @@ class EquationSystemTest {
         EquationTerm i2 = equationSystem.getEquation(branch.getBus2().getNum(), EquationType.BUS_I).orElse(null).getTerms().stream().filter(OpenBranchSide1CurrentMagnitudeEquationTerm.class::isInstance).findAny().get();
         Variable v2var = variableSet.getVariable(branch.getBus2().getNum(), VariableType.BUS_V);
         Variable ph2var = variableSet.getVariable(branch.getBus2().getNum(), VariableType.BUS_PHI);
-        assertEquals(322.837, i2.der(v2var), 10E-3);
+        assertEquals(0.55917, i2.der(v2var), 10E-6);
         assertThrows(IllegalStateException.class, () -> i2.der(ph2var));
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/network/PerUnitTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/PerUnitTest.java
@@ -66,4 +66,17 @@ class PerUnitTest {
         p1.update(x);
         assertEquals(856.4176570806668, p1.eval() / PerUnit.SB, 0d);
     }
+
+    @Test
+    void testBaseCurrent() {
+        // silly test to check the formulae:
+        // when P = SB and v = vnom, i should be equal to base current
+        double p = PerUnit.SB;
+        double v = 400;
+        // factor 1000 because p is in MW and V in kV, so :
+        // p = 1000 * sqrt(3) * v * i
+        double i = 1000 * p / (Math.sqrt(3) * v);
+        double ib = PerUnit.ib(400);
+        assertEquals(i, ib);
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -571,10 +571,9 @@ class OpenSecurityAnalysisTest {
         SecurityAnalysisResult result = runSecurityAnalysis(network, allBranches(network), monitors);
 
         assertEquals(1, result.getPreContingencyResult().getPreContingencyThreeWindingsTransformerResults().size());
-        assertEquals(new ThreeWindingsTransformerResult("3wt", 1.6109556638123288,
-                        0.8188422244941966, 1030.4601542294686, -1.6100000049961467, -0.7400000017321797,
-                        978.937148970407, -1.7348031191643076E-16, 0.0, 4.0061722632990915E-14),
-                result.getPreContingencyResult().getPreContingencyThreeWindingsTransformerResults().get(0));
+        assertAlmostEquals(new ThreeWindingsTransformerResult("3wt", 161, 82, 258,
+                                                              -161, -74, 435, 0, 0, 0),
+                result.getPreContingencyResult().getPreContingencyThreeWindingsTransformerResults().get(0), 1);
     }
 
     @Test
@@ -633,6 +632,19 @@ class OpenSecurityAnalysisTest {
         assertEquals(expected.getP2(), actual.getP2(), epsilon);
         assertEquals(expected.getQ2(), actual.getQ2(), epsilon);
         assertEquals(expected.getI2(), actual.getI2(), epsilon);
+    }
+
+    private static void assertAlmostEquals(ThreeWindingsTransformerResult expected, ThreeWindingsTransformerResult actual, double epsilon) {
+        assertEquals(expected.getThreeWindingsTransformerId(), actual.getThreeWindingsTransformerId());
+        assertEquals(expected.getP1(), actual.getP1(), epsilon);
+        assertEquals(expected.getQ1(), actual.getQ1(), epsilon);
+        assertEquals(expected.getI1(), actual.getI1(), epsilon);
+        assertEquals(expected.getP2(), actual.getP2(), epsilon);
+        assertEquals(expected.getQ2(), actual.getQ2(), epsilon);
+        assertEquals(expected.getI2(), actual.getI2(), epsilon);
+        assertEquals(expected.getP3(), actual.getP3(), epsilon);
+        assertEquals(expected.getQ3(), actual.getQ3(), epsilon);
+        assertEquals(expected.getI3(), actual.getI3(), epsilon);
     }
 
     /**

--- a/src/test/java/com/powsybl/openloadflow/sensi/ac/AcSensitivityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/ac/AcSensitivityAnalysisTest.java
@@ -634,7 +634,7 @@ class AcSensitivityAnalysisTest extends AbstractSensitivityAnalysisTest {
         ContingencyContext contingencyContext = ContingencyContext.all();
         List<SensitivityFactor2> factors = SensitivityFactor2.createMatrix(SensitivityFunctionType.BRANCH_ACTIVE_POWER, List.of("l12", "l13", "l23"),
                                                                            SensitivityVariableType.HVDC_LINE_ACTIVE_POWER, List.of("hvdc34"), false, contingencyContext);
-        SensitivityAnalysisResult2 result = sensiProvider.run(HvdcNetworkFactory.createNetworkWithGenerators(), Collections.emptyList(), Collections.emptyList(),
+        SensitivityAnalysisResult2 result = sensiProvider.run(network, Collections.emptyList(), Collections.emptyList(),
                 sensiParameters, factors);
 
         assertEquals(-0.346002, result.getValue(null, "l12", "hvdc34").getValue(), LoadFlowAssert.DELTA_POWER);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Refactoring

**What is the current behavior?** *(You can also link to an open issue here)*

Per uniting is hard to follow in a few places :
 - current values are not per-united with the correct base current value. In consequence, per-united values are not close at all to 1, and some "normalization factor" has been introduced in equations, which has nothing to do there.
 - in sensitivity analysis, per-uniting is also mixed in equations, whereas it should only be applied in pre/post processing

**What is the new behavior (if this is a feature change)?**

Current values are per-united using base current value = (Sb * 1000)/(nominalV * sqrt(3)).
Perunit-related factors are remove from equations systems.

