### PR TITLE
Replace deprecated simulShunt by shuntCompensatorVoltageControlOn

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
@@ -421,7 +421,7 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
         LOGGER.info("Connected component mode: {}", parameters.getConnectedComponentMode());
         LOGGER.info("Voltage per reactive power control: {}", parametersExt.isVoltagePerReactivePowerControl());
         LOGGER.info("Reactive Power Remote control: {}", parametersExt.hasReactivePowerRemoteControl());
-        LOGGER.info("Shunt voltage control: {}", parameters.isSimulShunt());
+        LOGGER.info("Shunt voltage control: {}", parameters.isShuntCompensatorVoltageControlOn());
     }
 
     static VoltageInitializer getVoltageInitializer(LoadFlowParameters parameters, LfNetworkParameters networkParameters, MatrixFactory matrixFactory, Reporter reporter) {
@@ -477,7 +477,7 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
                                        parametersExt.isVoltagePerReactivePowerControl(),
                                        parametersExt.hasReactivePowerRemoteControl(),
                                        parameters.isDc(),
-                                       parameters.isSimulShunt(),
+                                       parameters.isShuntCompensatorVoltageControlOn(),
                                        !parameters.isNoGeneratorReactiveLimits());
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowShuntTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowShuntTest.java
@@ -185,7 +185,7 @@ class AcLoadFlowShuntTest {
 
     @Test
     void testVoltageControl() {
-        parameters.setSimulShunt(true);
+        parameters.setShuntCompensatorVoltageControlOn(true);
         shunt.setSectionCount(0);
         shunt.setVoltageRegulatorOn(true);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
@@ -200,7 +200,7 @@ class AcLoadFlowShuntTest {
         ShuntCompensator shuntCompensator2 = network.getShuntCompensator("SHUNT2");
         shuntCompensator2.setVoltageRegulatorOn(false);
         ShuntCompensator shuntCompensator3 = network.getShuntCompensator("SHUNT3");
-        parameters.setSimulShunt(true);
+        parameters.setShuntCompensatorVoltageControlOn(true);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isOk());
         assertVoltageEquals(399.602, network.getBusBreakerView().getBus("b4"));
@@ -233,7 +233,7 @@ class AcLoadFlowShuntTest {
                 .add()
                 .add();
 
-        parameters.setSimulShunt(true);
+        parameters.setShuntCompensatorVoltageControlOn(true);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isOk());
         assertVoltageEquals(393.308, bus3);
@@ -267,7 +267,7 @@ class AcLoadFlowShuntTest {
                 .add()
                 .add();
 
-        parameters.setSimulShunt(true);
+        parameters.setShuntCompensatorVoltageControlOn(true);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isOk());
         assertVoltageEquals(391.640, bus3);
@@ -301,7 +301,7 @@ class AcLoadFlowShuntTest {
                 .add()
                 .add();
 
-        parameters.setSimulShunt(true);
+        parameters.setShuntCompensatorVoltageControlOn(true);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isOk());
         assertVoltageEquals(393.308, bus3);
@@ -330,7 +330,7 @@ class AcLoadFlowShuntTest {
                 .add()
                 .add();
 
-        parameters.setSimulShunt(true);
+        parameters.setShuntCompensatorVoltageControlOn(true);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isOk());
         assertVoltageEquals(400.600, bus3);
@@ -340,7 +340,7 @@ class AcLoadFlowShuntTest {
     @Test
     void testSharedRemoteVoltageControl() {
         Network network = VoltageControlNetworkFactory.createWithShuntSharedRemoteControl();
-        parameters.setSimulShunt(true);
+        parameters.setShuntCompensatorVoltageControlOn(true);
         ShuntCompensator shuntCompensator2 = network.getShuntCompensator("SHUNT2");
         ShuntCompensator shuntCompensator3 = network.getShuntCompensator("SHUNT3");
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
@@ -352,7 +352,7 @@ class AcLoadFlowShuntTest {
 
     @Test
     void testNoShuntVoltageControl() {
-        parameters.setSimulShunt(true);
+        parameters.setShuntCompensatorVoltageControlOn(true);
         shunt.setRegulatingTerminal(network.getGenerator("g1").getTerminal());
         shunt.setSectionCount(0);
         shunt.setVoltageRegulatorOn(true);
@@ -364,7 +364,7 @@ class AcLoadFlowShuntTest {
 
     @Test
     void testNoShuntVoltageControl2() {
-        parameters.setSimulShunt(true);
+        parameters.setShuntCompensatorVoltageControlOn(true);
         shunt.setSectionCount(0);
         shunt.setVoltageRegulatorOn(true);
         shunt.setRegulatingTerminal(network.getLoad("ld1").getTerminal());
@@ -408,7 +408,7 @@ class AcLoadFlowShuntTest {
                 .setB(0.09090909090909092)
                 .endStep()
                 .add();
-        parameters.setSimulShunt(true);
+        parameters.setShuntCompensatorVoltageControlOn(true);
         parameters.setTransformerVoltageControlOn(true);
         ShuntCompensator shuntCompensator2 = network.getShuntCompensator("SHUNT2");
         ShuntCompensator shuntCompensator3 = network.getShuntCompensator("SHUNT3");
@@ -445,7 +445,7 @@ class AcLoadFlowShuntTest {
                 .add()
                 .add();
 
-        parameters.setSimulShunt(true);
+        parameters.setShuntCompensatorVoltageControlOn(true);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isOk());
         assertVoltageEquals(391.640, bus3);

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -702,7 +702,7 @@ class OpenSecurityAnalysisTest {
         Network network = VoltageControlNetworkFactory.createWithShuntSharedRemoteControl();
 
         LoadFlowParameters lfParameters = new LoadFlowParameters()
-                .setSimulShunt(true);
+                .setShuntCompensatorVoltageControlOn(true);
 
         List<Contingency> contingencies = allBranches(network);
 
@@ -827,7 +827,7 @@ class OpenSecurityAnalysisTest {
         });
 
         LoadFlowParameters lfParameters = new LoadFlowParameters()
-                .setSimulShunt(true);
+                .setShuntCompensatorVoltageControlOn(true);
 
         List<Contingency> contingencies = List.of(new Contingency("SHUNT2", new ShuntCompensatorContingency("SHUNT2")),
                                                   new Contingency("tr3", new BranchContingency("tr3")));


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Technical debt 


**What is the current behavior?** *(You can also link to an open issue here)*
simulShunt load flow parameter is deprecated


**What is the new behavior (if this is a feature change)?**
shuntCompensatorVoltageControlOn is used instead

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
