### PR TITLE
Fix equation term notification

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/equations/AbstractEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/AbstractEquationTerm.java
@@ -21,6 +21,8 @@ public abstract class AbstractEquationTerm<V extends Enum<V> & Quantity, E exten
 
     protected StateVector stateVector;
 
+    protected EquationTerm<V, E> self = this;
+
     @Override
     public void setStateVector(StateVector stateVector) {
         this.stateVector = Objects.requireNonNull(stateVector);
@@ -40,7 +42,7 @@ public abstract class AbstractEquationTerm<V extends Enum<V> & Quantity, E exten
     public void setActive(boolean active) {
         if (this.active != active) {
             this.active = active;
-            equation.getEquationSystem().notifyEquationTermChange(this, active ? EquationTermEventType.EQUATION_TERM_ACTIVATED
+            equation.getEquationSystem().notifyEquationTermChange(self, active ? EquationTermEventType.EQUATION_TERM_ACTIVATED
                                                                                : EquationTermEventType.EQUATION_TERM_DEACTIVATED);
         }
     }
@@ -48,6 +50,11 @@ public abstract class AbstractEquationTerm<V extends Enum<V> & Quantity, E exten
     @Override
     public boolean isActive() {
         return active;
+    }
+
+    @Override
+    public void setSelf(EquationTerm<V, E> self) {
+        this.self = Objects.requireNonNull(self);
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationTerm.java
@@ -36,6 +36,7 @@ public interface EquationTerm<V extends Enum<V> & Quantity, E extends Enum<E> & 
         MultiplyByScalarEquationTerm(EquationTerm<V, E> term, DoubleSupplier scalarSupplier) {
             this.term = Objects.requireNonNull(term);
             this.scalarSupplier = Objects.requireNonNull(scalarSupplier);
+            term.setSelf(this);
         }
 
         @Override
@@ -56,6 +57,11 @@ public interface EquationTerm<V extends Enum<V> & Quantity, E extends Enum<E> & 
         @Override
         public boolean isActive() {
             return term.isActive();
+        }
+
+        @Override
+        public void setSelf(EquationTerm<V, E> self) {
+            term.setSelf(self);
         }
 
         @Override
@@ -174,6 +180,8 @@ public interface EquationTerm<V extends Enum<V> & Quantity, E extends Enum<E> & 
     boolean isActive();
 
     void setActive(boolean active);
+
+    void setSelf(EquationTerm<V, E> self);
 
     ElementType getElementType();
 


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
For wrapped `EquationTerm`, the `this` passed to notification event is not correct: this is the most inner term. 


**What is the new behavior (if this is a feature change)?**
The most outer term is passed to notification event.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
