### PR TITLE
Fix parameters loading

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
@@ -366,7 +366,7 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
     public static OpenLoadFlowParameters get(LoadFlowParameters parameters) {
         OpenLoadFlowParameters parametersExt = parameters.getExtension(OpenLoadFlowParameters.class);
         if (parametersExt == null) {
-            parametersExt = OpenLoadFlowParameters.load();
+            parametersExt = new OpenLoadFlowParameters();
         }
         return parametersExt;
     }

--- a/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProvider.java
@@ -86,17 +86,9 @@ public class OpenSensitivityAnalysisProvider implements SensitivityAnalysisProvi
     private static OpenSensitivityAnalysisParameters getSensitivityAnalysisParametersExtension(SensitivityAnalysisParameters sensitivityAnalysisParameters) {
         OpenSensitivityAnalysisParameters sensiParametersExt = sensitivityAnalysisParameters.getExtension(OpenSensitivityAnalysisParameters.class);
         if (sensiParametersExt == null) {
-            sensiParametersExt = OpenSensitivityAnalysisParameters.load();
+            sensiParametersExt = new OpenSensitivityAnalysisParameters();
         }
         return sensiParametersExt;
-    }
-
-    private static OpenLoadFlowParameters getLoadFlowParametersExtension(LoadFlowParameters lfParameters) {
-        OpenLoadFlowParameters lfParametersExt = lfParameters.getExtension(OpenLoadFlowParameters.class);
-        if (lfParametersExt == null) {
-            lfParametersExt = OpenLoadFlowParameters.load();
-        }
-        return lfParametersExt;
     }
 
     private static ObjectMapper createObjectMapper() {
@@ -134,7 +126,7 @@ public class OpenSensitivityAnalysisProvider implements SensitivityAnalysisProvi
                         sensitivityAnalysisParameters.getLoadFlowParameters().getBalanceType() == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD);
 
                 LoadFlowParameters lfParameters = sensitivityAnalysisParameters.getLoadFlowParameters();
-                OpenLoadFlowParameters lfParametersExt = getLoadFlowParametersExtension(lfParameters);
+                OpenLoadFlowParameters lfParametersExt = OpenLoadFlowParameters.get(lfParameters);
                 OpenSensitivityAnalysisParameters sensitivityAnalysisParametersExt = getSensitivityAnalysisParametersExtension(sensitivityAnalysisParameters);
 
                 SensitivityFactorReader decoratedFactorReader = factorReader;


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When loadflow, and sensitivity parameters are created using the constructor (so without loading from platform config), extension if not already added is loaded from platform config which is inconsistent with base parameters.


**What is the new behavior (if this is a feature change)?**
we don't load extension if not present but create it from contructor


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
