### PR TITLE
Remove equation access in Newtow Raphson

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/ReactiveLimitsOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/ReactiveLimitsOuterLoop.java
@@ -176,7 +176,7 @@ public class ReactiveLimitsOuterLoop implements OuterLoop {
     private void checkPvBus(LfBus controllerBus, List<PvToPqBus> pvToPqBuses, MutableInt remainingPvBusCount) {
         double minQ = controllerBus.getMinQ();
         double maxQ = controllerBus.getMaxQ();
-        double q = controllerBus.getCalculatedQ() + controllerBus.getLoadTargetQ();
+        double q = controllerBus.getQ().eval() + controllerBus.getLoadTargetQ();
         if (q < minQ) {
             pvToPqBuses.add(new PvToPqBus(controllerBus, q, minQ, ReactiveLimitDirection.MIN));
         } else if (q > maxQ) {

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonResult.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonResult.java
@@ -13,11 +13,11 @@ import java.util.Objects;
  */
 public class NewtonRaphsonResult {
 
-    private int iteration;
+    private final int iteration;
 
-    private NewtonRaphsonStatus status;
+    private final NewtonRaphsonStatus status;
 
-    private double slackBusActivePowerMismatch;
+    private final double slackBusActivePowerMismatch;
 
     public NewtonRaphsonResult(NewtonRaphsonStatus status, int iteration, double slackBusActivePowerMismatch) {
         if (iteration < 0) {

--- a/src/main/java/com/powsybl/openloadflow/network/LfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBus.java
@@ -98,10 +98,6 @@ public interface LfBus extends LfElement {
 
     void setAngle(double angle);
 
-    double getCalculatedQ();
-
-    void setCalculatedQ(double calculatedQ);
-
     /**
      * Get nominal voltage in Kv.
      * @return nominal voltage in Kv
@@ -166,4 +162,10 @@ public interface LfBus extends LfElement {
     double getRemoteVoltageControlReactivePercent();
 
     void setRemoteVoltageControlReactivePercent(double remoteVoltageControlReactivePercent);
+
+    /**
+     * Get active power mismatch.
+     * Only make sens for slack bus.
+     */
+    double getMismatchP();
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -38,8 +38,6 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
 
     protected double angle;
 
-    protected double calculatedQ = Double.NaN;
-
     private boolean hasGeneratorsWithSlope;
 
     protected boolean voltageControlEnabled = false;
@@ -384,16 +382,6 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     }
 
     @Override
-    public double getCalculatedQ() {
-        return calculatedQ / PerUnit.SB;
-    }
-
-    @Override
-    public void setCalculatedQ(double calculatedQ) {
-        this.calculatedQ = calculatedQ * PerUnit.SB;
-    }
-
-    @Override
     public Optional<LfShunt> getShunt() {
         return Optional.ofNullable(shunt);
     }
@@ -471,7 +459,7 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     @Override
     public void updateState(boolean reactiveLimits, boolean writeSlackBus, boolean distributedOnConformLoad, boolean loadPowerFactorConstant) {
         // update generator reactive power
-        updateGeneratorsState(voltageControlEnabled ? calculatedQ + loadTargetQ : generationTargetQ, reactiveLimits);
+        updateGeneratorsState(voltageControlEnabled ? q.eval()  * PerUnit.SB + loadTargetQ : generationTargetQ, reactiveLimits);
 
         // update load power
         lfLoads.updateState(getLoadTargetP() - getInitialLoadTargetP(), loadPowerFactorConstant);
@@ -573,5 +561,10 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     @Override
     public void setRemoteVoltageControlReactivePercent(double remoteVoltageControlReactivePercent) {
         this.remoteVoltageControlReactivePercent = remoteVoltageControlReactivePercent;
+    }
+
+    @Override
+    public double getMismatchP() {
+        return p.eval() - getTargetP(); // slack bus can also have real injection connected
     }
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
We access the equation system to get bus p and q in Newton Raphson and AC LF. 


**What is the new behavior (if this is a feature change)?**
We only rely on p and q of LfBus.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
