### PR TITLE
User object to extend LF network

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/AbstractElement.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractElement.java
@@ -17,6 +17,8 @@ public abstract class AbstractElement {
 
     protected int num = -1;
 
+    protected Object userObject;
+
     protected AbstractElement(LfNetwork network) {
         this.network = Objects.requireNonNull(network);
     }
@@ -31,5 +33,13 @@ public abstract class AbstractElement {
 
     public LfNetwork getNetwork() {
         return network;
+    }
+
+    public Object getUserObject() {
+        return userObject;
+    }
+
+    public void setUserObject(Object userObject) {
+        this.userObject = userObject;
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/LfElement.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfElement.java
@@ -20,4 +20,8 @@ public interface LfElement {
     void setNum(int num);
 
     LfNetwork getNetwork();
+
+    Object getUserObject();
+
+    void setUserObject(Object userObject);
 }

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -65,6 +65,8 @@ public class LfNetwork {
 
     private boolean valid = true;
 
+    private Object userObject;
+
     public LfNetwork(int numCC, int numSC, SlackBusSelector slackBusSelector) {
         this.numCC = numCC;
         this.numSC = numSC;
@@ -514,6 +516,14 @@ public class LfNetwork {
 
     public void setValid(boolean valid) {
         this.valid = valid;
+    }
+
+    public Object getUserObject() {
+        return userObject;
+    }
+
+    public void setUserObject(Object userObject) {
+        this.userObject = userObject;
     }
 
     @Override

--- a/src/test/java/com/powsybl/openloadflow/network/UserObjectTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/UserObjectTest.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.network;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ *
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+class UserObjectTest {
+
+    @Test
+    void test() {
+        Network network = EurostagTutorialExample1Factory.create();
+        LfNetwork lfNetwork = LfNetwork.load(network, new FirstSlackBusSelector()).get(0);
+        assertNull(lfNetwork.getUserObject());
+        lfNetwork.setUserObject("test");
+        assertEquals("test", lfNetwork.getUserObject());
+        LfBus lfBus = lfNetwork.getBus(0);
+        assertNull(lfBus.getUserObject());
+        lfBus.setUserObject("hello");
+        assertEquals("hello", lfBus.getUserObject());
+    }
+}


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
There is no way to extend the LF network to use it for something else that a load flow. 


**What is the new behavior (if this is a feature change)?**
We can add any additional data to a LF network and to its elements through a user object.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
