### PR TITLE
Fix merge control order

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -382,11 +382,10 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
             if (voltageControls.size() > 1) {
                 LOGGER.info("Zero impedance connected set with several voltage controls: controls are merged");
 
-                checkVcUniqueTargetV(voltageControls);
-
                 // Sort voltage controls to have a merged voltage control with a deterministic controlled bus,
                 // a deterministic target value and controller buses in a deterministic order
                 voltageControls.sort(Comparator.comparing(VoltageControl::getTargetValue).thenComparing(vc -> vc.getControlledBus().getId()));
+                checkVcUniqueTargetV(voltageControls);
 
                 // Merge the controllers into the kept voltage control
                 VoltageControl keptVoltageControl = voltageControls.remove(voltageControls.size() - 1);
@@ -416,7 +415,6 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
             // Sort discrete voltage controls to have a merged discrete voltage control with a deterministic controlled bus,
             // a deterministic target value and controller branches in a deterministic order
             discreteVoltageControls.sort(Comparator.comparing(DiscreteVoltageControl::getTargetValue).thenComparing(vc -> vc.getControlled().getId()));
-
             checkDvcUniqueTargetV(discreteVoltageControls);
 
             // Merge the controllers into the kept voltage control

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -430,6 +430,8 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
     }
 
     private static void checkVcUniqueTargetV(List<VoltageControl> voltageControls) {
+        // To check uniqueness we take the target value which will be kept as reference.
+        // The kept target value is the highest, it corresponds to the last voltage control in the ordered list.
         VoltageControl vcRef = voltageControls.get(voltageControls.size() - 1);
         boolean uniqueTargetV = voltageControls.stream().noneMatch(vc -> FastMath.abs(vc.getTargetValue() - vcRef.getTargetValue()) > TARGET_V_EPSILON);
         if (!uniqueTargetV) {
@@ -441,6 +443,8 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
     }
 
     private static void checkDvcUniqueTargetV(List<DiscreteVoltageControl> discreteVoltageControls) {
+        // To check uniqueness we take the target value which will be kept as reference.
+        // The kept target value is the highest, it corresponds to the last discrete voltage control in the ordered list.
         DiscreteVoltageControl dvcRef = discreteVoltageControls.get(discreteVoltageControls.size() - 1);
         boolean uniqueTargetV = discreteVoltageControls.stream().noneMatch(dvc -> FastMath.abs(dvc.getTargetValue() - dvcRef.getTargetValue()) > TARGET_V_EPSILON);
         if (!uniqueTargetV) {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -357,11 +357,13 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
 
     private static void mergeVoltageControls(Set<LfBus> zeroImpedanceConnectedSet, boolean transformerVoltageControl) {
         // Get the list of voltage controls from controlled buses in the zero impedance connected set
+        // Note that the list order is not deterministic as jgrapht connected set computation is using a basic HashSet
         List<VoltageControl> voltageControls = zeroImpedanceConnectedSet.stream().filter(LfBus::isVoltageControlled)
                 .map(LfBus::getVoltageControl).filter(Optional::isPresent).map(Optional::get)
                 .collect(Collectors.toList());
 
         // Get the list of discrete voltage controls from controlled buses in the zero impedance connected set
+        // Note that the list order is not deterministic as jgrapht connected set computation is using a basic HashSet
         List<DiscreteVoltageControl> discreteVoltageControls = !transformerVoltageControl ? Collections.emptyList() :
             zeroImpedanceConnectedSet.stream().filter(LfBus::isDiscreteVoltageControlled)
                 .map(LfBus::getDiscreteVoltageControl).filter(Optional::isPresent).map(Optional::get)
@@ -372,24 +374,30 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
         }
 
         if (!voltageControls.isEmpty()) {
-            // The first voltage control is kept and removed from the list
-            VoltageControl firstVoltageControl = voltageControls.remove(0);
 
-            // First resolve problem of voltage controls (generator, static var compensator, etc.)
+            // First, resolve problem of voltage controls (generator, static var compensator, etc.)
             // We have several controls whose controlled bus are in the same non-impedant connected set
             // To solve that we keep only one voltage control (and its target value), the other ones are removed
             // and the corresponding controllers are added to the control kept
-            LOGGER.info("Zero impedance connected set with several voltage controls: controls are merged");
-            voltageControls.forEach(voltageControl -> checkUniqueTargetV(voltageControl, firstVoltageControl));
-            voltageControls.stream()
+            if (!voltageControls.isEmpty()) {
+                LOGGER.info("Zero impedance connected set with several voltage controls: controls are merged");
+
+                checkVcUniqueTargetV(voltageControls);
+
+                // Sort voltage controls to have a merged voltage control with a deterministic controlled bus,
+                // a deterministic target value and controller buses in a deterministic order
+                voltageControls.sort(Comparator.comparing(VoltageControl::getTargetValue).thenComparing(vc -> vc.getControlledBus().getId()));
+
+                // Merge the controllers into the kept voltage control
+                VoltageControl keptVoltageControl = voltageControls.remove(voltageControls.size() - 1);
+                voltageControls.forEach(vc -> vc.getControlledBus().removeVoltageControl());
+                voltageControls.stream()
                     .flatMap(vc -> vc.getControllerBuses().stream())
                     .forEach(controller -> {
-                        firstVoltageControl.addControllerBus(controller);
-                        controller.setVoltageControl(firstVoltageControl);
+                        keptVoltageControl.addControllerBus(controller);
+                        controller.setVoltageControl(keptVoltageControl);
                     });
-            voltageControls.stream()
-                    .filter(vc -> !firstVoltageControl.getControllerBuses().contains(vc.getControlledBus()))
-                    .forEach(vc -> vc.getControlledBus().removeVoltageControl());
+            }
 
             // Second, we have to remove all the discrete voltage controls if present.
             if (!discreteVoltageControls.isEmpty()) {
@@ -400,35 +408,48 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
                 discreteVoltageControls.forEach(dvc -> dvc.getControlled().setDiscreteVoltageControl(null));
             }
         } else {
-            // The first discrete voltage control is kept and removed from the list
-            // Note that here we know that there is at least one discrete voltage control
-            DiscreteVoltageControl firstDiscreteVoltageControl = discreteVoltageControls.remove(0);
             // We have several discrete controls whose controlled bus are in the same non-impedant connected set
             // To solve that we keep only one discrete voltage control, the other ones are removed
             // and the corresponding controllers are added to the discrete control kept
             LOGGER.info("Zero impedance connected set with several discrete voltage controls: discrete controls merged");
-            discreteVoltageControls.forEach(dvc -> checkUniqueTargetV(dvc, firstDiscreteVoltageControl));
+
+            // Sort discrete voltage controls to have a merged discrete voltage control with a deterministic controlled bus,
+            // a deterministic target value and controller branches in a deterministic order
+            discreteVoltageControls.sort(Comparator.comparing(DiscreteVoltageControl::getTargetValue).thenComparing(vc -> vc.getControlled().getId()));
+
+            checkDvcUniqueTargetV(discreteVoltageControls);
+
+            // Merge the controllers into the kept voltage control
+            DiscreteVoltageControl keptDiscreteVoltageControl = discreteVoltageControls.remove(discreteVoltageControls.size() - 1);
+            discreteVoltageControls.forEach(dvc -> dvc.getControlled().setDiscreteVoltageControl(null));
             discreteVoltageControls.stream()
                 .flatMap(dvc -> dvc.getControllers().stream())
                 .forEach(controller -> {
-                    firstDiscreteVoltageControl.addController(controller);
-                    controller.setDiscreteVoltageControl(firstDiscreteVoltageControl);
+                    keptDiscreteVoltageControl.addController(controller);
+                    controller.setDiscreteVoltageControl(keptDiscreteVoltageControl);
                 });
-            discreteVoltageControls.forEach(dvc -> dvc.getControlled().setDiscreteVoltageControl(null));
         }
     }
 
-    private static void checkUniqueTargetV(VoltageControl vc1, VoltageControl vc2) {
-        if (FastMath.abs(vc1.getTargetValue() - vc2.getTargetValue()) > TARGET_V_EPSILON) {
-            LOGGER.error("Two controller buses are controlling buses {} and {} which are in the same non-impedant connected set, but with different target voltages ({} and {}): only target voltage {} is kept",
-                vc1.getControlledBus().getId(), vc2.getControlledBus().getId(), vc1.getTargetValue(), vc2.getTargetValue(), vc2.getTargetValue());
+    private static void checkVcUniqueTargetV(List<VoltageControl> voltageControls) {
+        VoltageControl vcRef = voltageControls.get(voltageControls.size() - 1);
+        boolean uniqueTargetV = voltageControls.stream().noneMatch(vc -> FastMath.abs(vc.getTargetValue() - vcRef.getTargetValue()) > TARGET_V_EPSILON);
+        if (!uniqueTargetV) {
+            LOGGER.error("Inconsistent voltage controls: buses {} are in the same non-impedant connected set and are controlled with different target voltages ({}). Only target voltage {} is kept",
+                voltageControls.stream().map(vc -> vc.getControlledBus().getId()).collect(Collectors.toList()),
+                voltageControls.stream().map(vc -> String.valueOf(vc.getTargetValue())).collect(Collectors.toList()),
+                vcRef.getTargetValue());
         }
     }
 
-    private static void checkUniqueTargetV(DiscreteVoltageControl dvc1, DiscreteVoltageControl dvc2) {
-        if (FastMath.abs(dvc1.getTargetValue() - dvc2.getTargetValue()) > TARGET_V_EPSILON) {
-            LOGGER.error("Two transformers are controlling buses {} and {} which are in the same non-impedant connected set, but with different target voltages ({} and {}): only target voltage {} is kept",
-                dvc1.getControlled().getId(), dvc2.getControlled().getId(), dvc1.getTargetValue(), dvc2.getTargetValue(), dvc2.getTargetValue());
+    private static void checkDvcUniqueTargetV(List<DiscreteVoltageControl> discreteVoltageControls) {
+        DiscreteVoltageControl dvcRef = discreteVoltageControls.get(discreteVoltageControls.size() - 1);
+        boolean uniqueTargetV = discreteVoltageControls.stream().noneMatch(dvc -> FastMath.abs(dvc.getTargetValue() - dvcRef.getTargetValue()) > TARGET_V_EPSILON);
+        if (!uniqueTargetV) {
+            LOGGER.error("Inconsistent transformer voltage controls: buses {} are in the same non-impedant connected set and are controlled with different target voltages ({}). Only target voltage {} is kept",
+                discreteVoltageControls.stream().map(dvc -> dvc.getControlled().getId()).collect(Collectors.toList()),
+                discreteVoltageControls.stream().map(dvc -> String.valueOf(dvc.getTargetValue())).collect(Collectors.toList()),
+                dvcRef.getTargetValue());
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -434,8 +434,8 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
         boolean uniqueTargetV = voltageControls.stream().noneMatch(vc -> FastMath.abs(vc.getTargetValue() - vcRef.getTargetValue()) > TARGET_V_EPSILON);
         if (!uniqueTargetV) {
             LOGGER.error("Inconsistent voltage controls: buses {} are in the same non-impedant connected set and are controlled with different target voltages ({}). Only target voltage {} is kept",
-                voltageControls.stream().map(vc -> vc.getControlledBus().getId()).collect(Collectors.toList()),
-                voltageControls.stream().map(vc -> String.valueOf(vc.getTargetValue())).collect(Collectors.toList()),
+                voltageControls.stream().map(VoltageControl::getControlledBus).collect(Collectors.toList()),
+                voltageControls.stream().map(VoltageControl::getTargetValue).collect(Collectors.toList()),
                 vcRef.getTargetValue());
         }
     }
@@ -445,8 +445,8 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
         boolean uniqueTargetV = discreteVoltageControls.stream().noneMatch(dvc -> FastMath.abs(dvc.getTargetValue() - dvcRef.getTargetValue()) > TARGET_V_EPSILON);
         if (!uniqueTargetV) {
             LOGGER.error("Inconsistent transformer voltage controls: buses {} are in the same non-impedant connected set and are controlled with different target voltages ({}). Only target voltage {} is kept",
-                discreteVoltageControls.stream().map(dvc -> dvc.getControlled().getId()).collect(Collectors.toList()),
-                discreteVoltageControls.stream().map(dvc -> String.valueOf(dvc.getTargetValue())).collect(Collectors.toList()),
+                discreteVoltageControls.stream().map(DiscreteVoltageControl::getControlled).collect(Collectors.toList()),
+                discreteVoltageControls.stream().map(DiscreteVoltageControl::getTargetValue).collect(Collectors.toList()),
                 dvcRef.getTargetValue());
         }
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -369,7 +369,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
                 .map(LfBus::getDiscreteVoltageControl).filter(Optional::isPresent).map(Optional::get)
                 .collect(Collectors.toList());
 
-        if (voltageControls.isEmpty() && discreteVoltageControls.isEmpty()) {
+        if (voltageControls.isEmpty() && discreteVoltageControls.size() <= 1) {
             return;
         }
 
@@ -379,7 +379,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
             // We have several controls whose controlled bus are in the same non-impedant connected set
             // To solve that we keep only one voltage control (and its target value), the other ones are removed
             // and the corresponding controllers are added to the control kept
-            if (!voltageControls.isEmpty()) {
+            if (voltageControls.size() > 1) {
                 LOGGER.info("Zero impedance connected set with several voltage controls: controls are merged");
 
                 checkVcUniqueTargetV(voltageControls);
@@ -408,7 +408,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader {
                 discreteVoltageControls.forEach(dvc -> dvc.getControlled().setDiscreteVoltageControl(null));
             }
         } else {
-            // We have several discrete controls whose controlled bus are in the same non-impedant connected set
+            // We have at least 2 discrete controls whose controlled bus are in the same non-impedant connected set
             // To solve that we keep only one discrete voltage control, the other ones are removed
             // and the corresponding controllers are added to the discrete control kept
             LOGGER.info("Zero impedance connected set with several discrete voltage controls: discrete controls merged");

--- a/src/test/java/com/powsybl/openloadflow/NonImpedantBranchTest.java
+++ b/src/test/java/com/powsybl/openloadflow/NonImpedantBranchTest.java
@@ -172,7 +172,8 @@ class NonImpedantBranchTest extends AbstractLoadFlowNetworkFactory {
 
         loadFlowRunner.run(network, parameters);
 
-        assertEquals(b1.getV(), b2.getV(), DELTA_V);
+        assertEquals(1.01, b1.getV(), DELTA_V);
+        assertEquals(1.01, b2.getV(), DELTA_V);
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
@@ -274,6 +274,32 @@ class AcLoadFlowTransformerControlTest {
     }
 
     @Test
+    void inconsistentT2wtTargetVoltagesTest() {
+        selectNetwork(createNetworkWithSharedControl());
+
+        parameters.setTransformerVoltageControlOn(true);
+        t2wt.getRatioTapChanger()
+            .setTargetDeadband(0)
+            .setRegulating(true)
+            .setTapPosition(0)
+            .setRegulationTerminal(t2wt.getTerminal2())
+            .setTargetV(33.6);
+        t2wt2.getRatioTapChanger()
+            .setTargetDeadband(0)
+            .setRegulating(true)
+            .setTapPosition(0)
+            .setRegulationTerminal(t2wt2.getTerminal2())
+            .setTargetV(34.0);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertVoltageEquals(134.279, bus2);
+        assertVoltageEquals(35.73, t2wt.getTerminal2().getBusView().getBus());
+        assertEquals(2, t2wt.getRatioTapChanger().getTapPosition());
+        assertEquals(2, t2wt.getRatioTapChanger().getTapPosition());
+    }
+
+    @Test
     void sharedVoltageControlT2wtWithZeroImpedanceLinesTest2() {
         selectNetwork(createNetworkWithSharedControl());
         network.getVoltageLevel("VL_3").newGenerator()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?** 
Bug fix



**What is the current behavior?**
When several buses are controlled in the same non-impedant connected set, in the merged voltage control the controlled bus, the target voltage and the controllers order are not deterministic


**What is the new behavior (if this is a feature change)?**
In the merged voltage control the controlled bus, the target voltage and the controllers order are deterministic (voltage control kept is the one with the highest voltage control)


**Does this PR introduce a breaking change or deprecate an API?** 
No


**Other information**:
Issue due to PR #321 