### PR TITLE
Add option to write inactive equations and terms

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/equations/Equation.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/Equation.java
@@ -145,14 +145,20 @@ public class Equation<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity
         return c;
     }
 
-    public void write(Writer writer) throws IOException {
+    public void write(Writer writer, boolean writeInactiveTerms) throws IOException {
         writer.append(type.getSymbol())
                 .append(Integer.toString(elementNum))
                 .append(" = ");
-        List<EquationTerm<V, E>> activeTerms = terms.stream().filter(EquationTerm::isActive).collect(Collectors.toList());
+        List<EquationTerm<V, E>> activeTerms = writeInactiveTerms ? terms : terms.stream().filter(EquationTerm::isActive).collect(Collectors.toList());
         for (Iterator<EquationTerm<V, E>> it = activeTerms.iterator(); it.hasNext();) {
             EquationTerm<V, E> term = it.next();
+            if (!term.isActive()) {
+                writer.write("[ ");
+            }
             term.write(writer);
+            if (!term.isActive()) {
+                writer.write(" ]");
+            }
             if (it.hasNext()) {
                 writer.append(" + ");
             }

--- a/src/test/java/com/powsybl/openloadflow/equations/EquationSystemTest.java
+++ b/src/test/java/com/powsybl/openloadflow/equations/EquationSystemTest.java
@@ -24,8 +24,6 @@ import com.powsybl.openloadflow.network.util.UniformValueVoltageInitializer;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -123,45 +121,65 @@ class EquationSystemTest {
     }
 
     @Test
-    void writeAcSystemTest() throws IOException {
+    void writeAcSystemTest() {
         List<LfNetwork> lfNetworks = Networks.load(EurostagTutorialExample1Factory.create(), new FirstSlackBusSelector());
         LfNetwork network = lfNetworks.get(0);
 
         EquationSystem<AcVariableType, AcEquationType> equationSystem = AcEquationSystem.create(network);
-        try (StringWriter writer = new StringWriter()) {
-            equationSystem.write(writer);
-            writer.flush();
-            String ref = String.join(System.lineSeparator(),
-                    "bus_target_v0 = v0",
-                    "bus_target_φ0 = φ0",
-                    "bus_target_p1 = ac_p_closed_2(v0, v1, φ0, φ1) + ac_p_closed_1(v1, v2, φ1, φ2) + ac_p_closed_1(v1, v2, φ1, φ2)",
-                    "bus_target_q1 = ac_q_closed_2(v0, v1, φ0, φ1) + ac_q_closed_1(v1, v2, φ1, φ2) + ac_q_closed_1(v1, v2, φ1, φ2)",
-                    "bus_target_p2 = ac_p_closed_2(v1, v2, φ1, φ2) + ac_p_closed_2(v1, v2, φ1, φ2) + ac_p_closed_1(v2, v3, φ2, φ3)",
-                    "bus_target_q2 = ac_q_closed_2(v1, v2, φ1, φ2) + ac_q_closed_2(v1, v2, φ1, φ2) + ac_q_closed_1(v2, v3, φ2, φ3)",
-                    "bus_target_p3 = ac_p_closed_2(v2, v3, φ2, φ3)",
-                    "bus_target_q3 = ac_q_closed_2(v2, v3, φ2, φ3)")
-                    + System.lineSeparator();
-            assertEquals(ref, writer.toString());
-        }
+        String ref = String.join(System.lineSeparator(),
+                "bus_target_v0 = v0",
+                "bus_target_φ0 = φ0",
+                "bus_target_p1 = ac_p_closed_2(v0, v1, φ0, φ1) + ac_p_closed_1(v1, v2, φ1, φ2) + ac_p_closed_1(v1, v2, φ1, φ2)",
+                "bus_target_q1 = ac_q_closed_2(v0, v1, φ0, φ1) + ac_q_closed_1(v1, v2, φ1, φ2) + ac_q_closed_1(v1, v2, φ1, φ2)",
+                "bus_target_p2 = ac_p_closed_2(v1, v2, φ1, φ2) + ac_p_closed_2(v1, v2, φ1, φ2) + ac_p_closed_1(v2, v3, φ2, φ3)",
+                "bus_target_q2 = ac_q_closed_2(v1, v2, φ1, φ2) + ac_q_closed_2(v1, v2, φ1, φ2) + ac_q_closed_1(v2, v3, φ2, φ3)",
+                "bus_target_p3 = ac_p_closed_2(v2, v3, φ2, φ3)",
+                "bus_target_q3 = ac_q_closed_2(v2, v3, φ2, φ3)")
+                + System.lineSeparator();
+        assertEquals(ref, equationSystem.writeToString());
     }
 
     @Test
-    void writeDcSystemTest() throws IOException {
+    void writeAllEquationsAcSystemTest() {
+        List<LfNetwork> lfNetworks = Networks.load(EurostagTutorialExample1Factory.create(), new FirstSlackBusSelector());
+        LfNetwork network = lfNetworks.get(0);
+
+        EquationSystem<AcVariableType, AcEquationType> equationSystem = AcEquationSystem.create(network);
+        // just to test inactive term writing
+        for (var equationTerm : equationSystem.getEquationTerms(ElementType.BRANCH, network.getBranchById("NHV1_NHV2_1").getNum())) {
+            equationTerm.setActive(false);
+        }
+        String ref = String.join(System.lineSeparator(),
+                "[ bus_target_p0 = ac_p_closed_1(v0, v1, φ0, φ1) ]",
+                "[ bus_target_q0 = ac_q_closed_1(v0, v1, φ0, φ1) ]",
+                "bus_target_v0 = v0",
+                "bus_target_φ0 = φ0",
+                "bus_target_p1 = ac_p_closed_2(v0, v1, φ0, φ1) + [ ac_p_closed_1(v1, v2, φ1, φ2) ] + ac_p_closed_1(v1, v2, φ1, φ2)",
+                "bus_target_q1 = ac_q_closed_2(v0, v1, φ0, φ1) + [ ac_q_closed_1(v1, v2, φ1, φ2) ] + ac_q_closed_1(v1, v2, φ1, φ2)",
+                "[ bus_target_v1 = v1 ]",
+                "bus_target_p2 = [ ac_p_closed_2(v1, v2, φ1, φ2) ] + ac_p_closed_2(v1, v2, φ1, φ2) + ac_p_closed_1(v2, v3, φ2, φ3)",
+                "bus_target_q2 = [ ac_q_closed_2(v1, v2, φ1, φ2) ] + ac_q_closed_2(v1, v2, φ1, φ2) + ac_q_closed_1(v2, v3, φ2, φ3)",
+                "[ bus_target_v2 = v2 ]",
+                "bus_target_p3 = ac_p_closed_2(v2, v3, φ2, φ3)",
+                "bus_target_q3 = ac_q_closed_2(v2, v3, φ2, φ3)",
+                "[ bus_target_v3 = v3 ]")
+                + System.lineSeparator();
+        assertEquals(ref, equationSystem.writeToString(true));
+    }
+
+    @Test
+    void writeDcSystemTest() {
         List<LfNetwork> lfNetworks = Networks.load(EurostagTutorialExample1Factory.create(), new FirstSlackBusSelector());
         LfNetwork network = lfNetworks.get(0);
 
         EquationSystem<DcVariableType, DcEquationType> equationSystem = DcEquationSystem.create(network, new DcEquationSystemCreationParameters(true, false, false, true));
-        try (StringWriter writer = new StringWriter()) {
-            equationSystem.write(writer);
-            writer.flush();
-            String ref = String.join(System.lineSeparator(),
-                    "bus_target_φ0 = φ0",
-                    "bus_target_p1 = dc_p_2(φ0, φ1) + dc_p_1(φ1, φ2) + dc_p_1(φ1, φ2)",
-                    "bus_target_p2 = dc_p_2(φ1, φ2) + dc_p_2(φ1, φ2) + dc_p_1(φ2, φ3)",
-                    "bus_target_p3 = dc_p_2(φ2, φ3)")
-                    + System.lineSeparator();
-            assertEquals(ref, writer.toString());
-        }
+        String ref = String.join(System.lineSeparator(),
+                "bus_target_φ0 = φ0",
+                "bus_target_p1 = dc_p_2(φ0, φ1) + dc_p_1(φ1, φ2) + dc_p_1(φ1, φ2)",
+                "bus_target_p2 = dc_p_2(φ1, φ2) + dc_p_2(φ1, φ2) + dc_p_1(φ2, φ3)",
+                "bus_target_p3 = dc_p_2(φ2, φ3)")
+                + System.lineSeparator();
+        assertEquals(ref, equationSystem.writeToString());
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
There is no way to write an equation system and see inactive equations ands terms.


**What is the new behavior (if this is a feature change)?**
An option has been added to write into [ ] inactive equations and terms. 


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
