### PR TITLE
Fix transformer voltage control with multiple components

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/AbstractElement.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractElement.java
@@ -55,7 +55,7 @@ public abstract class AbstractElement implements LfElement {
     public Object getUserObject(String name) {
         Objects.requireNonNull(name);
         if (userObjects == null) {
-            userObjects = new HashMap<>();
+            return null;
         }
         return userObjects.get(name);
     }

--- a/src/main/java/com/powsybl/openloadflow/network/AbstractElement.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractElement.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.openloadflow.network;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -19,7 +21,7 @@ public abstract class AbstractElement implements LfElement {
 
     protected boolean disabled = false;
 
-    protected Object userObject;
+    protected Map<String, Object> userObjects;
 
     protected AbstractElement(LfNetwork network) {
         this.network = Objects.requireNonNull(network);
@@ -50,12 +52,20 @@ public abstract class AbstractElement implements LfElement {
         return network;
     }
 
-    public Object getUserObject() {
-        return userObject;
+    public Object getUserObject(String name) {
+        Objects.requireNonNull(name);
+        if (userObjects == null) {
+            userObjects = new HashMap<>();
+        }
+        return userObjects.get(name);
     }
 
-    public void setUserObject(Object userObject) {
-        this.userObject = userObject;
+    public void setUserObject(String name, Object userObject) {
+        Objects.requireNonNull(name);
+        if (userObjects == null) {
+            userObjects = new HashMap<>();
+        }
+        this.userObjects.put(name, userObject);
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/AbstractElement.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractElement.java
@@ -65,7 +65,7 @@ public abstract class AbstractElement implements LfElement {
         if (userObjects == null) {
             userObjects = new HashMap<>();
         }
-        this.userObjects.put(name, userObject);
+        userObjects.put(name, userObject);
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/LfElement.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfElement.java
@@ -25,7 +25,7 @@ public interface LfElement {
 
     LfNetwork getNetwork();
 
-    Object getUserObject();
+    Object getUserObject(String name);
 
-    void setUserObject(Object userObject);
+    void setUserObject(String name, Object userObject);
 }

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -74,7 +74,7 @@ public class LfNetwork {
 
     private boolean valid = true;
 
-    private Object userObject;
+    private final Map<String, Object> userObjects = new HashMap<>();
 
     private final GraphDecrementalConnectivityFactory<LfBus> connectivityFactory;
 
@@ -586,12 +586,14 @@ public class LfNetwork {
         return valid;
     }
 
-    public Object getUserObject() {
-        return userObject;
+    public Object getUserObject(String name) {
+        Objects.requireNonNull(name);
+        return userObjects.get(name);
     }
 
-    public void setUserObject(Object userObject) {
-        this.userObject = userObject;
+    public void setUserObject(String name, Object userObject) {
+        Objects.requireNonNull(name);
+        this.userObjects.put(name, userObject);
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -593,7 +593,7 @@ public class LfNetwork {
 
     public void setUserObject(String name, Object userObject) {
         Objects.requireNonNull(name);
-        this.userObjects.put(name, userObject);
+        userObjects.put(name, userObject);
     }
 
     @Override

--- a/src/test/java/com/powsybl/openloadflow/network/UserObjectTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/UserObjectTest.java
@@ -24,12 +24,12 @@ class UserObjectTest {
     void test() {
         Network network = EurostagTutorialExample1Factory.create();
         LfNetwork lfNetwork = Networks.load(network, new FirstSlackBusSelector()).get(0);
-        assertNull(lfNetwork.getUserObject());
-        lfNetwork.setUserObject("test");
-        assertEquals("test", lfNetwork.getUserObject());
+        assertNull(lfNetwork.getUserObject("a"));
+        lfNetwork.setUserObject("a", "test");
+        assertEquals("test", lfNetwork.getUserObject("a"));
         LfBus lfBus = lfNetwork.getBus(0);
-        assertNull(lfBus.getUserObject());
-        lfBus.setUserObject("hello");
-        assertEquals("hello", lfBus.getUserObject());
+        assertNull(lfBus.getUserObject("b"));
+        lfBus.setUserObject("b", "hello");
+        assertEquals("hello", lfBus.getUserObject("b"));
     }
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When transformer voltage control is activated and multiple connected components is activated, the max nominal voltage stored inside outer loop is shared between the different component calculation => consequence is inconsistency/crash for other component calculation. This is because outer loop are not supposed to be stateful as there is only one instance for all calculation. So no data should be stored as a attribute of outer loops. 


**What is the new behavior (if this is a feature change)?**
State is store in LfNetwork as a user object.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
