### PR TITLE
Refactor shared voltage control modelling

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
@@ -198,15 +198,14 @@ public final class AcEquationSystem {
                                                                  EquationSystem<AcVariableType, AcEquationType> equationSystem,
                                                                  AcEquationSystemCreationParameters creationParameters) {
         for (LfBus controllerBus : controllerBuses) {
-            double qPercent = controllerBus.getRemoteControlReactivePercent();
             Equation<AcVariableType, AcEquationType> zero = equationSystem.createEquation(controllerBus.getNum(), AcEquationType.DISTR_Q)
                     .addTerms(createReactiveTerms(controllerBus, networkParameters, equationSystem.getVariableSet(), creationParameters).stream()
-                                .map(term -> term.multiply(qPercent - 1))
+                                .map(term -> term.multiply(() -> controllerBus.getRemoteControlReactivePercent() - 1))
                                 .collect(Collectors.toList()));
             for (LfBus otherControllerBus : controllerBuses) {
                 if (otherControllerBus != controllerBus) {
                     zero.addTerms(createReactiveTerms(otherControllerBus, networkParameters, equationSystem.getVariableSet(), creationParameters).stream()
-                            .map(term -> term.multiply(qPercent))
+                            .map(term -> term.multiply(controllerBus::getRemoteControlReactivePercent))
                             .collect(Collectors.toList()));
                 }
             }

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
@@ -505,7 +505,7 @@ public final class AcEquationSystem {
 
         EquationSystemPostProcessor.findAll().forEach(pp -> pp.onCreate(equationSystem));
 
-        network.addListener(new AcEquationSystemUpdater(equationSystem, creationParameters, networkParameters));
+        network.addListener(new AcEquationSystemUpdater(equationSystem));
 
         return equationSystem;
     }

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
@@ -127,6 +127,9 @@ public final class AcEquationSystem {
     }
 
     static void updateRemoteVoltageControlEquations(VoltageControl voltageControl, EquationSystem<AcVariableType, AcEquationType> equationSystem) {
+        // ensure reactive keys are up-to-date
+        voltageControl.updateReactiveKeys();
+
         Set<LfBus> controllerBuses = voltageControl.getControllerBuses();
         List<LfBus> enabledControllerBuses = new ArrayList<>(controllerBuses.size());
         List<LfBus> disabledControllerBuses = new ArrayList<>(controllerBuses.size());

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
@@ -342,11 +342,10 @@ public final class AcEquationSystem {
         // which is modeled here with: V + slope * (sum_branch qBranch) = TargetV - slope * qLoads + slope * qGenerators
         Equation<AcVariableType, AcEquationType> eq = equationSystem.createEquation(bus.getNum(), AcEquationType.BUS_TARGET_V_WITH_SLOPE);
         eq.addTerm(vTerm);
-        List<EquationTerm<AcVariableType, AcEquationType>> controllerBusReactiveTerms = createReactiveTerms(bus, networkParameters, equationSystem.getVariableSet(), creationParameters);
-        eq.setData(new DistributionData(bus.getNum(), slope)); // for later use
-        for (EquationTerm<AcVariableType, AcEquationType> eqTerm : controllerBusReactiveTerms) {
-            eq.addTerm(eqTerm.multiply(slope));
-        }
+        eq.addTerms(createReactiveTerms(bus, networkParameters, equationSystem.getVariableSet(), creationParameters)
+                        .stream()
+                        .map(term -> term.multiply(slope))
+                        .collect(Collectors.toList()));
     }
 
     public static void createR1DistributionEquations(List<LfBranch> controllerBranches,

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
@@ -10,8 +10,6 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.openloadflow.equations.*;
 import com.powsybl.openloadflow.network.*;
 import com.powsybl.openloadflow.network.DiscretePhaseControl.Mode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,8 +21,6 @@ import java.util.stream.Collectors;
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public final class AcEquationSystem {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(AcEquationSystem.class);
 
     private AcEquationSystem() {
     }
@@ -72,8 +68,7 @@ public final class AcEquationSystem {
             if (voltageControl.isVoltageControlLocal()) {
                 createLocalVoltageControlEquation(bus, networkParameters, equationSystem, creationParameters);
             } else if (bus.isVoltageControlled()) {
-                // remote controlled: set voltage equation on this controlled bus
-                createVoltageControlledBusEquations(voltageControl, networkParameters, equationSystem, creationParameters);
+                createRemoteVoltageControlEquations(voltageControl, networkParameters, equationSystem, creationParameters);
             }
 
             if (bus.isVoltageControllerEnabled()) {
@@ -117,25 +112,50 @@ public final class AcEquationSystem {
         }
     }
 
-    private static void createVoltageControlledBusEquations(VoltageControl voltageControl, LfNetworkParameters networkParameters,
+    private static void createRemoteVoltageControlEquations(VoltageControl voltageControl, LfNetworkParameters networkParameters,
                                                             EquationSystem<AcVariableType, AcEquationType> equationSystem,
                                                             AcEquationSystemCreationParameters creationParameters) {
         LfBus controlledBus = voltageControl.getControlledBus();
 
         // create voltage equation at voltage controlled bus
         EquationTerm<AcVariableType, AcEquationType> vTerm = equationSystem.getVariable(controlledBus.getNum(), AcVariableType.BUS_V).createTerm();
-        Equation<AcVariableType, AcEquationType> vEq = equationSystem.createEquation(controlledBus.getNum(), AcEquationType.BUS_TARGET_V)
+        equationSystem.createEquation(controlledBus.getNum(), AcEquationType.BUS_TARGET_V)
                 .addTerm(vTerm);
         controlledBus.setCalculatedV(vTerm);
 
-        List<LfBus> controllerBuses = voltageControl.getControllerBuses().stream()
-                .filter(LfBus::isVoltageControllerEnabled)
-                .collect(Collectors.toList());
-        if (controllerBuses.isEmpty()) {
-            vEq.setActive(false);
-        } else {
-            // create reactive power distribution equations at voltage controller buses (except one)
-            createReactivePowerDistributionEquations(controllerBuses, networkParameters, equationSystem, creationParameters);
+        // create reactive power distribution equations at voltage controller buses
+        createReactivePowerDistributionEquations(new ArrayList<>(voltageControl.getControllerBuses()), networkParameters, equationSystem, creationParameters);
+
+        updateRemoteVoltageControlEquations(voltageControl, equationSystem);
+    }
+
+    static void updateRemoteVoltageControlEquations(VoltageControl voltageControl, EquationSystem<AcVariableType, AcEquationType> equationSystem) {
+        List<LfBus> enabledControllerBuses = new ArrayList<>(voltageControl.getControllerBuses().size());
+        List<LfBus> disabledControllerBuses = new ArrayList<>(voltageControl.getControllerBuses().size());
+        for (LfBus controllerBus : voltageControl.getControllerBuses()) {
+            if (controllerBus.isVoltageControllerEnabled()) {
+                enabledControllerBuses.add(controllerBus);
+            } else {
+                disabledControllerBuses.add(controllerBus);
+            }
+        }
+
+        // activate voltage control at controlled bus only if at least one controller bus is enabled
+        Equation<AcVariableType, AcEquationType> vEq = equationSystem.getEquation(voltageControl.getControlledBus().getNum(), AcEquationType.BUS_TARGET_V).orElseThrow();
+        vEq.setActive(!enabledControllerBuses.isEmpty());
+
+        // deactivate reactive power distribution equation on all disabled (PQ) buses
+        for (LfBus controllerBus : disabledControllerBuses) {
+            equationSystem.getEquation(controllerBus.getNum(), AcEquationType.DISTR_Q)
+                    .orElseThrow()
+                    .setActive(false);
+        }
+
+        // activate reactive power distribution equation at all enabled controller buses except one
+        for (int i = 0; i < enabledControllerBuses.size(); i++) {
+            LfBus controllerBus = enabledControllerBuses.get(i);
+            var qDistrEq = equationSystem.getEquation(controllerBus.getNum(), AcEquationType.DISTR_Q).orElseThrow();
+            qDistrEq.setActive(i != 0);
         }
     }
 
@@ -176,77 +196,25 @@ public final class AcEquationSystem {
         return terms;
     }
 
-    public static void createReactivePowerDistributionEquations(List<LfBus> controllerBuses, LfNetworkParameters networkParameters,
-                                                                EquationSystem<AcVariableType, AcEquationType> equationSystem,
-                                                                AcEquationSystemCreationParameters creationParameters) {
-        double[] qKeys = createReactiveKeys(controllerBuses);
-
-        // we choose first controller bus as reference for reactive power
-        LfBus firstControllerBus = controllerBuses.get(0);
-        List<EquationTerm<AcVariableType, AcEquationType>> firstControllerBusReactiveTerms
-                = createReactiveTerms(firstControllerBus, networkParameters, equationSystem.getVariableSet(), creationParameters);
-
-        // create a reactive power distribution equation for all the other controller buses
-        for (int i = 1; i < controllerBuses.size(); i++) {
-            LfBus controllerBus = controllerBuses.get(i);
-            double c = qKeys[0] / qKeys[i];
-
-            // l0 - c * li = q0 - c * qi
-            Equation<AcVariableType, AcEquationType> zero = equationSystem.createEquation(controllerBus.getNum(), AcEquationType.DISTR_Q);
-            zero.setData(new DistributionData(firstControllerBus.getNum(), c)); // for later use
-            zero.addTerms(firstControllerBusReactiveTerms);
-            zero.addTerms(createReactiveTerms(controllerBus, networkParameters, equationSystem.getVariableSet(), creationParameters).
-                    stream()
-                    .map(term -> term.multiply(-c))
-                    .collect(Collectors.toList()));
-        }
-    }
-
-    private static double[] createUniformReactiveKeys(List<LfBus> controllerBuses) {
-        double[] qKeys = new double[controllerBuses.size()];
+    private static void createReactivePowerDistributionEquations(List<LfBus> controllerBuses, LfNetworkParameters networkParameters,
+                                                                 EquationSystem<AcVariableType, AcEquationType> equationSystem,
+                                                                 AcEquationSystemCreationParameters creationParameters) {
         for (int i = 0; i < controllerBuses.size(); i++) {
             LfBus controllerBus = controllerBuses.get(i);
-            qKeys[i] = controllerBus.getGenerators().stream().filter(LfGenerator::hasVoltageControl).count();
-        }
-        return qKeys;
-    }
-
-    private static double[] createReactiveKeysFromMaxReactivePowerRange(List<LfBus> controllerBuses) {
-        double[] qKeys = new double[controllerBuses.size()];
-        // try to build keys from reactive power range
-        for (int i = 0; i < controllerBuses.size(); i++) {
-            LfBus controllerBus = controllerBuses.get(i);
-            for (LfGenerator generator : controllerBus.getGenerators()) {
-                double maxRangeQ = generator.getMaxRangeQ();
-                // if one reactive range is not plausible, we fallback to uniform keys
-                if (maxRangeQ < PlausibleValues.MIN_REACTIVE_RANGE / PerUnit.SB || maxRangeQ > PlausibleValues.MAX_REACTIVE_RANGE / PerUnit.SB) {
-                    return createUniformReactiveKeys(controllerBuses);
-                } else {
-                    qKeys[i] += maxRangeQ;
+            double qPercent = controllerBus.getRemoteControlReactivePercent();
+            Equation<AcVariableType, AcEquationType> zero = equationSystem.createEquation(controllerBus.getNum(), AcEquationType.DISTR_Q)
+                    .addTerms(createReactiveTerms(controllerBus, networkParameters, equationSystem.getVariableSet(), creationParameters).stream()
+                                .map(term -> term.multiply(qPercent - 1))
+                                .collect(Collectors.toList()));
+            for (int j = 0; j < controllerBuses.size(); j++) {
+                if (j != i) {
+                    LfBus otherControllerBus = controllerBuses.get(j);
+                    zero.addTerms(createReactiveTerms(otherControllerBus, networkParameters, equationSystem.getVariableSet(), creationParameters).stream()
+                            .map(term -> term.multiply(qPercent))
+                            .collect(Collectors.toList()));
                 }
             }
         }
-        return qKeys;
-    }
-
-    private static double[] createReactiveKeys(List<LfBus> controllerBuses) {
-        double[] qKeys = new double[controllerBuses.size()];
-        for (int i = 0; i < controllerBuses.size(); i++) {
-            LfBus controllerBus = controllerBuses.get(i);
-            for (LfGenerator generator : controllerBus.getGenerators()) {
-                double qKey = generator.getRemoteControlReactiveKey().orElse(Double.NaN);
-                if (Double.isNaN(qKey) || qKey == 0) {
-                    if (qKey == 0) {
-                        LOGGER.error("Generator '{}' remote control reactive key value is zero", generator.getId());
-                    }
-                    // in case of one missing key, we fallback to keys based on reactive power range
-                    return createReactiveKeysFromMaxReactivePowerRange(controllerBuses);
-                } else {
-                    qKeys[i] += qKey;
-                }
-            }
-        }
-        return qKeys;
     }
 
     private static void createNonImpedantBranch(LfBranch branch, LfBus bus1, LfBus bus2,

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
@@ -210,12 +210,12 @@ public final class AcEquationSystem {
             // 0 = (qPercent_i - 1) * q_i + qPercent_i * sum_j(q_j) where j are all the voltage controller buses except i
             Equation<AcVariableType, AcEquationType> zero = equationSystem.createEquation(controllerBus.getNum(), AcEquationType.DISTR_Q)
                     .addTerms(createReactiveTerms(controllerBus, networkParameters, equationSystem.getVariableSet(), creationParameters).stream()
-                                .map(term -> term.multiply(() -> controllerBus.getRemoteControlReactivePercent() - 1))
+                                .map(term -> term.multiply(() -> controllerBus.getRemoteVoltageControlReactivePercent() - 1))
                                 .collect(Collectors.toList()));
             for (LfBus otherControllerBus : controllerBuses) {
                 if (otherControllerBus != controllerBus) {
                     zero.addTerms(createReactiveTerms(otherControllerBus, networkParameters, equationSystem.getVariableSet(), creationParameters).stream()
-                            .map(term -> term.multiply(controllerBus::getRemoteControlReactivePercent))
+                            .map(term -> term.multiply(controllerBus::getRemoteVoltageControlReactivePercent))
                             .collect(Collectors.toList()));
                 }
             }

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
@@ -340,12 +340,12 @@ public final class AcEquationSystem {
         // we only support one generator controlling voltage with a non zero slope at a bus.
         // equation is: V + slope * qSVC = targetV
         // which is modeled here with: V + slope * (sum_branch qBranch) = TargetV - slope * qLoads + slope * qGenerators
-        Equation<AcVariableType, AcEquationType> eq = equationSystem.createEquation(bus.getNum(), AcEquationType.BUS_TARGET_V_WITH_SLOPE);
-        eq.addTerm(vTerm);
-        eq.addTerms(createReactiveTerms(bus, networkParameters, equationSystem.getVariableSet(), creationParameters)
-                        .stream()
-                        .map(term -> term.multiply(slope))
-                        .collect(Collectors.toList()));
+        equationSystem.createEquation(bus.getNum(), AcEquationType.BUS_TARGET_V_WITH_SLOPE)
+                .addTerm(vTerm)
+                .addTerms(createReactiveTerms(bus, networkParameters, equationSystem.getVariableSet(), creationParameters)
+                            .stream()
+                            .map(term -> term.multiply(slope))
+                            .collect(Collectors.toList()));
     }
 
     public static void createR1DistributionEquations(List<LfBranch> controllerBranches,

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.openloadflow.ac.equations;
 
-import com.powsybl.openloadflow.equations.Equation;
 import com.powsybl.openloadflow.equations.EquationSystem;
 import com.powsybl.openloadflow.network.*;
 
@@ -25,9 +24,6 @@ public class AcEquationSystemUpdater extends AbstractLfNetworkListener {
     }
 
     private void updateVoltageControl(VoltageControl voltageControl) {
-        // ensure reactive keys are up-to-date
-        voltageControl.updateReactiveKeys();
-
         LfBus controlledBus = voltageControl.getControlledBus();
         Set<LfBus> controllerBuses = voltageControl.getControllerBuses();
 
@@ -50,8 +46,10 @@ public class AcEquationSystemUpdater extends AbstractLfNetworkListener {
     }
 
     private void updateVoltageControl(LfBus controllerBus, boolean newVoltageControllerEnabled) {
-        Equation<AcVariableType, AcEquationType> qEq = equationSystem.createEquation(controllerBus.getNum(), AcEquationType.BUS_TARGET_Q);
-        qEq.setActive(!newVoltageControllerEnabled);
+        // active/de-activate bus target reactive power equation to switch bus PV or PQ
+        equationSystem.createEquation(controllerBus.getNum(), AcEquationType.BUS_TARGET_Q)
+                .setActive(!newVoltageControllerEnabled);
+
         updateVoltageControl(controllerBus.getVoltageControl().orElseThrow());
     }
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
@@ -32,6 +32,9 @@ public class AcEquationSystemUpdater extends AbstractLfNetworkListener {
     }
 
     private void updateVoltageControl(VoltageControl voltageControl) {
+        // ensure reactive keys are up-to-date
+        voltageControl.updateReactiveKeys();
+
         LfBus controlledBus = voltageControl.getControlledBus();
         Set<LfBus> controllerBuses = voltageControl.getControllerBuses();
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
@@ -51,11 +51,7 @@ public class AcEquationSystemUpdater extends AbstractLfNetworkListener {
 
     private void updateVoltageControl(LfBus controllerBus, boolean newVoltageControllerEnabled) {
         Equation<AcVariableType, AcEquationType> qEq = equationSystem.createEquation(controllerBus.getNum(), AcEquationType.BUS_TARGET_Q);
-        if (newVoltageControllerEnabled) { // switch PQ/PV
-            qEq.setActive(false);
-        } else { // switch PV/PQ
-            qEq.setActive(true);
-        }
+        qEq.setActive(!newVoltageControllerEnabled);
         updateVoltageControl(controllerBus.getVoltageControl().orElseThrow());
     }
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
@@ -20,15 +20,8 @@ public class AcEquationSystemUpdater extends AbstractLfNetworkListener {
 
     private final EquationSystem<AcVariableType, AcEquationType> equationSystem;
 
-    private final AcEquationSystemCreationParameters creationParameters;
-
-    private final LfNetworkParameters networkParameters;
-
-    public AcEquationSystemUpdater(EquationSystem<AcVariableType, AcEquationType> equationSystem,
-                                   AcEquationSystemCreationParameters creationParameters, LfNetworkParameters networkParameters) {
+    public AcEquationSystemUpdater(EquationSystem<AcVariableType, AcEquationType> equationSystem) {
         this.equationSystem = Objects.requireNonNull(equationSystem);
-        this.creationParameters = Objects.requireNonNull(creationParameters);
-        this.networkParameters = Objects.requireNonNull(networkParameters);
     }
 
     private void updateVoltageControl(VoltageControl voltageControl) {
@@ -60,17 +53,10 @@ public class AcEquationSystemUpdater extends AbstractLfNetworkListener {
         Equation<AcVariableType, AcEquationType> qEq = equationSystem.createEquation(controllerBus.getNum(), AcEquationType.BUS_TARGET_Q);
         if (newVoltageControllerEnabled) { // switch PQ/PV
             qEq.setActive(false);
-
-            if (controllerBus.isVoltageControllerEnabled()) {
-                controllerBus.getVoltageControl()
-                        .ifPresent(this::updateVoltageControl);
-            }
         } else { // switch PV/PQ
             qEq.setActive(true);
-
-            controllerBus.getVoltageControl()
-                    .ifPresent(this::updateVoltageControl);
         }
+        updateVoltageControl(controllerBus.getVoltageControl().orElseThrow());
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcloadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcloadFlowEngine.java
@@ -128,10 +128,10 @@ public class AcloadFlowEngine implements AutoCloseable {
 
     private static double getReactivePowerDistributionTarget(LfNetwork network, int busNum) {
         LfBus controllerBus = network.getBus(busNum);
-        double target = (controllerBus.getRemoteControlReactivePercent() - 1) * controllerBus.getTargetQ();
+        double target = (controllerBus.getRemoteVoltageControlReactivePercent() - 1) * controllerBus.getTargetQ();
         for (LfBus otherControllerBus : controllerBus.getVoltageControl().orElseThrow().getControllerBuses()) {
             if (otherControllerBus != controllerBus) {
-                target += controllerBus.getRemoteControlReactivePercent() * otherControllerBus.getTargetQ();
+                target += controllerBus.getRemoteVoltageControlReactivePercent() * otherControllerBus.getTargetQ();
             }
         }
         return target;

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcloadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcloadFlowEngine.java
@@ -144,8 +144,9 @@ public class AcloadFlowEngine implements AutoCloseable {
         return controllerBranch.getPiModel().getR1() - firstControllerBranch.getPiModel().getR1();
     }
 
-    private static double createBusWithSlopeTarget(LfBus bus, DistributionData data) {
-        double slope = data.getC();
+    private static double createBusWithSlopeTarget(LfBus bus) {
+        // take first generator with slope: network loading ensures that there's only one generator with slope
+        double slope = bus.getGeneratorsControllingVoltageWithSlope().get(0).getSlope();
         return getBusTargetV(bus) - slope * (bus.getLoadTargetQ() - bus.getGenerationTargetQ());
     }
 
@@ -170,7 +171,7 @@ public class AcloadFlowEngine implements AutoCloseable {
                 break;
 
             case BUS_TARGET_V_WITH_SLOPE:
-                targets[equation.getColumn()] = createBusWithSlopeTarget(network.getBus(equation.getElementNum()), equation.getData());
+                targets[equation.getColumn()] = createBusWithSlopeTarget(network.getBus(equation.getElementNum()));
                 break;
 
             case BUS_TARGET_PHI:

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcloadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcloadFlowEngine.java
@@ -128,10 +128,10 @@ public class AcloadFlowEngine implements AutoCloseable {
 
     private static double getReactivePowerDistributionTarget(LfNetwork network, int busNum) {
         LfBus controllerBus = network.getBus(busNum);
-        double target = (controllerBus.getRemoteControlReactivePercent() - 1) * (controllerBus.getLoadTargetQ() - controllerBus.getGenerationTargetQ());
+        double target = (controllerBus.getRemoteControlReactivePercent() - 1) * controllerBus.getTargetQ();
         for (LfBus otherControllerBus : controllerBus.getVoltageControl().orElseThrow().getControllerBuses()) {
             if (otherControllerBus != controllerBus) {
-                target += otherControllerBus.getRemoteControlReactivePercent() * (otherControllerBus.getLoadTargetQ() - otherControllerBus.getGenerationTargetQ());
+                target += controllerBus.getRemoteControlReactivePercent() * otherControllerBus.getTargetQ();
             }
         }
         return target;

--- a/src/main/java/com/powsybl/openloadflow/network/LfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBus.java
@@ -152,4 +152,8 @@ public interface LfBus extends LfElement {
      * Find bus + parallel branches neighbors.
      */
     Map<LfBus, List<LfBranch>> findNeighbors();
+
+    double getRemoteControlReactivePercent();
+
+    void setRemoteControlReactivePercent(double key);
 }

--- a/src/main/java/com/powsybl/openloadflow/network/LfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBus.java
@@ -153,7 +153,7 @@ public interface LfBus extends LfElement {
      */
     Map<LfBus, List<LfBranch>> findNeighbors();
 
-    double getRemoteControlReactivePercent();
+    double getRemoteVoltageControlReactivePercent();
 
-    void setRemoteControlReactivePercent(double key);
+    void setRemoteVoltageControlReactivePercent(double remoteVoltageControlReactivePercent);
 }

--- a/src/main/java/com/powsybl/openloadflow/network/VoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/VoltageControl.java
@@ -82,7 +82,7 @@ public class VoltageControl {
         double reactiveKeysSum = Arrays.stream(reactiveKeys).sum();
         for (int i = 0; i < controllerBuses.size(); i++) {
             LfBus controllerBus = controllerBuses.get(i);
-            controllerBus.setRemoteControlReactivePercent(reactiveKeys[i] / reactiveKeysSum);
+            controllerBus.setRemoteVoltageControlReactivePercent(reactiveKeysSum == 0 ? 0 : reactiveKeys[i] / reactiveKeysSum);
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/VoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/VoltageControl.java
@@ -67,10 +67,22 @@ public class VoltageControl {
 
     public void updateReactiveKeys() {
         List<LfBus> controllerBuses = new ArrayList<>(controllers);
+
         double[] reactiveKeys = createReactiveKeys(controllerBuses);
+
+        // no reactive dispatch on PQ buses, so we set the key to 0
+        for (int i = 0; i < controllerBuses.size(); i++) {
+            LfBus controllerBus = controllerBuses.get(i);
+            if (!controllerBus.isVoltageControllerEnabled()) {
+                reactiveKeys[i] = 0d;
+            }
+        }
+
+        // update bus reactive keys
         double reactiveKeysSum = Arrays.stream(reactiveKeys).sum();
         for (int i = 0; i < controllerBuses.size(); i++) {
-            controllerBuses.get(i).setRemoteControlReactivePercent(reactiveKeys[i] / reactiveKeysSum);
+            LfBus controllerBus = controllerBuses.get(i);
+            controllerBus.setRemoteControlReactivePercent(reactiveKeys[i] / reactiveKeysSum);
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/VoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/VoltageControl.java
@@ -6,6 +6,9 @@
  */
 package com.powsybl.openloadflow.network;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.*;
 
 /**
@@ -13,6 +16,8 @@ import java.util.*;
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
 public class VoltageControl {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VoltageControl.class);
 
     private final LfBus controlled;
 
@@ -58,5 +63,61 @@ public class VoltageControl {
      */
     public boolean isSharedControl() {
         return controllers.stream().flatMap(lfBus -> lfBus.getGenerators().stream()).filter(LfGenerator::hasVoltageControl).count() > 1;
+    }
+
+    public void updateReactiveKeys() {
+        List<LfBus> controllerBuses = new ArrayList<>(controllers);
+        double[] reactiveKeys = createReactiveKeys(controllerBuses);
+        double reactiveKeysSum = Arrays.stream(reactiveKeys).sum();
+        for (int i = 0; i < controllerBuses.size(); i++) {
+            controllerBuses.get(i).setRemoteControlReactivePercent(reactiveKeys[i] / reactiveKeysSum);
+        }
+    }
+
+    private static double[] createUniformReactiveKeys(List<LfBus> controllerBuses) {
+        double[] qKeys = new double[controllerBuses.size()];
+        for (int i = 0; i < controllerBuses.size(); i++) {
+            LfBus controllerBus = controllerBuses.get(i);
+            qKeys[i] = controllerBus.getGenerators().stream().filter(LfGenerator::hasVoltageControl).count();
+        }
+        return qKeys;
+    }
+
+    private static double[] createReactiveKeysFromMaxReactivePowerRange(List<LfBus> controllerBuses) {
+        double[] qKeys = new double[controllerBuses.size()];
+        // try to build keys from reactive power range
+        for (int i = 0; i < controllerBuses.size(); i++) {
+            LfBus controllerBus = controllerBuses.get(i);
+            for (LfGenerator generator : controllerBus.getGenerators()) {
+                double maxRangeQ = generator.getMaxRangeQ();
+                // if one reactive range is not plausible, we fallback to uniform keys
+                if (maxRangeQ < PlausibleValues.MIN_REACTIVE_RANGE / PerUnit.SB || maxRangeQ > PlausibleValues.MAX_REACTIVE_RANGE / PerUnit.SB) {
+                    return createUniformReactiveKeys(controllerBuses);
+                } else {
+                    qKeys[i] += maxRangeQ;
+                }
+            }
+        }
+        return qKeys;
+    }
+
+    private static double[] createReactiveKeys(List<LfBus> controllerBuses) {
+        double[] qKeys = new double[controllerBuses.size()];
+        for (int i = 0; i < controllerBuses.size(); i++) {
+            LfBus controllerBus = controllerBuses.get(i);
+            for (LfGenerator generator : controllerBus.getGenerators()) {
+                double qKey = generator.getRemoteControlReactiveKey().orElse(Double.NaN);
+                if (Double.isNaN(qKey) || qKey == 0) {
+                    if (qKey == 0) {
+                        LOGGER.error("Generator '{}' remote control reactive key value is zero", generator.getId());
+                    }
+                    // in case of one missing key, we fallback to keys based on reactive power range
+                    return createReactiveKeysFromMaxReactivePowerRange(controllerBuses);
+                } else {
+                    qKeys[i] += qKey;
+                }
+            }
+        }
+        return qKeys;
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -77,7 +77,7 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
 
     protected Evaluable q = NAN;
 
-    protected double remoteControlReactivePercent = Double.NaN;
+    protected double remoteVoltageControlReactivePercent = Double.NaN;
 
     protected AbstractLfBus(LfNetwork network, double v, double angle) {
         super(network);
@@ -554,13 +554,13 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     }
 
     @Override
-    public double getRemoteControlReactivePercent() {
-        return remoteControlReactivePercent;
+    public double getRemoteVoltageControlReactivePercent() {
+        return remoteVoltageControlReactivePercent;
     }
 
     @Override
-    public void setRemoteControlReactivePercent(double remoteControlReactivePercent) {
-        this.remoteControlReactivePercent = remoteControlReactivePercent;
+    public void setRemoteVoltageControlReactivePercent(double remoteVoltageControlReactivePercent) {
+        this.remoteVoltageControlReactivePercent = remoteVoltageControlReactivePercent;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -77,6 +77,8 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
 
     protected Evaluable q = NAN;
 
+    protected double remoteControlReactivePercent = Double.NaN;
+
     protected AbstractLfBus(LfNetwork network, double v, double angle) {
         super(network);
         this.v = v;
@@ -549,6 +551,16 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
             }
         }
         return neighbors;
+    }
+
+    @Override
+    public double getRemoteControlReactivePercent() {
+        return remoteControlReactivePercent;
+    }
+
+    @Override
+    public void setRemoteControlReactivePercent(double remoteControlReactivePercent) {
+        this.remoteControlReactivePercent = remoteControlReactivePercent;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -639,6 +639,11 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         if (!parameters.isDc()) {
             // Fixing voltage controls need to be done after creating switches, as the zero-impedance graph is changed with switches
             fixAllVoltageControls(lfNetwork, parameters.isMinImpedance(), parameters.isTransformerVoltageControl());
+
+            // calculate voltage remote control reactive keys
+            for (LfBus bus : lfNetwork.getBuses()) {
+                bus.getVoltageControl().ifPresent(VoltageControl::updateReactiveKeys);
+            }
         }
 
         if (!parameters.isMinImpedance()) {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -639,11 +639,6 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         if (!parameters.isDc()) {
             // Fixing voltage controls need to be done after creating switches, as the zero-impedance graph is changed with switches
             fixAllVoltageControls(lfNetwork, parameters.isMinImpedance(), parameters.isTransformerVoltageControl());
-
-            // calculate voltage remote control reactive keys
-            for (LfBus bus : lfNetwork.getBuses()) {
-                bus.getVoltageControl().ifPresent(VoltageControl::updateReactiveKeys);
-            }
         }
 
         if (!parameters.isMinImpedance()) {


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
Shared voltage control is modeled using one PQV bus at controlled bus and (Ngen - 1) reactive distribution equations at all controller buses except one. These equations allows to define reactive power distribution across all voltage controller buses.  
The problem with such a modeling is that when one controller bus of the shared control switch PQ (reactive limit bound reached), as reactive power equations have been defined 2 by 2 using an arbitrary reference controller bus we have to remove all reactive power distribution equations and re-create all of them using potentially a new reference controller bus.
This is a heavy operation and it should be simpler if we can just active/deactivate some predefined equations. Furthermore for later performance optimization we will try to define alternative equations (i.e couple of equation that when one is activate the other is deactivate automatically and vice versa) so that we only have to update Jacobian matrix when a bus is switched PV/PQ ou PQ/PV and not fully rebuild it.

TODO: same for transformer voltage control has to be done in this PR

**What is the new behavior (if this is a feature change)?**
We only need to deactivate/activate right predefined equations when switch a PV to PQ or PQ to PV bus. There is no more equation removal. 


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
