### PR TITLE
[WIP] Handle deadband in PhaseControlOuterLoop

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcloadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcloadFlowEngine.java
@@ -112,7 +112,7 @@ public class AcloadFlowEngine implements AutoCloseable {
             MutableInt outerLoopIteration = runningContext.outerLoopIterationByType.computeIfAbsent(outerLoop.getType(), k -> new MutableInt());
 
             // check outer loop status
-            outerLoopStatus = outerLoop.check(new OuterLoopContext(outerLoopIteration.getValue(), network, runningContext.lastNrResult), olReporter);
+            outerLoopStatus = outerLoop.check(new OuterLoopContext(outerLoopIteration.getValue(), network, equationSystem, variableSet, runningContext.lastNrResult), olReporter);
 
             if (outerLoopStatus == OuterLoopStatus.UNSTABLE) {
                 LOGGER.debug("Start outer loop iteration {} (name='{}')", outerLoopIteration, outerLoop.getType());

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/OuterLoopContext.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/OuterLoopContext.java
@@ -7,6 +7,8 @@
 package com.powsybl.openloadflow.ac.outerloop;
 
 import com.powsybl.openloadflow.ac.nr.NewtonRaphsonResult;
+import com.powsybl.openloadflow.equations.EquationSystem;
+import com.powsybl.openloadflow.equations.VariableSet;
 import com.powsybl.openloadflow.network.LfNetwork;
 
 import java.util.Objects;
@@ -22,10 +24,16 @@ public class OuterLoopContext {
 
     private final NewtonRaphsonResult lastNewtonRaphsonResult;
 
-    OuterLoopContext(int iteration, LfNetwork network, NewtonRaphsonResult lastNewtonRaphsonResult) {
+    private final EquationSystem equationSystem;
+
+    private final VariableSet variableSet;
+
+    OuterLoopContext(int iteration, LfNetwork network, EquationSystem equationSystem, VariableSet variableSet, NewtonRaphsonResult lastNewtonRaphsonResult) {
         this.iteration = iteration;
         this.network = Objects.requireNonNull(network);
         this.lastNewtonRaphsonResult = Objects.requireNonNull(lastNewtonRaphsonResult);
+        this.equationSystem = Objects.requireNonNull(equationSystem);
+        this.variableSet = Objects.requireNonNull(variableSet);
     }
 
     public int getIteration() {
@@ -38,5 +46,13 @@ public class OuterLoopContext {
 
     public NewtonRaphsonResult getLastNewtonRaphsonResult() {
         return lastNewtonRaphsonResult;
+    }
+
+    public EquationSystem getEquationSystem() {
+        return equationSystem;
+    }
+
+    public VariableSet getVariableSet() {
+        return variableSet;
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/PiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModel.java
@@ -47,4 +47,6 @@ public interface PiModel {
 
     void roundR1ToClosestTap();
 
+    double getCurrentTapA1();
+
 }

--- a/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
@@ -40,6 +40,11 @@ public class PiModelArray implements PiModel {
     }
 
     @Override
+    public double getCurrentTapA1() {
+        return getModel().getA1();
+    }
+
+    @Override
     public double getR() {
         return getModel().getR();
     }

--- a/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
@@ -124,4 +124,9 @@ public class SimplePiModel implements PiModel {
     public void roundR1ToClosestTap() {
         throw new IllegalStateException("R1 rounding is not supported in simple Pi model implementation");
     }
+
+    @Override
+    public double getCurrentTapA1() {
+        throw new IllegalStateException("Getting current tap A1 is not supported for simple Pi model implementation.");
+    }
 }


### PR DESCRIPTION
Handle deadband in PhaseControlOuterLoop check process. Deadband is supported only when controlled branch is the same as controller branch.

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Handle deadband parameter provided in DiscretePhaseControl parameter for switchOffPhaseControl function.

**What is the current behavior?** *(You can also link to an open issue here)*

Deadband paramater is ignored.

**What is the new behavior (if this is a feature change)?**

Deadband parameter is taken into account but only if controllerBranch is equal to the controlledBranch.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
