### PR TITLE
Fix shunt voltage control

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/TransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/TransformerVoltageControlOuterLoop.java
@@ -56,7 +56,7 @@ public class TransformerVoltageControlOuterLoop implements OuterLoop {
             double r1Value = piModel.getR1();
             piModel.roundR1ToClosestTap();
             double roundedR1Value = piModel.getR1();
-            LOGGER.trace("Round voltage shift of '{}': {} -> {}", controllerBranch.getId(), r1Value, roundedR1Value);
+            LOGGER.info("Round voltage shift of '{}': {} -> {}", controllerBranch.getId(), r1Value, roundedR1Value);
         }
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/ac/TransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/TransformerVoltageControlOuterLoop.java
@@ -56,7 +56,7 @@ public class TransformerVoltageControlOuterLoop implements OuterLoop {
             double r1Value = piModel.getR1();
             piModel.roundR1ToClosestTap();
             double roundedR1Value = piModel.getR1();
-            LOGGER.info("Round voltage shift of '{}': {} -> {}", controllerBranch.getId(), r1Value, roundedR1Value);
+            LOGGER.trace("Round voltage shift of '{}': {} -> {}", controllerBranch.getId(), r1Value, roundedR1Value);
         }
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
@@ -107,7 +107,7 @@ public final class AcEquationSystem {
             equationSystem.createEquation(bus.getNum(), AcEquationType.BUS_TARGET_Q).addTerm(q);
         });
         bus.getControllerShunt().ifPresent(shunt -> {
-            ShuntCompensatorReactiveFlowEquationTerm q = new ShuntCompensatorReactiveFlowEquationTerm(shunt, bus, equationSystem.getVariableSet(), true);
+            ShuntCompensatorReactiveFlowEquationTerm q = new ShuntCompensatorReactiveFlowEquationTerm(shunt, bus, equationSystem.getVariableSet(), shunt.hasVoltageControl());
             equationSystem.createEquation(bus.getNum(), AcEquationType.BUS_TARGET_Q).addTerm(q);
         });
     }

--- a/src/main/java/com/powsybl/openloadflow/network/LfShunt.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfShunt.java
@@ -18,4 +18,8 @@ public interface LfShunt extends LfElement {
     double dispatchB();
 
     void updateState();
+
+    boolean hasVoltageControl();
+
+    void setVoltageControl(boolean voltageControl);
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -628,14 +628,23 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         LfBus controlledBus = getLfBus(shuntCompensator.getRegulatingTerminal(), lfNetwork, breakers);
         if (controlledBus == null) {
             LOGGER.warn("Regulating terminal of voltage controller shunt {} is out of voltage: no voltage control created", shuntCompensator.getId());
+            controllerBus.getControllerShunt().ifPresent(shunt ->
+                    shunt.setVoltageControl(false)
+            );
             return;
         }
         if (controlledBus.isVoltageControlled()) {
             LOGGER.warn("Controlled bus {} has both generator and shunt voltage control on: only generator control is kept", controlledBus.getId());
+            controllerBus.getControllerShunt().ifPresent(shunt ->
+                    shunt.setVoltageControl(false)
+            );
             return;
         }
         controlledBus.getTransformerVoltageControl().ifPresent(vc -> {
             LOGGER.trace("Controlled bus {} has already a transformer voltage control: only transformer control is kept", controlledBus.getId());
+            controllerBus.getControllerShunt().ifPresent(shunt ->
+                    shunt.setVoltageControl(false)
+            );
             return;
         });
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -645,7 +645,6 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
             controllerBus.getControllerShunt().ifPresent(shunt ->
                     shunt.setVoltageControl(false)
             );
-            return;
         });
 
         double regulatingTerminalNominalV = shuntCompensator.getRegulatingTerminal().getVoltageLevel().getNominalV();

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -640,12 +640,14 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
             );
             return;
         }
-        controlledBus.getTransformerVoltageControl().ifPresent(vc -> {
-            LOGGER.trace("Controlled bus {} has already a transformer voltage control: only transformer control is kept", controlledBus.getId());
+        Optional<TransformerVoltageControl> tvc = controlledBus.getTransformerVoltageControl();
+        if (tvc.isPresent()) {
+            LOGGER.error("Controlled bus {} has already a transformer voltage control: only transformer control is kept", controlledBus.getId());
             controllerBus.getControllerShunt().ifPresent(shunt ->
                     shunt.setVoltageControl(false)
             );
-        });
+            return;
+        }
 
         double regulatingTerminalNominalV = shuntCompensator.getRegulatingTerminal().getVoltageLevel().getNominalV();
         double targetValue = shuntCompensator.getTargetV() / regulatingTerminalNominalV;

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfShuntImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfShuntImpl.java
@@ -142,7 +142,7 @@ public class LfShuntImpl extends AbstractElement implements LfShunt {
 
     @Override
     public boolean hasVoltageControl() {
-        return this.withVoltageControl;
+        return withVoltageControl;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfShuntImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfShuntImpl.java
@@ -26,7 +26,7 @@ public class LfShuntImpl extends AbstractElement implements LfShunt {
 
     private final LfBus bus;
 
-    private final boolean withVoltageControl;
+    private boolean withVoltageControl;
 
     private final List<Controller> controllers = new ArrayList<>();
 
@@ -138,6 +138,16 @@ public class LfShuntImpl extends AbstractElement implements LfShunt {
     @Override
     public void setB(double b) {
         this.b = b;
+    }
+
+    @Override
+    public boolean hasVoltageControl() {
+        return this.withVoltageControl;
+    }
+
+    @Override
+    public void setVoltageControl(boolean voltageControl) {
+        this.withVoltageControl = voltageControl;
     }
 
     private void roundBToClosestSection(double b, Controller controller) {

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowShuntTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowShuntTest.java
@@ -350,4 +350,29 @@ class AcLoadFlowShuntTest {
         assertEquals(10, shuntCompensator2.getSectionCount());
         assertEquals(10, shuntCompensator3.getSectionCount());
     }
+
+    @Test
+    void testNoShuntVoltageControl() {
+        parameters.setSimulShunt(true);
+        shunt.setRegulatingTerminal(network.getGenerator("g1").getTerminal());
+        shunt.setSectionCount(0);
+        shunt.setVoltageRegulatorOn(true);
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertVoltageEquals(388.581, bus3);
+        assertEquals(0, shunt.getSectionCount());
+    }
+
+    @Test
+    void testNoShuntVoltageControl2() {
+        parameters.setSimulShunt(true);
+        shunt.setSectionCount(0);
+        shunt.setVoltageRegulatorOn(true);
+        shunt.setRegulatingTerminal(network.getLoad("ld1").getTerminal());
+        network.getLoad("ld1").getTerminal().disconnect();
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertVoltageEquals(389.999, bus3);
+        assertEquals(0, shunt.getSectionCount());
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowShuntTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowShuntTest.java
@@ -375,4 +375,48 @@ class AcLoadFlowShuntTest {
         assertVoltageEquals(389.999, bus3);
         assertEquals(0, shunt.getSectionCount());
     }
+
+    @Test
+    void testNoShuntVoltageControl3() {
+        Network network = VoltageControlNetworkFactory.createWithShuntRemoteControl();
+        TwoWindingsTransformer twt = network.getTwoWindingsTransformer("tr1");
+        twt.newRatioTapChanger()
+                .setTargetDeadband(0)
+                .setTapPosition(0)
+                .setLoadTapChangingCapabilities(true)
+                .setRegulating(true)
+                .setTargetV(400)
+                .setRegulationTerminal(network.getLoad("l4").getTerminal())
+                .beginStep()
+                .setRho(0.9)
+                .setR(0.1089)
+                .setX(0.01089)
+                .setG(0.8264462809917356)
+                .setB(0.08264462809917356)
+                .endStep()
+                .beginStep()
+                .setRho(1.0)
+                .setR(0.121)
+                .setX(0.0121)
+                .setG(0.8264462809917356)
+                .setB(0.08264462809917356)
+                .endStep()
+                .beginStep()
+                .setRho(1.1)
+                .setR(0.1331)
+                .setX(0.01331)
+                .setG(0.9090909090909092)
+                .setB(0.09090909090909092)
+                .endStep()
+                .add();
+        parameters.setSimulShunt(true);
+        parameters.setTransformerVoltageControlOn(true);
+        ShuntCompensator shuntCompensator2 = network.getShuntCompensator("SHUNT2");
+        ShuntCompensator shuntCompensator3 = network.getShuntCompensator("SHUNT3");
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertVoltageEquals(419.690, network.getBusBreakerView().getBus("b4"));
+        assertEquals(0, shuntCompensator2.getSectionCount());
+        assertEquals(0, shuntCompensator3.getSectionCount());
+    }
 }


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <anne.tilloy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

No SHUNT_B variable are created when the shunt controller is indeed deactivated after creation. For example, if we have already a voltage control at controlled bus or a transformer volatge control at controlled bus. 

**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
