### PR TITLE
Fix HVDC set point increase sensitivity convention

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
@@ -115,11 +115,10 @@ public final class HvdcConverterStations {
         // of the HVDC active power setpoint.
         // As a first approximation, we don't take into account the losses due to HVDC line itself.
         boolean isConverterStationRectifier = isRectifier(station);
-        double sign = getSign(station);
         if (isConverterStationRectifier) {
-            return sign;
+            return (station instanceof VscConverterStation) ? 1 : -1;
         } else {
-            return sign * (1 - (station.getLossFactor() + getOtherConversionStation(station).getLossFactor()) / 100);
+            return ((station instanceof VscConverterStation) ? -1 : 1) * (1 - (station.getLossFactor() + getOtherConversionStation(station).getLossFactor()) / 100);
         }
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
@@ -113,12 +113,13 @@ public final class HvdcConverterStations {
     public static double getActivePowerSetpointMultiplier(HvdcConverterStation<?> station) {
         // For sensitivity analysis, we need the multiplier by converter station for an increase of 1MW
         // of the HVDC active power setpoint.
+        // VSC injection follow here a load sign convention as LCC injection.
         // As a first approximation, we don't take into account the losses due to HVDC line itself.
         boolean isConverterStationRectifier = isRectifier(station);
         if (isConverterStationRectifier) {
-            return (station instanceof VscConverterStation) ? 1 : -1;
+            return -1;
         } else {
-            return ((station instanceof VscConverterStation) ? -1 : 1) * (1 - (station.getLossFactor() + getOtherConversionStation(station).getLossFactor()) / 100);
+            return 1 - (station.getLossFactor() + getOtherConversionStation(station).getLossFactor()) / 100;
         }
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
@@ -901,16 +901,12 @@ public abstract class AbstractSensitivityAnalysis<V extends Enum<V> & Quantity, 
                     // => we create a multi (bi) variables factor
                     Map<LfElement, Double> injectionLfBuses = new HashMap<>(2);
                     if (bus1 != null) {
-                        // VSC injection follow here a load sign convention as LCC injection.
                         // FIXME: for LCC, Q changes when P changes
-                        injectionLfBuses.put(bus1, (hvdcLine.getConverterStation1() instanceof VscConverterStation ? -1 : 1)
-                                * HvdcConverterStations.getActivePowerSetpointMultiplier(hvdcLine.getConverterStation1()));
+                        injectionLfBuses.put(bus1, HvdcConverterStations.getActivePowerSetpointMultiplier(hvdcLine.getConverterStation1()));
                     }
                     if (bus2 != null) {
-                        // VSC injection follow here a load sign convention as LCC injection.
                         // FIXME: for LCC, Q changes when P changes
-                        injectionLfBuses.put(bus2, (hvdcLine.getConverterStation2() instanceof VscConverterStation ? -1 : 1)
-                                * HvdcConverterStations.getActivePowerSetpointMultiplier(hvdcLine.getConverterStation2()));
+                        injectionLfBuses.put(bus2, HvdcConverterStations.getActivePowerSetpointMultiplier(hvdcLine.getConverterStation2()));
                     }
 
                     factorHolder.addFactor(new MultiVariablesLfSensitivityFactor<>(factorIndex[0], variableId,

--- a/src/test/java/com/powsybl/openloadflow/sensi/dc/DcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/dc/DcSensitivityAnalysisContingenciesTest.java
@@ -1070,7 +1070,7 @@ class DcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
         network.getGeneratorStream().forEach(gen -> gen.setMaxP(2 * gen.getMaxP()));
         Map<String, Double> loadFlowDiff = network.getLineStream()
                 .map(Identifiable::getId)
-                .collect(Collectors.toMap(Function.identity(), line -> (network1.getLine(line).getTerminal1().getP() - network2.getLine(line).getTerminal1().getP()) / SENSI_CHANGE));
+                .collect(Collectors.toMap(Function.identity(), line -> (network2.getLine(line).getTerminal1().getP() - network1.getLine(line).getTerminal1().getP()) / SENSI_CHANGE));
 
         List<SensitivityFactor> factors = SensitivityFactor.createMatrix(SensitivityFunctionType.BRANCH_ACTIVE_POWER, List.of("l12", "l13", "l23", "l25", "l45", "l46", "l56"),
                                                                          SensitivityVariableType.HVDC_LINE_ACTIVE_POWER, List.of("hvdc34"),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

It changes the sign convention for a sensitivity variable of type `HVDC_LINE_ACTIVE_POWER`, that was totally inverse for both LCCs and VSCs. In the unit tests, we were testing the sensitivity values doing flow before minus flow after, and it seems that it is the contrary.

**What is the current behavior?** *(You can also link to an open issue here)*

It is fixed in principle. 

**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
