### PR TITLE
Improve transformer voltage control unit testing

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
@@ -56,7 +56,7 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenLoadFlowProvider.class);
 
-    private static final String NAME = "OpenLoadFlow";
+    public static final String NAME = "OpenLoadFlow";
 
     private final MatrixFactory matrixFactory;
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
@@ -129,7 +129,7 @@ public interface LfBranch extends LfElement {
 
     void setVoltageControl(TransformerVoltageControl transformerVoltageControl);
 
-    BranchResult createBranchResult(double preContingencyP1, double branchInContingencyP1);
+    BranchResult createBranchResult(double preContingencyP1, double branchInContingencyP1, boolean createExtension);
 
     double computeApparentPower1();
 

--- a/src/main/java/com/powsybl/openloadflow/network/PiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModel.java
@@ -37,6 +37,8 @@ public interface PiModel {
 
     double getR1();
 
+    double getContinuousR1();
+
     double getA1();
 
     PiModel setA1(double a1);

--- a/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
@@ -24,6 +24,8 @@ public class PiModelArray implements PiModel {
 
     private double r1 = Double.NaN;
 
+    private double continuousR1 = Double.NaN;
+
     private LfBranch branch;
 
     public PiModelArray(List<PiModel> models, int lowTapPosition, int tapPosition) {
@@ -92,6 +94,11 @@ public class PiModelArray implements PiModel {
     }
 
     @Override
+    public double getContinuousR1() {
+        return continuousR1;
+    }
+
+    @Override
     public double getA1() {
         return Double.isNaN(a1) ? getModel().getA1() : a1;
     }
@@ -141,6 +148,7 @@ public class PiModelArray implements PiModel {
                 smallestDistance = distance;
             }
         }
+        continuousR1 = r1;
         r1 = Double.NaN;
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
@@ -99,6 +99,11 @@ public class SimplePiModel implements PiModel {
         return r1;
     }
 
+    @Override
+    public double getContinuousR1() {
+        return r1;
+    }
+
     public SimplePiModel setR1(double r1) {
         this.r1 = r1;
         return this;

--- a/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
@@ -101,7 +101,7 @@ public class SimplePiModel implements PiModel {
 
     @Override
     public double getContinuousR1() {
-        return r1;
+        return getR1();
     }
 
     public SimplePiModel setR1(double r1) {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
@@ -31,7 +31,7 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
 
     private final Map<LimitType, List<LfLimit>> limits2 = new EnumMap<>(LimitType.class);
 
-    private final PiModel piModel;
+    protected final PiModel piModel;
 
     protected DiscretePhaseControl discretePhaseControl;
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
@@ -42,8 +42,6 @@ public class LfBranchImpl extends AbstractLfBranch {
 
     private Evaluable i2 = NAN;
 
-    private boolean debug = false;
-
     protected LfBranchImpl(LfNetwork network, LfBus bus1, LfBus bus2, PiModel piModel, Branch<?> branch) {
         super(network, bus1, bus2, piModel);
         this.branch = branch;
@@ -115,11 +113,7 @@ public class LfBranchImpl extends AbstractLfBranch {
             piModel = Transformers.createPiModel(tapCharacteristics, zb, baseRatio, twtSplitShuntAdmittance);
         }
 
-        LfBranchImpl branch = new LfBranchImpl(network, bus1, bus2, piModel, twt);
-        if (twt.hasProperty("olf-debug")) {
-            branch.setDebug(true);
-        }
-        return branch;
+        return new LfBranchImpl(network, bus1, bus2, piModel, twt);
     }
 
     public static LfBranchImpl create(Branch<?> branch, LfNetwork network, LfBus bus1, LfBus bus2, boolean twtSplitShuntAdmittance,
@@ -213,10 +207,6 @@ public class LfBranchImpl extends AbstractLfBranch {
         return i2;
     }
 
-    public void setDebug(boolean debug) {
-        this.debug = debug;
-    }
-
     @Override
     public BranchResult createBranchResult(double preContingencyP1, double branchInContingencyP1) {
         double flowTransfer = Double.NaN;
@@ -225,14 +215,10 @@ public class LfBranchImpl extends AbstractLfBranch {
         }
         double currentScale1 = PerUnit.ib(branch.getTerminal1().getVoltageLevel().getNominalV());
         double currentScale2 = PerUnit.ib(branch.getTerminal2().getVoltageLevel().getNominalV());
-        if (debug) {
-            return new OlfBranchResult(getId(), p1.eval() * PerUnit.SB, q1.eval() * PerUnit.SB, currentScale1 * i1.eval(),
-                                       p2.eval() * PerUnit.SB, q2.eval() * PerUnit.SB, currentScale2 * i2.eval(), flowTransfer,
-                                       piModel.getR1(), piModel.getContinuousR1());
-        } else {
-            return new BranchResult(getId(), p1.eval() * PerUnit.SB, q1.eval() * PerUnit.SB, currentScale1 * i1.eval(),
-                                    p2.eval() * PerUnit.SB, q2.eval() * PerUnit.SB, currentScale2 * i2.eval(), flowTransfer);
-        }
+        var branchResult = new BranchResult(getId(), p1.eval() * PerUnit.SB, q1.eval() * PerUnit.SB, currentScale1 * i1.eval(),
+                                            p2.eval() * PerUnit.SB, q2.eval() * PerUnit.SB, currentScale2 * i2.eval(), flowTransfer);
+        branchResult.addExtension(OlfBranchResult.class, new OlfBranchResult(piModel.getR1(), piModel.getContinuousR1()));
+        return branchResult;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
@@ -208,7 +208,7 @@ public class LfBranchImpl extends AbstractLfBranch {
     }
 
     @Override
-    public BranchResult createBranchResult(double preContingencyP1, double branchInContingencyP1) {
+    public BranchResult createBranchResult(double preContingencyP1, double branchInContingencyP1, boolean createExtension) {
         double flowTransfer = Double.NaN;
         if (!Double.isNaN(preContingencyP1) && !Double.isNaN(branchInContingencyP1)) {
             flowTransfer = (p1.eval() * PerUnit.SB - preContingencyP1) / branchInContingencyP1;
@@ -217,7 +217,9 @@ public class LfBranchImpl extends AbstractLfBranch {
         double currentScale2 = PerUnit.ib(branch.getTerminal2().getVoltageLevel().getNominalV());
         var branchResult = new BranchResult(getId(), p1.eval() * PerUnit.SB, q1.eval() * PerUnit.SB, currentScale1 * i1.eval(),
                                             p2.eval() * PerUnit.SB, q2.eval() * PerUnit.SB, currentScale2 * i2.eval(), flowTransfer);
-        branchResult.addExtension(OlfBranchResult.class, new OlfBranchResult(piModel.getR1(), piModel.getContinuousR1()));
+        if (createExtension) {
+            branchResult.addExtension(OlfBranchResult.class, new OlfBranchResult(piModel.getR1(), piModel.getContinuousR1()));
+        }
         return branchResult;
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
@@ -60,7 +60,7 @@ public class LfDanglingLineBranch extends AbstractFictitiousLfBranch {
     }
 
     @Override
-    public BranchResult createBranchResult(double preContingencyP1, double branchInContingencyP1) {
+    public BranchResult createBranchResult(double preContingencyP1, double branchInContingencyP1, boolean createExtension) {
         throw new PowsyblException("Unsupported type of branch for branch result: " + getId());
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
@@ -126,7 +126,7 @@ public class LfLegBranch extends AbstractFictitiousLfBranch {
     }
 
     @Override
-    public BranchResult createBranchResult(double preContingencyP1, double branchInContingencyP1) {
+    public BranchResult createBranchResult(double preContingencyP1, double branchInContingencyP1, boolean createExtension) {
         throw new PowsyblException("Unsupported type of branch for branch result: " + getId());
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfSwitch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfSwitch.java
@@ -107,7 +107,7 @@ public class LfSwitch extends AbstractLfBranch {
     }
 
     @Override
-    public BranchResult createBranchResult(double preContingencyP1, double branchInContingencyP1) {
+    public BranchResult createBranchResult(double preContingencyP1, double branchInContingencyP1, boolean createExtension) {
         throw new PowsyblException("Unsupported type of branch for branch result: " + aSwitch.getId());
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/OlfBranchResult.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/OlfBranchResult.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.network.impl;
+
+import com.powsybl.security.results.BranchResult;
+
+import java.util.Objects;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class OlfBranchResult extends BranchResult {
+
+    private final double r1;
+
+    private final double continuousR1;
+
+    public OlfBranchResult(String branchId, double p1, double q1, double i1, double p2, double q2, double i2,
+                           double flowTransfer, double r1, double continuousR1) {
+        super(branchId, p1, q1, i1, p2, q2, i2, flowTransfer);
+        this.r1 = r1;
+        this.continuousR1 = continuousR1;
+    }
+
+    public double getR1() {
+        return r1;
+    }
+
+    public double getContinuousR1() {
+        return continuousR1;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        OlfBranchResult that = (OlfBranchResult) o;
+        return Double.compare(that.r1, r1) == 0 && Double.compare(that.continuousR1, continuousR1) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), r1, continuousR1);
+    }
+}

--- a/src/main/java/com/powsybl/openloadflow/network/impl/OlfBranchResult.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/OlfBranchResult.java
@@ -6,24 +6,26 @@
  */
 package com.powsybl.openloadflow.network.impl;
 
+import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.security.results.BranchResult;
-
-import java.util.Objects;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public class OlfBranchResult extends BranchResult {
+public class OlfBranchResult extends AbstractExtension<BranchResult> {
 
     private final double r1;
 
     private final double continuousR1;
 
-    public OlfBranchResult(String branchId, double p1, double q1, double i1, double p2, double q2, double i2,
-                           double flowTransfer, double r1, double continuousR1) {
-        super(branchId, p1, q1, i1, p2, q2, i2, flowTransfer);
+    public OlfBranchResult(double r1, double continuousR1) {
         this.r1 = r1;
         this.continuousR1 = continuousR1;
+    }
+
+    @Override
+    public String getName() {
+        return "OlfBranchResult";
     }
 
     public double getR1() {
@@ -32,25 +34,5 @@ public class OlfBranchResult extends BranchResult {
 
     public double getContinuousR1() {
         return continuousR1;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-        OlfBranchResult that = (OlfBranchResult) o;
-        return Double.compare(that.r1, r1) == 0 && Double.compare(that.continuousR1, continuousR1) == 0;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), r1, continuousR1);
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
@@ -250,18 +250,18 @@ public abstract class AbstractSecurityAnalysis {
 
     protected void addMonitorInfo(LfNetwork network, StateMonitor monitor, Collection<BranchResult> branchResultConsumer,
                                   Collection<BusResult> busResultsConsumer, Collection<ThreeWindingsTransformerResult> threeWindingsTransformerResultConsumer,
-                                  Map<String, BranchResult> preContingencyBranchResults, String contingencyId) {
+                                  Map<String, BranchResult> preContingencyBranchResults, String contingencyId, boolean createResultExtension) {
         network.getBranches().stream().filter(lfBranch -> monitor.getBranchIds().contains(lfBranch.getId()))
                 .filter(lfBranch -> !lfBranch.isDisabled())
                 .forEach(lfBranch -> {
                     BranchResult branchResult;
                     if (contingencyId == null) {
-                        branchResult = lfBranch.createBranchResult(Double.NaN, Double.NaN);
+                        branchResult = lfBranch.createBranchResult(Double.NaN, Double.NaN, createResultExtension);
                         preContingencyBranchResults.put(lfBranch.getId(), branchResult);
                     } else {
                         double preContingencyP1 = preContingencyBranchResults.get(lfBranch.getId()) != null ? preContingencyBranchResults.get(lfBranch.getId()).getP1() : Double.NaN;
                         double branchInContingencyP1 = preContingencyBranchResults.get(contingencyId) != null ? preContingencyBranchResults.get(contingencyId).getP1() : Double.NaN;
-                        branchResult = lfBranch.createBranchResult(preContingencyP1, branchInContingencyP1);
+                        branchResult = lfBranch.createBranchResult(preContingencyP1, branchInContingencyP1, createResultExtension);
                     }
                     branchResultConsumer.add(branchResult);
                 });

--- a/src/main/java/com/powsybl/openloadflow/sa/AcSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AcSecurityAnalysis.java
@@ -125,9 +125,9 @@ public class AcSecurityAnalysis extends AbstractSecurityAnalysis {
                     .run(Reporter.NO_OP);
             Map<String, BranchResult> results = new LinkedHashMap<>();
             addMonitorInfo(network, monitorIndex.getNoneStateMonitor(), preContingencyBranchResults, preContingencyBusResults,
-                    preContingencyThreeWindingsTransformerResults, results, null);
+                    preContingencyThreeWindingsTransformerResults, results, null, true);
             addMonitorInfo(network, monitorIndex.getAllStateMonitor(), preContingencyBranchResults, preContingencyBusResults,
-                    preContingencyThreeWindingsTransformerResults, results, null);
+                    preContingencyThreeWindingsTransformerResults, results, null, true);
             boolean preContingencyComputationOk = preContingencyLoadFlowResult.getNewtonRaphsonStatus() == NewtonRaphsonStatus.CONVERGED;
             Map<Pair<String, Branch.Side>, LimitViolation> preContingencyLimitViolations = new LinkedHashMap<>();
 
@@ -193,11 +193,11 @@ public class AcSecurityAnalysis extends AbstractSecurityAnalysis {
                     network.getBuses().stream().filter(b -> !b.isDisabled()),
                     postContingencyLimitViolations);
 
-            addMonitorInfo(network, monitorIndex.getAllStateMonitor(), branchResults, busResults, threeWindingsTransformerResults, preContingencyBranchResults, lfContingency.getId());
+            addMonitorInfo(network, monitorIndex.getAllStateMonitor(), branchResults, busResults, threeWindingsTransformerResults, preContingencyBranchResults, lfContingency.getId(), true);
 
             StateMonitor stateMonitor = monitorIndex.getSpecificStateMonitors().get(lfContingency.getId());
             if (stateMonitor != null) {
-                addMonitorInfo(network, stateMonitor, branchResults, busResults, threeWindingsTransformerResults, preContingencyBranchResults, lfContingency.getId());
+                addMonitorInfo(network, stateMonitor, branchResults, busResults, threeWindingsTransformerResults, preContingencyBranchResults, lfContingency.getId(), true);
             }
         }
 

--- a/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisParameterJsonSerializer.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisParameterJsonSerializer.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.sa;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.powsybl.commons.extensions.ExtensionJsonSerializer;
+import com.powsybl.commons.json.JsonUtil;
+import com.powsybl.openloadflow.sensi.OpenSensitivityAnalysisParameters;
+import com.powsybl.security.SecurityAnalysisParameters;
+
+import java.io.IOException;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class OpenSecurityAnalysisParameterJsonSerializer implements ExtensionJsonSerializer<SecurityAnalysisParameters, OpenSecurityAnalysisParameters> {
+
+    @Override
+    public String getExtensionName() {
+        return "open-security-analysis-parameters";
+    }
+
+    @Override
+    public String getCategoryName() {
+        return "security-analysis-parameters";
+    }
+
+    @Override
+    public Class<? super OpenSecurityAnalysisParameters> getExtensionClass() {
+        return OpenSecurityAnalysisParameters.class;
+    }
+
+    /**
+     * Specifies serialization for our extension: ignore name et extendable
+     */
+    private interface SerializationSpec {
+
+        @JsonIgnore
+        String getName();
+
+        @JsonIgnore
+        OpenSensitivityAnalysisParameters getExtendable();
+    }
+
+    private static ObjectMapper createMapper() {
+        return JsonUtil.createObjectMapper()
+                .addMixIn(OpenSecurityAnalysisParameters.class, SerializationSpec.class);
+    }
+
+    @Override
+    public void serialize(OpenSecurityAnalysisParameters extension, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        createMapper().writeValue(jsonGenerator, extension);
+    }
+
+    @Override
+    public OpenSecurityAnalysisParameters deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        return createMapper().readValue(jsonParser, OpenSecurityAnalysisParameters.class);
+    }
+}

--- a/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisParameterJsonSerializer.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisParameterJsonSerializer.java
@@ -14,7 +14,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.powsybl.commons.extensions.ExtensionJsonSerializer;
 import com.powsybl.commons.json.JsonUtil;
-import com.powsybl.openloadflow.sensi.OpenSensitivityAnalysisParameters;
 import com.powsybl.security.SecurityAnalysisParameters;
 
 import java.io.IOException;
@@ -48,7 +47,7 @@ public class OpenSecurityAnalysisParameterJsonSerializer implements ExtensionJso
         String getName();
 
         @JsonIgnore
-        OpenSensitivityAnalysisParameters getExtendable();
+        OpenSecurityAnalysisParameters getExtendable();
     }
 
     private static ObjectMapper createMapper() {

--- a/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisParameters.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.sa;
+
+import com.powsybl.commons.config.PlatformConfig;
+import com.powsybl.commons.extensions.AbstractExtension;
+import com.powsybl.security.SecurityAnalysisParameters;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class OpenSecurityAnalysisParameters extends AbstractExtension<SecurityAnalysisParameters> {
+
+    private boolean createResultExtension;
+
+    public static final String CREATE_RESULT_EXTENSION_PARAM_NAME = "createResultExtension";
+    public static final boolean CREATE_RESULT_EXTENSION_DEFAULT_VALUE = false;
+    public static final List<String> SPECIFIC_PARAMETERS_NAMES = List.of(CREATE_RESULT_EXTENSION_PARAM_NAME);
+
+    @Override
+    public String getName() {
+        return "open-security-analysis-parameters";
+    }
+
+    public boolean isCreateResultExtension() {
+        return createResultExtension;
+    }
+
+    public OpenSecurityAnalysisParameters setCreateResultExtension(boolean createResultExtension) {
+        this.createResultExtension = createResultExtension;
+        return this;
+    }
+
+    public static OpenSecurityAnalysisParameters getOrDefault(SecurityAnalysisParameters parameters) {
+        OpenSecurityAnalysisParameters parametersExt = parameters.getExtension(OpenSecurityAnalysisParameters.class);
+        if (parametersExt == null) {
+            parametersExt = new OpenSecurityAnalysisParameters();
+        }
+        return parametersExt;
+    }
+
+    public static OpenSecurityAnalysisParameters load() {
+        return load(PlatformConfig.defaultConfig());
+    }
+
+    public static OpenSecurityAnalysisParameters load(PlatformConfig platformConfig) {
+        OpenSecurityAnalysisParameters parameters = new OpenSecurityAnalysisParameters();
+        platformConfig.getOptionalModuleConfig("open-security-analysis-default-parameters")
+                .ifPresent(config -> parameters
+                        .setCreateResultExtension(config.getBooleanProperty(CREATE_RESULT_EXTENSION_PARAM_NAME, CREATE_RESULT_EXTENSION_DEFAULT_VALUE)));
+        return parameters;
+    }
+
+    public static OpenSecurityAnalysisParameters load(Map<String, String> properties) {
+        return new OpenSecurityAnalysisParameters()
+                .update(properties);
+    }
+
+    public OpenSecurityAnalysisParameters update(Map<String, String> properties) {
+        Optional.ofNullable(properties.get(CREATE_RESULT_EXTENSION_PARAM_NAME))
+                .ifPresent(value -> this.setCreateResultExtension(Boolean.parseBoolean(value)));
+        return this;
+    }
+}

--- a/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProvider.java
@@ -16,6 +16,7 @@ import com.powsybl.contingency.ContingenciesProvider;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.math.matrix.MatrixFactory;
 import com.powsybl.math.matrix.SparseMatrixFactory;
+import com.powsybl.openloadflow.OpenLoadFlowProvider;
 import com.powsybl.openloadflow.graph.EvenShiloachGraphDecrementalConnectivityFactory;
 import com.powsybl.openloadflow.graph.GraphDecrementalConnectivityFactory;
 import com.powsybl.openloadflow.network.LfBranch;
@@ -85,6 +86,11 @@ public class OpenSecurityAnalysisProvider implements SecurityAnalysisProvider {
     @Override
     public String getVersion() {
         return new PowsyblOpenLoadFlowVersion().toString();
+    }
+
+    @Override
+    public Optional<String> getLoadFlowProviderName() {
+        return Optional.of(OpenLoadFlowProvider.NAME);
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProvider.java
@@ -20,7 +20,6 @@ import com.powsybl.openloadflow.graph.EvenShiloachGraphDecrementalConnectivityFa
 import com.powsybl.openloadflow.graph.GraphDecrementalConnectivityFactory;
 import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.LfBus;
-import com.powsybl.openloadflow.sensi.OpenSensitivityAnalysisParameterJsonSerializer;
 import com.powsybl.openloadflow.util.PowsyblOpenLoadFlowVersion;
 import com.powsybl.security.*;
 import com.powsybl.security.interceptors.SecurityAnalysisInterceptor;
@@ -90,7 +89,7 @@ public class OpenSecurityAnalysisProvider implements SecurityAnalysisProvider {
 
     @Override
     public Optional<ExtensionJsonSerializer> getSpecificParametersSerializer() {
-        return Optional.of(new OpenSensitivityAnalysisParameterJsonSerializer());
+        return Optional.of(new OpenSecurityAnalysisParameterJsonSerializer());
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProvider.java
@@ -7,6 +7,9 @@
 package com.powsybl.openloadflow.sa;
 
 import com.google.auto.service.AutoService;
+import com.powsybl.commons.config.PlatformConfig;
+import com.powsybl.commons.extensions.Extension;
+import com.powsybl.commons.extensions.ExtensionJsonSerializer;
 import com.powsybl.commons.reporter.Reporter;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.contingency.ContingenciesProvider;
@@ -17,13 +20,16 @@ import com.powsybl.openloadflow.graph.EvenShiloachGraphDecrementalConnectivityFa
 import com.powsybl.openloadflow.graph.GraphDecrementalConnectivityFactory;
 import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.LfBus;
+import com.powsybl.openloadflow.sensi.OpenSensitivityAnalysisParameterJsonSerializer;
 import com.powsybl.openloadflow.util.PowsyblOpenLoadFlowVersion;
 import com.powsybl.security.*;
 import com.powsybl.security.interceptors.SecurityAnalysisInterceptor;
 import com.powsybl.security.monitor.StateMonitor;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -80,5 +86,30 @@ public class OpenSecurityAnalysisProvider implements SecurityAnalysisProvider {
     @Override
     public String getVersion() {
         return new PowsyblOpenLoadFlowVersion().toString();
+    }
+
+    @Override
+    public Optional<ExtensionJsonSerializer> getSpecificParametersSerializer() {
+        return Optional.of(new OpenSensitivityAnalysisParameterJsonSerializer());
+    }
+
+    @Override
+    public Optional<Extension<SecurityAnalysisParameters>> loadSpecificParameters(PlatformConfig platformConfig) {
+        return Optional.of(OpenSecurityAnalysisParameters.load(platformConfig));
+    }
+
+    @Override
+    public Optional<Extension<SecurityAnalysisParameters>> loadSpecificParameters(Map<String, String> properties) {
+        return Optional.of(OpenSecurityAnalysisParameters.load(properties));
+    }
+
+    @Override
+    public List<String> getSpecificParametersNames() {
+        return OpenSecurityAnalysisParameters.SPECIFIC_PARAMETERS_NAMES;
+    }
+
+    @Override
+    public void updateSpecificParameters(Extension<SecurityAnalysisParameters> extension, Map<String, String> properties) {
+        ((OpenSecurityAnalysisParameters) extension).update(properties);
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProvider.java
@@ -29,6 +29,7 @@ import com.powsybl.loadflow.json.LoadFlowParametersJsonModule;
 import com.powsybl.math.matrix.MatrixFactory;
 import com.powsybl.math.matrix.SparseMatrixFactory;
 import com.powsybl.openloadflow.OpenLoadFlowParameters;
+import com.powsybl.openloadflow.OpenLoadFlowProvider;
 import com.powsybl.openloadflow.graph.EvenShiloachGraphDecrementalConnectivityFactory;
 import com.powsybl.openloadflow.graph.GraphDecrementalConnectivityFactory;
 import com.powsybl.openloadflow.network.LfBranch;
@@ -87,6 +88,11 @@ public class OpenSensitivityAnalysisProvider implements SensitivityAnalysisProvi
     @Override
     public String getVersion() {
         return new PowsyblCoreVersion().getMavenProjectVersion();
+    }
+
+    @Override
+    public Optional<String> getLoadFlowProviderName() {
+        return Optional.of(OpenLoadFlowProvider.NAME);
     }
 
     @Override

--- a/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
@@ -549,67 +549,72 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
         return network;
     }
 
+    /**
+     *
+     *     G1        LD2           LD3
+     *     |    L12   |   T2WT2    |
+     *     |  ------- |  /     \   |
+     *     B1         B2        B3
+     *                  \      /
+     *                    T2WT
+     */
     public static Network createWithTransformerSharedRemoteControl() {
-
         Network network = createNetworkWithT2wt();
 
-        TwoWindingsTransformer t2wt2 = network.getSubstation("SUBSTATION").newTwoWindingsTransformer()
-                .setId("T2wT2")
-                .setVoltageLevel1("VL_2")
-                .setVoltageLevel2("VL_3")
-                .setRatedU1(132.0)
-                .setRatedU2(33.0)
-                .setR(17.0)
-                .setX(10.0)
-                .setG(0.00573921028466483)
-                .setB(0.000573921028466483)
-                .setBus1("BUS_2")
-                .setBus2("BUS_3")
+        TwoWindingsTransformer t2wt2 = network.getSubstation("SUBSTATION")
+                .newTwoWindingsTransformer()
+                    .setId("T2wT2")
+                    .setVoltageLevel1("VL_2")
+                    .setVoltageLevel2("VL_3")
+                    .setRatedU1(132.0)
+                    .setRatedU2(33.0)
+                    .setR(17.0)
+                    .setX(10.0)
+                    .setG(0.00573921028466483)
+                    .setB(0.000573921028466483)
+                    .setBus1("BUS_2")
+                    .setBus2("BUS_3")
                 .add();
 
         t2wt2.newRatioTapChanger()
                 .beginStep()
-                .setRho(0.9)
-                .setR(0.1089)
-                .setX(0.01089)
-                .setG(0.8264462809917356)
-                .setB(0.08264462809917356)
+                    .setRho(0.9)
+                    .setR(0.1089)
+                    .setX(0.01089)
+                    .setG(0.8264462809917356)
+                    .setB(0.08264462809917356)
                 .endStep()
                 .beginStep()
-                .setRho(1.0)
-                .setR(0.121)
-                .setX(0.0121)
-                .setG(0.8264462809917356)
-                .setB(0.08264462809917356)
+                    .setRho(1.0)
+                    .setR(0.121)
+                    .setX(0.0121)
+                    .setG(0.8264462809917356)
+                    .setB(0.08264462809917356)
                 .endStep()
                 .beginStep()
-                .setRho(1.05)
-                .setR(0.1331)
-                .setX(0.01331)
-                .setG(0.9090909090909092)
-                .setB(0.09090909090909092)
+                    .setRho(1.05)
+                    .setR(0.1331)
+                    .setX(0.01331)
+                    .setG(0.9090909090909092)
+                    .setB(0.09090909090909092)
                 .endStep()
                 .beginStep()
-                .setRho(1.1)
-                .setR(0.1331)
-                .setX(0.01331)
-                .setG(0.9090909090909092)
-                .setB(0.09090909090909092)
+                    .setRho(1.1)
+                    .setR(0.1331)
+                    .setX(0.01331)
+                    .setG(0.9090909090909092)
+                    .setB(0.09090909090909092)
                 .endStep()
                 .setTapPosition(0)
                 .setLoadTapChangingCapabilities(true)
-                .setRegulating(false)
-                .setTargetV(33.0)
-                .setRegulationTerminal(network.getLoad("LOAD_3").getTerminal())
+                .setRegulating(true)
+                .setTargetV(34.0)
+                .setTargetDeadband(0)
+                .setRegulationTerminal(t2wt2.getTerminal2())
                 .add();
+
         TwoWindingsTransformer t2wt = network.getTwoWindingsTransformer("T2wT");
         t2wt.getRatioTapChanger()
-                .setTargetDeadband(0)
-                .setRegulating(true)
-                .setTapPosition(0)
-                .setRegulationTerminal(t2wt.getTerminal2())
-                .setTargetV(34.0);
-        t2wt2.getRatioTapChanger()
                 .setTargetDeadband(0)
                 .setRegulating(true)
                 .setTapPosition(0)

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProviderTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProviderTest.java
@@ -6,19 +6,15 @@
  */
 package com.powsybl.openloadflow.sa;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Jimfs;
 import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.config.InMemoryPlatformConfig;
 import com.powsybl.openloadflow.util.PowsyblOpenLoadFlowVersion;
 import com.powsybl.security.SecurityAnalysisParameters;
-import com.powsybl.security.json.SecurityAnalysisParametersJsonModule;
+import com.powsybl.security.json.JsonSecurityAnalysisParameters;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.nio.file.FileSystem;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -32,12 +28,10 @@ class OpenSecurityAnalysisProviderTest extends AbstractConverterTest {
 
     private OpenSecurityAnalysisProvider provider;
 
-    private FileSystem fileSystem;
-
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws IOException {
+        super.setUp();
         provider = new OpenSecurityAnalysisProvider();
-        fileSystem = Jimfs.newFileSystem(Configuration.unix());
     }
 
     @Test
@@ -90,9 +84,6 @@ class OpenSecurityAnalysisProviderTest extends AbstractConverterTest {
         OpenSecurityAnalysisParameters parametersExt = new OpenSecurityAnalysisParameters()
                 .setCreateResultExtension(true);
         parameters.addExtension(OpenSecurityAnalysisParameters.class, parametersExt);
-        ObjectMapper objectMapper = new ObjectMapper()
-                .registerModule(new SecurityAnalysisParametersJsonModule());
-        String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(parameters);
-        compareTxt(getClass().getResourceAsStream("/sa-params.json"), json);
+        roundTripTest(parameters, JsonSecurityAnalysisParameters::write, JsonSecurityAnalysisParameters::read, "/sa-params.json");
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProviderTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProviderTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.sa;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.powsybl.commons.AbstractConverterTest;
+import com.powsybl.commons.config.InMemoryPlatformConfig;
+import com.powsybl.openloadflow.util.PowsyblOpenLoadFlowVersion;
+import com.powsybl.security.SecurityAnalysisParameters;
+import com.powsybl.security.json.SecurityAnalysisParametersJsonModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+class OpenSecurityAnalysisProviderTest extends AbstractConverterTest {
+
+    private OpenSecurityAnalysisProvider provider;
+
+    private FileSystem fileSystem;
+
+    @BeforeEach
+    public void setUp() {
+        provider = new OpenSecurityAnalysisProvider();
+        fileSystem = Jimfs.newFileSystem(Configuration.unix());
+    }
+
+    @Test
+    void basicTest() {
+        assertEquals("OpenSecurityAnalysis", provider.getName());
+        assertEquals(new PowsyblOpenLoadFlowVersion().toString(), provider.getVersion());
+        assertEquals("OpenLoadFlow", provider.getLoadFlowProviderName().orElseThrow());
+    }
+
+    @Test
+    void specificParametersNamesTest() {
+        assertEquals(List.of("createResultExtension"), provider.getSpecificParametersNames());
+    }
+
+    @Test
+    void specificParametersFromDefaultPlatformConfigTest() {
+        InMemoryPlatformConfig platformConfig = new InMemoryPlatformConfig(fileSystem);
+        OpenSecurityAnalysisParameters parametersExt = (OpenSecurityAnalysisParameters) provider.loadSpecificParameters(platformConfig).orElseThrow();
+        assertEquals("open-security-analysis-parameters", parametersExt.getName());
+        assertFalse(parametersExt.isCreateResultExtension());
+        parametersExt.setCreateResultExtension(true);
+        assertTrue(parametersExt.isCreateResultExtension());
+    }
+
+    @Test
+    void specificParametersFromPlatformConfigTest() {
+        InMemoryPlatformConfig platformConfig = new InMemoryPlatformConfig(fileSystem);
+        platformConfig.createModuleConfig("open-security-analysis-default-parameters")
+                .setStringProperty("createResultExtension", "true");
+        OpenSecurityAnalysisParameters parametersExt = (OpenSecurityAnalysisParameters) provider.loadSpecificParameters(platformConfig).orElseThrow();
+        assertTrue(parametersExt.isCreateResultExtension());
+    }
+
+    @Test
+    void specificParametersFromEmptyPropertiesTest() {
+        OpenSecurityAnalysisParameters parametersExt = (OpenSecurityAnalysisParameters) provider.loadSpecificParameters(Collections.emptyMap()).orElseThrow();
+        assertFalse(parametersExt.isCreateResultExtension());
+    }
+
+    @Test
+    void specificParametersFromPropertiesTest() {
+        Map<String, String> properties = Map.of("createResultExtension", "true");
+        OpenSecurityAnalysisParameters parametersExt = (OpenSecurityAnalysisParameters) provider.loadSpecificParameters(properties).orElseThrow();
+        assertTrue(parametersExt.isCreateResultExtension());
+    }
+
+    @Test
+    void jsonTest() throws IOException {
+        SecurityAnalysisParameters parameters = new SecurityAnalysisParameters();
+        OpenSecurityAnalysisParameters parametersExt = new OpenSecurityAnalysisParameters()
+                .setCreateResultExtension(true);
+        parameters.addExtension(OpenSecurityAnalysisParameters.class, parametersExt);
+        ObjectMapper objectMapper = new ObjectMapper()
+                .registerModule(new SecurityAnalysisParametersJsonModule());
+        String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(parameters);
+        compareTxt(getClass().getResourceAsStream("/sa-params.json"), json);
+    }
+}

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -761,7 +761,6 @@ class OpenSecurityAnalysisTest {
     @Test
     void testSaWithTransformerRemoteSharedControl() {
         Network network = VoltageControlNetworkFactory.createWithTransformerSharedRemoteControl();
-        network.getTwoWindingsTransformerStream().forEach(twt -> twt.setProperty("olf-debug", "true"));
 
         LoadFlowParameters lfParameters = new LoadFlowParameters()
                 .setTransformerVoltageControlOn(true);
@@ -776,16 +775,16 @@ class OpenSecurityAnalysisTest {
         PreContingencyResult preContingencyResult = result.getPreContingencyResult();
         assertEquals(-0.659, preContingencyResult.getPreContingencyBranchResult("T2wT2").getQ1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(-0.659, preContingencyResult.getPreContingencyBranchResult("T2wT").getQ1(), LoadFlowAssert.DELTA_POWER);
-        assertEquals(1.05, ((OlfBranchResult) preContingencyResult.getPreContingencyBranchResult("T2wT2")).getR1(), 0d);
-        assertEquals(1.050302, ((OlfBranchResult) preContingencyResult.getPreContingencyBranchResult("T2wT2")).getContinuousR1(), LoadFlowAssert.DELTA_RHO);
-        assertEquals(1.05, ((OlfBranchResult) preContingencyResult.getPreContingencyBranchResult("T2wT")).getR1(), 0d);
-        assertEquals(1.050302, ((OlfBranchResult) preContingencyResult.getPreContingencyBranchResult("T2wT")).getContinuousR1(), LoadFlowAssert.DELTA_RHO);
+        assertEquals(1.05, preContingencyResult.getPreContingencyBranchResult("T2wT2").getExtension(OlfBranchResult.class).getR1(), 0d);
+        assertEquals(1.050302, preContingencyResult.getPreContingencyBranchResult("T2wT2").getExtension(OlfBranchResult.class).getContinuousR1(), LoadFlowAssert.DELTA_RHO);
+        assertEquals(1.05, preContingencyResult.getPreContingencyBranchResult("T2wT").getExtension(OlfBranchResult.class).getR1(), 0d);
+        assertEquals(1.050302, preContingencyResult.getPreContingencyBranchResult("T2wT").getExtension(OlfBranchResult.class).getContinuousR1(), LoadFlowAssert.DELTA_RHO);
 
         // post-contingency tests
         PostContingencyResult postContingencyResult = getPostContingencyResult(result, "T2wT2");
         assertEquals(-0.577, postContingencyResult.getBranchResult("T2wT").getQ1(), LoadFlowAssert.DELTA_POWER); // this assertion is not so relevant. It is more relevant to look at the logs.
-        assertEquals(1.1, ((OlfBranchResult) postContingencyResult.getBranchResult("T2wT")).getR1(), 0d);
-        assertEquals(1.088228, ((OlfBranchResult) postContingencyResult.getBranchResult("T2wT")).getContinuousR1(), LoadFlowAssert.DELTA_RHO);
+        assertEquals(1.1, postContingencyResult.getBranchResult("T2wT").getExtension(OlfBranchResult.class).getR1(), 0d);
+        assertEquals(1.088228, postContingencyResult.getBranchResult("T2wT").getExtension(OlfBranchResult.class).getContinuousR1(), LoadFlowAssert.DELTA_RHO);
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -762,14 +762,17 @@ class OpenSecurityAnalysisTest {
     void testSaWithTransformerRemoteSharedControl() {
         Network network = VoltageControlNetworkFactory.createWithTransformerSharedRemoteControl();
 
-        LoadFlowParameters lfParameters = new LoadFlowParameters()
+        SecurityAnalysisParameters saParameters = new SecurityAnalysisParameters();
+        saParameters.getLoadFlowParameters()
                 .setTransformerVoltageControlOn(true);
+        saParameters.addExtension(OpenSecurityAnalysisParameters.class, new OpenSecurityAnalysisParameters()
+                .setCreateResultExtension(true));
 
         List<Contingency> contingencies = allBranches(network);
 
         List<StateMonitor> monitors = createAllBranchesMonitors(network);
 
-        SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies, monitors, lfParameters);
+        SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies, monitors, saParameters);
 
         // pre-contingency tests
         PreContingencyResult preContingencyResult = result.getPreContingencyResult();

--- a/src/test/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProviderTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProviderTest.java
@@ -27,6 +27,7 @@ class OpenSensitivityAnalysisProviderTest extends AbstractSensitivityAnalysisTes
         OpenSensitivityAnalysisProvider provider = new OpenSensitivityAnalysisProvider(new DenseMatrixFactory());
         assertEquals("OpenSensitivityAnalysis", provider.getName());
         assertEquals(new PowsyblCoreVersion().getMavenProjectVersion(), provider.getVersion());
+        assertEquals("OpenLoadFlow", provider.getLoadFlowProviderName().orElseThrow());
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/util/LoadFlowAssert.java
+++ b/src/test/java/com/powsybl/openloadflow/util/LoadFlowAssert.java
@@ -23,6 +23,7 @@ public final class LoadFlowAssert {
     public static final double DELTA_ANGLE = 1E-6d;
     public static final double DELTA_V = 1E-2d;
     public static final double DELTA_POWER = 1E-3d;
+    public static final double DELTA_RHO = 1E-6d;
     public static final double DELTA_I = 1000 * DELTA_POWER / Math.sqrt(3);
     public static final double DELTA_MISMATCH = 1E-4d;
     public static final double DELTA_SENSITIVITY_VALUE = 1E-4d;

--- a/src/test/resources/sa-params.json
+++ b/src/test/resources/sa-params.json
@@ -1,0 +1,33 @@
+{
+  "version" : "1.1",
+  "increased-violations-parameters" : {
+    "flow-proportional-threshold" : 0.1,
+    "low-voltage-proportional-threshold" : 0.0,
+    "low-voltage-absolute-threshold" : 0.0,
+    "high-voltage-proportional-threshold" : 0.0,
+    "high-voltage-absolute-threshold" : 0.0
+  },
+  "load-flow-parameters" : {
+    "version" : "1.7",
+    "voltageInitMode" : "UNIFORM_VALUES",
+    "transformerVoltageControlOn" : false,
+    "phaseShifterRegulationOn" : false,
+    "noGeneratorReactiveLimits" : false,
+    "twtSplitShuntAdmittance" : false,
+    "shuntCompensatorVoltageControlOn" : false,
+    "readSlackBus" : true,
+    "writeSlackBus" : false,
+    "dc" : false,
+    "distributedSlack" : true,
+    "balanceType" : "PROPORTIONAL_TO_GENERATION_P_MAX",
+    "dcUseTransformerRatio" : true,
+    "countriesToBalance" : [ ],
+    "connectedComponentMode" : "MAIN",
+    "hvdcAcEmulation" : true
+  },
+  "extensions" : {
+    "open-security-analysis-parameters" : {
+      "createResultExtension" : true
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
Unit test regarding transformer voltage control  on security analysis are not robust enough because we are not able to to assert post contingency value of the tap.


**What is the new behavior (if this is a feature change)?**
We can now thanks to a BranchResult extension assert discrete and continuous tap values.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
