### PR TITLE
Fix: Hvdc active power setpoint should be interpreted on rectifier AC side

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/PhaseControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/PhaseControlOuterLoop.java
@@ -43,7 +43,7 @@ public class PhaseControlOuterLoop implements OuterLoop {
         List<LfBranch> controllerBranches = new ArrayList<>(1);
         List<LfBranch> disabledBranches = new ArrayList<>(1);
         for (LfBranch branch : network.getBranches()) {
-            if (branch.isPhaseController() && branch.isPhaseControlEnabled()) {
+            if (!branch.isDisabled() && branch.isPhaseController() && branch.isPhaseControlEnabled()) {
                 controllerBranches.add(branch);
             }
             if (branch.isDisabled()) {
@@ -63,9 +63,7 @@ public class PhaseControlOuterLoop implements OuterLoop {
                 int smallComponentsCountBeforePhaseShifterLoss = connectivity.getSmallComponents().size();
 
                 // then the phase shifter controlled branch
-                if (!disabledBranches.contains(controlledBranch)) {
-                    connectivity.cut(controlledBranch.getBus1(), controlledBranch.getBus2());
-                }
+                connectivity.cut(controlledBranch.getBus1(), controlledBranch.getBus2());
 
                 if (connectivity.getSmallComponents().size() != smallComponentsCountBeforePhaseShifterLoss) {
                     // phase shifter controlled branch necessary for connectivity, we switch off control

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -212,10 +212,10 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
         // note that LCC converter station are out of the slack distribution.
         lccCss.add(lccCs);
         HvdcLine line = lccCs.getHvdcLine();
-        double targetP = HvdcConverterStations.getLccConverterStationLoadTargetP(lccCs, line);
+        double targetP = HvdcConverterStations.getLccConverterStationLoadTargetP(lccCs);
         loadTargetP += targetP;
         initialLoadTargetP += targetP;
-        loadTargetQ += HvdcConverterStations.getLccConverterStationLoadTargetQ(lccCs, line);
+        loadTargetQ += HvdcConverterStations.getLccConverterStationLoadTargetQ(lccCs);
     }
 
     protected void add(LfGenerator generator) {
@@ -473,8 +473,8 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
         // update lcc converter station power
         for (LccConverterStation lccCs : lccCss) {
             HvdcLine line = lccCs.getHvdcLine();
-            double pCs = HvdcConverterStations.getLccConverterStationLoadTargetP(lccCs, line); // A LCC station has active losses.
-            double qCs = HvdcConverterStations.getLccConverterStationLoadTargetQ(lccCs, line); // A LCC station always consumes reactive power.
+            double pCs = HvdcConverterStations.getLccConverterStationLoadTargetP(lccCs); // A LCC station has active losses.
+            double qCs = HvdcConverterStations.getLccConverterStationLoadTargetQ(lccCs); // A LCC station always consumes reactive power.
             lccCs.getTerminal()
                     .setP(pCs)
                     .setQ(qCs);

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -212,35 +212,10 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
         // note that LCC converter station are out of the slack distribution.
         lccCss.add(lccCs);
         HvdcLine line = lccCs.getHvdcLine();
-        double targetP = PerUnit.SB * getLccConverterStationLoadTargetP(lccCs, line);
+        double targetP = HvdcConverterStations.getLccConverterStationLoadTargetP(lccCs, line);
         loadTargetP += targetP;
         initialLoadTargetP += targetP;
-        loadTargetQ += PerUnit.SB * getLccConverterStationLoadTargetQ(lccCs, line);
-    }
-
-    /**
-     * Gets active power for an LCC station in per-unit.
-     */
-    public static double getLccConverterStationLoadTargetP(LccConverterStation lccCs, HvdcLine line) {
-        // The active power setpoint is always positive.
-        // If the converter station is at side 1 and is rectifier, p should be positive.
-        // If the converter station is at side 1 and is inverter, p should be negative.
-        // If the converter station is at side 2 and is rectifier, p should be positive.
-        // If the converter station is at side 2 and is inverter, p should be negative.
-        return line.getActivePowerSetpoint() / PerUnit.SB * HvdcConverterStations.getActivePowerSetpointMultiplier(lccCs); // A LCC station has active losses.
-    }
-
-    /**
-     * Gets reactive power for an LCC station in per-unit.
-     */
-    public static double getLccConverterStationLoadTargetQ(LccConverterStation lccCs, HvdcLine line) {
-        // The active power setpoint is always positive.
-        // If the converter station is at side 1 and is rectifier, p should be positive.
-        // If the converter station is at side 1 and is inverter, p should be negative.
-        // If the converter station is at side 2 and is rectifier, p should be positive.
-        // If the converter station is at side 2 and is inverter, p should be negative.
-        double pCs = getLccConverterStationLoadTargetP(lccCs, line);
-        return Math.abs(pCs * Math.tan(Math.acos(lccCs.getPowerFactor()))); // A LCC station always consumes reactive power.
+        loadTargetQ += HvdcConverterStations.getLccConverterStationLoadTargetQ(lccCs, line);
     }
 
     protected void add(LfGenerator generator) {
@@ -498,8 +473,8 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
         // update lcc converter station power
         for (LccConverterStation lccCs : lccCss) {
             HvdcLine line = lccCs.getHvdcLine();
-            double pCs = line.getActivePowerSetpoint() * HvdcConverterStations.getActivePowerSetpointMultiplier(lccCs); // A LCC station has active losses.
-            double qCs = Math.abs(pCs * Math.tan(Math.acos(lccCs.getPowerFactor()))); // A LCC station always consumes reactive power.
+            double pCs = HvdcConverterStations.getLccConverterStationLoadTargetP(lccCs, line); // A LCC station has active losses.
+            double qCs = HvdcConverterStations.getLccConverterStationLoadTargetQ(lccCs, line); // A LCC station always consumes reactive power.
             lccCs.getTerminal()
                     .setP(pCs)
                     .setQ(qCs);

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -211,8 +211,7 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     void addLccConverterStation(LccConverterStation lccCs) {
         // note that LCC converter station are out of the slack distribution.
         lccCss.add(lccCs);
-        HvdcLine line = lccCs.getHvdcLine();
-        double targetP = HvdcConverterStations.getLccConverterStationLoadTargetP(lccCs);
+        double targetP = HvdcConverterStations.getConverterStationTargetP(lccCs);
         loadTargetP += targetP;
         initialLoadTargetP += targetP;
         loadTargetQ += HvdcConverterStations.getLccConverterStationLoadTargetQ(lccCs);
@@ -472,8 +471,7 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
 
         // update lcc converter station power
         for (LccConverterStation lccCs : lccCss) {
-            HvdcLine line = lccCs.getHvdcLine();
-            double pCs = HvdcConverterStations.getLccConverterStationLoadTargetP(lccCs); // A LCC station has active losses.
+            double pCs = HvdcConverterStations.getConverterStationTargetP(lccCs); // A LCC station has active losses.
             double qCs = HvdcConverterStations.getLccConverterStationLoadTargetQ(lccCs); // A LCC station always consumes reactive power.
             lccCs.getTerminal()
                     .setP(pCs)

--- a/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
@@ -89,7 +89,7 @@ public final class HvdcConverterStations {
         // The active power value on rectifier DC side is known as the HVDC active power set point minus the losses related
         // to AC/DC conversion (rectifier conversion), the voltage is approximated to the nominal voltage as attribute of the HVDC line.
         // In an HVDC, as a branch with two sides, the difference between pDc1 and pDc2 can be computed with the assumptions:
-        // I = (V1 - V2) / R and pDc1 = I * V1 and pDc2 = I * V2
+        // I = (V1 - V2) / R and pDc1 = I * V1 and pDc2 = I * V2 and V1 = nominalV
         // we simply obtain that the absolute value of the difference is equal to R * pDc1 * pDc1 / (V1 * V1) if side 1 is rectifier side.
         return r * rectifierPDc * rectifierPDc / (nominalV * nominalV);
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
@@ -44,15 +44,20 @@ public final class HvdcConverterStations {
     }
 
     /**
-     * Gets active power for an LCC station.
+     * Gets targetP of an VSC converter station or load target P for a LCC converter station.
      */
-    public static double getLccConverterStationLoadTargetP(LccConverterStation lccCs) {
-        // Load convention.
+    public static double getConverterStationTargetP(HvdcConverterStation<?> station) {
+        // For a VSC converter station, we are in generator convention.
+        // If the converter station is at side 1 and is rectifier, targetP should be negative.
+        // If the converter station is at side 1 and is inverter, targetP should be positive.
+        // If the converter station is at side 2 and is rectifier, targetP should be negative.
+        // If the converter station is at side 2 and is inverter, targetP should be positive.
+        // for a LCC converter station, we are in load convention.
         // If the converter station is at side 1 and is rectifier, p should be positive.
         // If the converter station is at side 1 and is inverter, p should be negative.
         // If the converter station is at side 2 and is rectifier, p should be positive.
         // If the converter station is at side 2 and is inverter, p should be negative.
-        return getSign(lccCs) * getAbsoluteValuePAc(lccCs);
+        return getSign(station) * getAbsoluteValuePAc(station);
     }
 
     /**
@@ -64,20 +69,8 @@ public final class HvdcConverterStations {
         // If the converter station is at side 1 and is inverter, p should be negative.
         // If the converter station is at side 2 and is rectifier, p should be positive.
         // If the converter station is at side 2 and is inverter, p should be negative.
-        double pCs = getLccConverterStationLoadTargetP(lccCs);
+        double pCs = getConverterStationTargetP(lccCs);
         return Math.abs(pCs * Math.tan(Math.acos(lccCs.getPowerFactor()))); // A LCC station always consumes reactive power.
-    }
-
-    /**
-     * Gets targetP of an VSC converter station.
-     */
-    public static double getConverterStationTargetP(VscConverterStation vscCs) {
-        // Generator convention.
-        // If the converter station is at side 1 and is rectifier, targetP should be negative.
-        // If the converter station is at side 1 and is inverter, targetP should be positive.
-        // If the converter station is at side 2 and is rectifier, targetP should be negative.
-        // If the converter station is at side 2 and is inverter, targetP should be positive.
-        return getSign(vscCs) * getAbsoluteValuePAc(vscCs);
     }
 
     private static double getAbsoluteValuePAc(HvdcConverterStation<?> station) {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
@@ -41,4 +41,44 @@ public final class HvdcConverterStations {
         }
         return sign * (1 + (isConverterStationRectifier ? 1 : -1) * station.getLossFactor() / 100);
     }
+
+    /**
+     * Gets active power for an LCC station in per-unit.
+     */
+    public static double getLccConverterStationLoadTargetP(LccConverterStation lccCs, HvdcLine line) {
+        // The active power setpoint is always positive.
+        // If the converter station is at side 1 and is rectifier, p should be positive.
+        // If the converter station is at side 1 and is inverter, p should be negative.
+        // If the converter station is at side 2 and is rectifier, p should be positive.
+        // If the converter station is at side 2 and is inverter, p should be negative.
+        return line.getActivePowerSetpoint() * HvdcConverterStations.getActivePowerSetpointMultiplier(lccCs); // A LCC station has active losses.
+    }
+
+    /**
+     * Gets reactive power for an LCC station in per-unit.
+     */
+    public static double getLccConverterStationLoadTargetQ(LccConverterStation lccCs, HvdcLine line) {
+        // The active power setpoint is always positive.
+        // If the converter station is at side 1 and is rectifier, p should be positive.
+        // If the converter station is at side 1 and is inverter, p should be negative.
+        // If the converter station is at side 2 and is rectifier, p should be positive.
+        // If the converter station is at side 2 and is inverter, p should be negative.
+        double pCs = getLccConverterStationLoadTargetP(lccCs, line);
+        return Math.abs(pCs * Math.tan(Math.acos(lccCs.getPowerFactor()))); // A LCC station always consumes reactive power.
+    }
+
+    public static double getHvdcLineTargetP(VscConverterStation vscCs) {
+        // The active power setpoint is always positive.
+        // If the converter station is at side 1 and is rectifier, targetP should be negative.
+        // If the converter station is at side 1 and is inverter, targetP should be positive.
+        // If the converter station is at side 2 and is rectifier, targetP should be negative.
+        // If the converter station is at side 2 and is inverter, targetP should be positive.
+        HvdcLine line = vscCs.getHvdcLine();
+        return line.getActivePowerSetpoint() * HvdcConverterStations.getActivePowerSetpointMultiplier(vscCs);
+    }
+
+    public static HvdcConverterStation<?> getOtherConversionStation(HvdcConverterStation<?> station) {
+        HvdcLine line = station.getHvdcLine();
+        return line.getConverterStation1() == station ? line.getConverterStation2() : line.getConverterStation1();
+    }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
@@ -29,7 +29,8 @@ public final class HvdcConverterStations {
                 || (line.getConverterStation2() == station && line.getConvertersMode() == HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER);
     }
 
-    public static double getActivePowerSetpointMultiplier(HvdcConverterStation<?> station) {
+    public static double getSign(HvdcConverterStation<?> station) {
+        // This method gives the sign of PAc.
         boolean isConverterStationRectifier = isRectifier(station);
         double sign;
         if (station instanceof LccConverterStation) { // load convention.
@@ -39,46 +40,93 @@ public final class HvdcConverterStations {
         } else {
             throw new PowsyblException("Unknown HVDC converter station type: " + station.getClass().getSimpleName());
         }
-        return sign * (1 + (isConverterStationRectifier ? 1 : -1) * station.getLossFactor() / 100);
+        return sign;
     }
 
     /**
-     * Gets active power for an LCC station in per-unit.
+     * Gets active power for an LCC station.
      */
-    public static double getLccConverterStationLoadTargetP(LccConverterStation lccCs, HvdcLine line) {
-        // The active power setpoint is always positive.
+    public static double getLccConverterStationLoadTargetP(LccConverterStation lccCs) {
+        // Load convention.
         // If the converter station is at side 1 and is rectifier, p should be positive.
         // If the converter station is at side 1 and is inverter, p should be negative.
         // If the converter station is at side 2 and is rectifier, p should be positive.
         // If the converter station is at side 2 and is inverter, p should be negative.
-        return line.getActivePowerSetpoint() * HvdcConverterStations.getActivePowerSetpointMultiplier(lccCs); // A LCC station has active losses.
+        return getSign(lccCs) * getAbsoluteValuePAc(lccCs);
     }
 
     /**
-     * Gets reactive power for an LCC station in per-unit.
+     * Gets reactive power for an LCC converter station.
      */
-    public static double getLccConverterStationLoadTargetQ(LccConverterStation lccCs, HvdcLine line) {
-        // The active power setpoint is always positive.
+    public static double getLccConverterStationLoadTargetQ(LccConverterStation lccCs) {
+        // Load convention.
         // If the converter station is at side 1 and is rectifier, p should be positive.
         // If the converter station is at side 1 and is inverter, p should be negative.
         // If the converter station is at side 2 and is rectifier, p should be positive.
         // If the converter station is at side 2 and is inverter, p should be negative.
-        double pCs = getLccConverterStationLoadTargetP(lccCs, line);
+        double pCs = getLccConverterStationLoadTargetP(lccCs);
         return Math.abs(pCs * Math.tan(Math.acos(lccCs.getPowerFactor()))); // A LCC station always consumes reactive power.
     }
 
-    public static double getHvdcLineTargetP(VscConverterStation vscCs) {
-        // The active power setpoint is always positive.
+    /**
+     * Gets targetP of an VSC converter station.
+     */
+    public static double getConverterStationTargetP(VscConverterStation vscCs) {
+        // Generator convention.
         // If the converter station is at side 1 and is rectifier, targetP should be negative.
         // If the converter station is at side 1 and is inverter, targetP should be positive.
         // If the converter station is at side 2 and is rectifier, targetP should be negative.
         // If the converter station is at side 2 and is inverter, targetP should be positive.
-        HvdcLine line = vscCs.getHvdcLine();
-        return line.getActivePowerSetpoint() * HvdcConverterStations.getActivePowerSetpointMultiplier(vscCs);
+        return getSign(vscCs) * getAbsoluteValuePAc(vscCs);
     }
 
-    public static HvdcConverterStation<?> getOtherConversionStation(HvdcConverterStation<?> station) {
+    private static double getAbsoluteValuePAc(HvdcConverterStation<?> station) {
+        boolean isConverterStationRectifier = isRectifier(station);
+        if (isConverterStationRectifier) {
+            return station.getHvdcLine().getActivePowerSetpoint();
+        } else {
+            // the converter station is inverter.
+            HvdcConverterStation<?> otherStation = getOtherConversionStation(station);
+            return getAbsoluteValueInverterPAc(otherStation.getLossFactor(), station.getLossFactor(), station.getHvdcLine());
+        }
+    }
+
+    private static double getHvdcLineLosses(double rectifierPDc, double nominalV, double r) {
+        // This method computes the losses due to the HVDC line.
+        // The active power value on rectifier DC side is known as the HVDC active power set point minus the losses related
+        // to AC/DC conversion (rectifier conversion), the voltage is approximated to the nominal voltage as attribute of the HVDC line.
+        // In an HVDC, as a branch with two sides, the difference between pDc1 and pDc2 can be computed with the assumptions:
+        // I = (V1 - V2) / R and pDc1 = I * V1 and pDc2 = I * V2
+        // we simply obtain that the absolute value of the difference is equal to R * pDc1 * pDc1 / (V1 * V1) if side 1 is rectifier side.
+        return r * rectifierPDc * rectifierPDc / (nominalV * nominalV);
+    }
+
+    private static double getAbsoluteValueInverterPAc(double rectifierLossFactor, double inverterLossFactor,
+                                                      HvdcLine hvdcLine) {
+        // On inverter side, absolute value of PAc of a VSC converter station should be computed in three step:
+        // 1) compute the losses related to the rectifier conversion.
+        // 2) compute the losses related to the HVDC line itself (R i^2).
+        // 3) compute the losses related to the inverter conversion.
+        double rectifierPDc = hvdcLine.getActivePowerSetpoint() * (1 - rectifierLossFactor / 100); // rectifierPDc positive.
+        double inverterPDc = rectifierPDc - getHvdcLineLosses(rectifierPDc, hvdcLine.getNominalV(), hvdcLine.getR());
+        return inverterPDc * (1 - inverterLossFactor / 100); // always positive.
+    }
+
+    private static HvdcConverterStation<?> getOtherConversionStation(HvdcConverterStation<?> station) {
         HvdcLine line = station.getHvdcLine();
         return line.getConverterStation1() == station ? line.getConverterStation2() : line.getConverterStation1();
+    }
+
+    public static double getActivePowerSetpointMultiplier(HvdcConverterStation<?> station) {
+        // For sensitivity analysis, we need the multiplier by converter station for an increase of 1MW
+        // of the HVDC active power setpoint.
+        // As a first approximation, we don't take into account the losses due to HVDC line itself.
+        boolean isConverterStationRectifier = isRectifier(station);
+        double sign = getSign(station);
+        if (isConverterStationRectifier) {
+            return sign;
+        } else {
+            return sign * (1 - (station.getLossFactor() + getOtherConversionStation(station).getLossFactor()) / 100);
+        }
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfVscConverterStationImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfVscConverterStationImpl.java
@@ -20,7 +20,7 @@ public final class LfVscConverterStationImpl extends AbstractLfGenerator {
     private final VscConverterStation station;
 
     private LfVscConverterStationImpl(VscConverterStation station, boolean breakers, boolean reactiveLimits, LfNetworkLoadingReport report) {
-        super(HvdcConverterStations.getHvdcLineTargetP(station));
+        super(HvdcConverterStations.getConverterStationTargetP(station));
         this.station = station;
 
         // local control only

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfVscConverterStationImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfVscConverterStationImpl.java
@@ -20,7 +20,7 @@ public final class LfVscConverterStationImpl extends AbstractLfGenerator {
     private final VscConverterStation station;
 
     private LfVscConverterStationImpl(VscConverterStation station, boolean breakers, boolean reactiveLimits, LfNetworkLoadingReport report) {
-        super(getHvdcLineTargetP(station));
+        super(HvdcConverterStations.getHvdcLineTargetP(station));
         this.station = station;
 
         // local control only
@@ -32,16 +32,6 @@ public final class LfVscConverterStationImpl extends AbstractLfGenerator {
     public static LfVscConverterStationImpl create(VscConverterStation station, boolean breakers, boolean reactiveLimits, LfNetworkLoadingReport report) {
         Objects.requireNonNull(station);
         return new LfVscConverterStationImpl(station, breakers, reactiveLimits, report);
-    }
-
-    private static double getHvdcLineTargetP(VscConverterStation vscCs) {
-        // The active power setpoint is always positive.
-        // If the converter station is at side 1 and is rectifier, targetP should be negative.
-        // If the converter station is at side 1 and is inverter, targetP should be positive.
-        // If the converter station is at side 2 and is rectifier, targetP should be negative.
-        // If the converter station is at side 2 and is inverter, targetP should be positive.
-        HvdcLine line = vscCs.getHvdcLine();
-        return line.getActivePowerSetpoint() * HvdcConverterStations.getActivePowerSetpointMultiplier(vscCs);
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -601,7 +601,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
             LfBus bus = busAndlcc.getKey();
             LccConverterStation lcc = busAndlcc.getValue();
             HvdcLine line = lcc.getHvdcLine();
-            bus.setLoadTargetP(bus.getLoadTargetP() - AbstractLfBus.getLccConverterStationLoadTargetP(lcc, line));
+            bus.setLoadTargetP(bus.getLoadTargetP() - HvdcConverterStations.getLccConverterStationLoadTargetP(lcc, line) / PerUnit.SB);
         }
 
         for (LfVscConverterStationImpl vsc : vscs) {

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -600,7 +600,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
         for (Pair<LfBus, LccConverterStation> busAndlcc : lccs) {
             LfBus bus = busAndlcc.getKey();
             LccConverterStation lcc = busAndlcc.getValue();
-            bus.setLoadTargetP(bus.getLoadTargetP() - HvdcConverterStations.getLccConverterStationLoadTargetP(lcc) / PerUnit.SB);
+            bus.setLoadTargetP(bus.getLoadTargetP() - HvdcConverterStations.getConverterStationTargetP(lcc) / PerUnit.SB);
         }
 
         for (LfVscConverterStationImpl vsc : vscs) {

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -600,8 +600,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
         for (Pair<LfBus, LccConverterStation> busAndlcc : lccs) {
             LfBus bus = busAndlcc.getKey();
             LccConverterStation lcc = busAndlcc.getValue();
-            HvdcLine line = lcc.getHvdcLine();
-            bus.setLoadTargetP(bus.getLoadTargetP() - HvdcConverterStations.getLccConverterStationLoadTargetP(lcc, line) / PerUnit.SB);
+            bus.setLoadTargetP(bus.getLoadTargetP() - HvdcConverterStations.getLccConverterStationLoadTargetP(lcc) / PerUnit.SB);
         }
 
         for (LfVscConverterStationImpl vsc : vscs) {

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowLccTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowLccTest.java
@@ -39,18 +39,18 @@ class AcLoadFlowLccTest {
 
         Bus bus2 = network.getBusView().getBus("vl2_0");
         assertVoltageEquals(389.3763, bus2);
-        assertAngleEquals(-0.095311, bus2);
+        assertAngleEquals(-0.095268, bus2);
 
         Bus bus3 = network.getBusView().getBus("vl3_0");
         assertVoltageEquals(380, bus3);
         assertAngleEquals(0, bus3);
 
         LccConverterStation cs2 = network.getLccConverterStation("cs2");
-        assertActivePowerEquals(50.05, cs2.getTerminal());
-        assertReactivePowerEquals(37.538, cs2.getTerminal());
+        assertActivePowerEquals(50.00, cs2.getTerminal());
+        assertReactivePowerEquals(37.499, cs2.getTerminal());
 
         LccConverterStation cs3 = network.getLccConverterStation("cs3");
-        assertActivePowerEquals(-49.45, cs3.getTerminal());
-        assertReactivePowerEquals(37.087, cs3.getTerminal());
+        assertActivePowerEquals(-49.399, cs3.getTerminal());
+        assertReactivePowerEquals(37.049, cs3.getTerminal());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowPhaseShifterTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowPhaseShifterTest.java
@@ -410,7 +410,7 @@ class AcLoadFlowPhaseShifterTest {
                 .setRegulating(true);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isOk());
-        assertActivePowerEquals(100.1307, network.getLine("l12").getTerminal1());
+        assertActivePowerEquals(100.0805, network.getLine("l12").getTerminal1());
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
@@ -40,7 +40,7 @@ class AcLoadFlowVscTest {
 
         Bus bus2 = network.getBusView().getBus("vl2_0");
         assertVoltageEquals(385, bus2);
-        assertAngleEquals(0.116917, bus2);
+        assertAngleEquals(0.117616, bus2);
 
         Bus bus3 = network.getBusView().getBus("vl3_0");
         assertVoltageEquals(383, bus3);
@@ -48,21 +48,21 @@ class AcLoadFlowVscTest {
 
         Generator g1 = network.getGenerator("g1");
         assertActivePowerEquals(-102.56, g1.getTerminal());
-        assertReactivePowerEquals(-615.733, g1.getTerminal());
+        assertReactivePowerEquals(-615.918, g1.getTerminal());
 
         VscConverterStation cs2 = network.getVscConverterStation("cs2");
-        assertActivePowerEquals(50.55, cs2.getTerminal());
-        assertReactivePowerEquals(598.046, cs2.getTerminal());
+        assertActivePowerEquals(50.00, cs2.getTerminal());
+        assertReactivePowerEquals(598.228, cs2.getTerminal());
 
         VscConverterStation cs3 = network.getVscConverterStation("cs3");
-        assertActivePowerEquals(-49.90, cs3.getTerminal());
+        assertActivePowerEquals(-49.35, cs3.getTerminal());
         assertReactivePowerEquals(-10.0, cs3.getTerminal());
 
         Line l12 = network.getLine("l12");
-        assertActivePowerEquals(103.112, l12.getTerminal1());
-        assertReactivePowerEquals(615.733, l12.getTerminal1());
-        assertActivePowerEquals(-100.55, l12.getTerminal2());
-        assertReactivePowerEquals(-608.046, l12.getTerminal2());
+        assertActivePowerEquals(102.563, l12.getTerminal1());
+        assertReactivePowerEquals(615.918, l12.getTerminal1());
+        assertActivePowerEquals(-99.999, l12.getTerminal2());
+        assertReactivePowerEquals(-608.228, l12.getTerminal2());
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysisTest.java
@@ -318,9 +318,9 @@ public abstract class AbstractSensitivityAnalysisTest extends AbstractConverterT
         assertEquals(1, result.getValues().size());
         assertEquals(0d, result.getSensitivityValue("l45", "l12"), LoadFlowAssert.DELTA_POWER);
         if (dc) {
-            assertEquals(100.050, result.getFunctionReferenceValue("l12"), LoadFlowAssert.DELTA_POWER);
+            assertEquals(100.00, result.getFunctionReferenceValue("l12"), LoadFlowAssert.DELTA_POWER);
         } else {
-            assertEquals(100.131, result.getFunctionReferenceValue("l12"), LoadFlowAssert.DELTA_POWER);
+            assertEquals(100.08, result.getFunctionReferenceValue("l12"), LoadFlowAssert.DELTA_POWER);
         }
     }
 
@@ -339,9 +339,9 @@ public abstract class AbstractSensitivityAnalysisTest extends AbstractConverterT
         assertEquals(1, result.getValues().size());
         assertEquals(0, result.getSensitivityValue("glsk", "l12"), LoadFlowAssert.DELTA_POWER);
         if (dc) {
-            assertEquals(100.050, result.getFunctionReferenceValue("l12"), LoadFlowAssert.DELTA_POWER);
+            assertEquals(100.000, result.getFunctionReferenceValue("l12"), LoadFlowAssert.DELTA_POWER);
         } else {
-            assertEquals(100.131, result.getFunctionReferenceValue("l12"), LoadFlowAssert.DELTA_POWER);
+            assertEquals(100.080, result.getFunctionReferenceValue("l12"), LoadFlowAssert.DELTA_POWER);
         }
     }
 

--- a/src/test/java/com/powsybl/openloadflow/sensi/ac/AcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/ac/AcSensitivityAnalysisContingenciesTest.java
@@ -750,7 +750,7 @@ class AcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
         assertEquals(2, result.getValues().size());
         assertEquals(0, result.getSensitivityValue("glsk", "l12"), LoadFlowAssert.DELTA_POWER);
 
-        assertEquals(100.131, result.getFunctionReferenceValue("l12"), LoadFlowAssert.DELTA_POWER);
-        assertEquals(100.131, result.getFunctionReferenceValue("additionnalline_0", "l12"), LoadFlowAssert.DELTA_POWER);
+        assertEquals(100.080, result.getFunctionReferenceValue("l12"), LoadFlowAssert.DELTA_POWER);
+        assertEquals(100.080, result.getFunctionReferenceValue("additionnalline_0", "l12"), LoadFlowAssert.DELTA_POWER);
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sensi/ac/AcSensitivityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/ac/AcSensitivityAnalysisTest.java
@@ -644,9 +644,9 @@ class AcSensitivityAnalysisTest extends AbstractSensitivityAnalysisTest {
 
         SensitivityAnalysisResult result = sensiRunner.run(network, factors, Collections.emptyList(), Collections.emptyList(), sensiParameters);
 
-        assertEquals(-0.346002, result.getSensitivityValue("hvdc34", "l12"), LoadFlowAssert.DELTA_POWER);
-        assertEquals(0.346002, result.getSensitivityValue("hvdc34", "l13"), LoadFlowAssert.DELTA_POWER);
-        assertEquals(0.642998, result.getSensitivityValue("hvdc34", "l23"), LoadFlowAssert.DELTA_POWER);
+        assertEquals(-0.341889, result.getSensitivityValue("hvdc34", "l12"), LoadFlowAssert.DELTA_POWER);
+        assertEquals(0.341889, result.getSensitivityValue("hvdc34", "l13"), LoadFlowAssert.DELTA_POWER);
+        assertEquals(0.63611, result.getSensitivityValue("hvdc34", "l23"), LoadFlowAssert.DELTA_POWER);
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/sensi/dc/DcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/dc/DcSensitivityAnalysisContingenciesTest.java
@@ -1721,8 +1721,8 @@ class DcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
         assertEquals(2, result.getValues().size());
         assertEquals(0, result.getSensitivityValue("glsk", "l12"), LoadFlowAssert.DELTA_POWER);
 
-        assertEquals(100.050, result.getFunctionReferenceValue("l12"), LoadFlowAssert.DELTA_POWER);
-        assertEquals(100.050, result.getFunctionReferenceValue("additionnalline_0", "l12"), LoadFlowAssert.DELTA_POWER);
+        assertEquals(100.000, result.getFunctionReferenceValue("l12"), LoadFlowAssert.DELTA_POWER);
+        assertEquals(100.000, result.getFunctionReferenceValue("additionnalline_0", "l12"), LoadFlowAssert.DELTA_POWER);
     }
 
     @Test
@@ -1743,7 +1743,7 @@ class DcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
         assertEquals(2, result.getValues().size());
         assertEquals(0, result.getSensitivityValue("glsk", "l12"), LoadFlowAssert.DELTA_POWER);
 
-        assertEquals(100.050, result.getFunctionReferenceValue("l12"), LoadFlowAssert.DELTA_POWER);
+        assertEquals(100.0, result.getFunctionReferenceValue("l12"), LoadFlowAssert.DELTA_POWER);
         assertEquals(0, result.getFunctionReferenceValue("l12", "l12"), LoadFlowAssert.DELTA_POWER);
     }
 


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <anne.tilloy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

The Hvdc active power set point is applied on converter station that is in rectifier mode, on its AC side. On the inverter AC side, we computes the active power using both loss factors and the losses due to the line itself.

**What is the current behavior?** *(You can also link to an open issue here)*

The Hvdc active power set point is applied on converter station that is in rectifier mode, on its DC side.

**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
