### PR TITLE
Fix: unsupported shunt voltage control

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -634,6 +634,12 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
             controllerShunt.setVoltageControlCapability(false);
             return;
         }
+        if (controllerShunt.isVoltageControlEnabled()) {
+            // if a controller shunt is already in a shunt voltage control, the number of equations will not equal the
+            // number of variables. We have only one B variable for more than one bus target V equations.
+            LOGGER.error("Controller shunt {} is already in a shunt voltage control. The second controlled bus {} is ignored", controllerShunt.getId(), controlledBus.getId());
+            return;
+        }
 
         controllerShunt.setVoltageControlEnabled(true);
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowShuntTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowShuntTest.java
@@ -418,4 +418,38 @@ class AcLoadFlowShuntTest {
         assertEquals(0, shuntCompensator2.getSectionCount());
         assertEquals(0, shuntCompensator3.getSectionCount());
     }
+
+    @Test
+    void testUnsupportedSharedVoltageControl() {
+        network = createNetwork();
+        // in that test case, we test two shunts connected to the same bus, both are in voltage regulation
+        // but with a different regulating terminal.
+        ShuntCompensator shunt2 = network.getVoltageLevel("vl3").newShuntCompensator()
+                .setId("SHUNT2")
+                .setBus("b3")
+                .setConnectableBus("b3")
+                .setSectionCount(0)
+                .setVoltageRegulatorOn(true)
+                .setRegulatingTerminal(l2.getTerminal2())
+                .setTargetV(405)
+                .setTargetDeadband(5.0)
+                .newNonLinearModel()
+                .beginSection()
+                .setB(1e-4)
+                .setG(0.0)
+                .endSection()
+                .beginSection()
+                .setB(3e-4)
+                .setG(0.)
+                .endSection()
+                .add()
+                .add();
+
+        parameters.setSimulShunt(true);
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertVoltageEquals(391.640, bus3);
+        assertEquals(1, shunt.getSectionCount());
+        assertEquals(2, shunt2.getSectionCount());
+    }
 }


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <anne.tilloy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

I have met in an IGM (Litgrid) two shunt compensators connected to the same bus but with different regulating terminals (that lead to different buses). In that case, we can solve the equation system because we have more equations than variables. In the case, for example, we have two target V equations for only one B variable.

**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
