### PR TITLE
Get original ID

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/AbstractElement.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractElement.java
@@ -7,6 +7,7 @@
 package com.powsybl.openloadflow.network;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -25,6 +26,11 @@ public abstract class AbstractElement implements LfElement {
 
     protected AbstractElement(LfNetwork network) {
         this.network = Objects.requireNonNull(network);
+    }
+
+    @Override
+    public List<String> getOriginalIds() {
+        return List.of(getId());
     }
 
     public int getNum() {

--- a/src/main/java/com/powsybl/openloadflow/network/BusDcState.java
+++ b/src/main/java/com/powsybl/openloadflow/network/BusDcState.java
@@ -24,7 +24,7 @@ public class BusDcState extends ElementState<LfBus> {
         this.loadTargetP = bus.getLoadTargetP();
         this.generatorsTargetP = bus.getGenerators().stream().collect(Collectors.toMap(LfGenerator::getId, LfGenerator::getTargetP));
         this.participatingGenerators = bus.getGenerators().stream().collect(Collectors.toMap(LfGenerator::getId, LfGenerator::isParticipating));
-        this.absVariableLoadTargetP = bus.getLfLoads().getAbsVariableLoadTargetP();
+        this.absVariableLoadTargetP = bus.getLoads().getAbsVariableLoadTargetP();
     }
 
     @Override
@@ -33,7 +33,7 @@ public class BusDcState extends ElementState<LfBus> {
         element.setLoadTargetP(loadTargetP);
         element.getGenerators().forEach(g -> g.setTargetP(generatorsTargetP.get(g.getId())));
         element.getGenerators().forEach(g -> g.setParticipating(participatingGenerators.get(g.getId())));
-        element.getLfLoads().setAbsVariableLoadTargetP(absVariableLoadTargetP);
+        element.getLoads().setAbsVariableLoadTargetP(absVariableLoadTargetP);
     }
 
     public static BusDcState save(LfBus bus) {

--- a/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
@@ -23,6 +23,13 @@ public interface LfBranch extends LfElement {
 
     double LOW_IMPEDANCE_THRESHOLD = Math.pow(10, -8); // in per unit
 
+    enum BranchType {
+        LINE_OR_TRANSFO_2,
+        TRANSFO_3_LEG,
+        DANGLING_LINE,
+        SWITCH
+    }
+
     class LfLimit {
 
         private int acceptableDuration;
@@ -54,6 +61,8 @@ public interface LfBranch extends LfElement {
             this.acceptableDuration = acceptableDuration;
         }
     }
+
+    BranchType getBranchType();
 
     LfBus getBus1();
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
@@ -24,7 +24,8 @@ public interface LfBranch extends LfElement {
     double LOW_IMPEDANCE_THRESHOLD = Math.pow(10, -8); // in per unit
 
     enum BranchType {
-        LINE_OR_TRANSFO_2,
+        LINE,
+        TRANSFO_2,
         TRANSFO_3_LEG,
         DANGLING_LINE,
         SWITCH

--- a/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
@@ -26,7 +26,9 @@ public interface LfBranch extends LfElement {
     enum BranchType {
         LINE,
         TRANSFO_2,
-        TRANSFO_3_LEG,
+        TRANSFO_3_LEG_1,
+        TRANSFO_3_LEG_2,
+        TRANSFO_3_LEG_3,
         DANGLING_LINE,
         SWITCH
     }

--- a/src/main/java/com/powsybl/openloadflow/network/LfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBus.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.openloadflow.network;
 
-import com.powsybl.openloadflow.network.impl.LfLoads;
 import com.powsybl.openloadflow.util.Evaluable;
 import com.powsybl.security.results.BusResults;
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBus.java
@@ -117,7 +117,7 @@ public interface LfBus extends LfElement {
 
     Optional<LfShunt> getControllerShunt();
 
-    LfLoads getLfLoads();
+    LfLoads getLoads();
 
     List<LfBranch> getBranches();
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfContingency.java
@@ -107,7 +107,7 @@ public class LfContingency {
             PowerShift shift = e.getValue();
             bus.setLoadTargetP(bus.getLoadTargetP() - getUpdatedLoadP0(bus, parameters.getBalanceType(), shift.getActive(), shift.getVariableActive()));
             bus.setLoadTargetQ(bus.getLoadTargetQ() - shift.getReactive());
-            bus.getLfLoads().setAbsVariableLoadTargetP(bus.getLfLoads().getAbsVariableLoadTargetP() - Math.abs(shift.getVariableActive()) * PerUnit.SB);
+            bus.getLoads().setAbsVariableLoadTargetP(bus.getLoads().getAbsVariableLoadTargetP() - Math.abs(shift.getVariableActive()) * PerUnit.SB);
         }
         for (LfGenerator generator : generators) {
             generator.setTargetP(0);
@@ -124,9 +124,9 @@ public class LfContingency {
     public static double getUpdatedLoadP0(LfBus bus, LoadFlowParameters.BalanceType balanceType, double initialP0, double initialVariableActivePower) {
         double factor = 0.0;
         if (balanceType == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD) {
-            factor = Math.abs(initialP0) / (bus.getLfLoads().getAbsVariableLoadTargetP() / PerUnit.SB);
+            factor = Math.abs(initialP0) / (bus.getLoads().getAbsVariableLoadTargetP() / PerUnit.SB);
         } else if (balanceType == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD) {
-            factor = initialVariableActivePower / (bus.getLfLoads().getAbsVariableLoadTargetP() / PerUnit.SB);
+            factor = initialVariableActivePower / (bus.getLoads().getAbsVariableLoadTargetP() / PerUnit.SB);
         }
         return initialP0 + (bus.getLoadTargetP() - bus.getInitialLoadTargetP()) * factor;
     }

--- a/src/main/java/com/powsybl/openloadflow/network/LfElement.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfElement.java
@@ -6,12 +6,16 @@
  */
 package com.powsybl.openloadflow.network;
 
+import java.util.List;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public interface LfElement {
 
     String getId();
+
+    List<String> getOriginalIds();
 
     ElementType getType();
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfGenerator.java
@@ -19,6 +19,8 @@ public interface LfGenerator {
 
     String getId();
 
+    String getOriginalId();
+
     LfBus getBus();
 
     void setBus(LfBus bus);

--- a/src/main/java/com/powsybl/openloadflow/network/LfLoads.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfLoads.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.network;
+
+import java.util.List;
+
+/**
+ * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ */
+public interface LfLoads {
+
+    List<String> getOriginalIds();
+
+    double getAbsVariableLoadTargetP();
+
+    void setAbsVariableLoadTargetP(double absVariableLoadTargetP);
+
+    double getLoadCount();
+
+    double getLoadTargetQ(double diffLoadTargetP);
+}

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -150,12 +150,12 @@ public class LfNetwork {
         bus.getShunt().ifPresent(shunt -> {
             shunt.setNum(shuntCount++);
             shuntsByIndex.add(shunt);
-            shunt.getIds().forEach(id -> shuntsById.put(id, shunt));
+            shunt.getOriginalIds().forEach(id -> shuntsById.put(id, shunt));
         });
         bus.getControllerShunt().ifPresent(shunt -> {
             shunt.setNum(shuntCount++);
             shuntsByIndex.add(shunt);
-            shunt.getIds().forEach(id -> shuntsById.put(id, shunt));
+            shunt.getOriginalIds().forEach(id -> shuntsById.put(id, shunt));
         });
         bus.getGenerators().forEach(gen -> generatorsById.put(gen.getId(), gen));
     }

--- a/src/main/java/com/powsybl/openloadflow/network/LfShunt.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfShunt.java
@@ -6,15 +6,12 @@
  */
 package com.powsybl.openloadflow.network;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public interface LfShunt extends LfElement {
-
-    List<String> getIds();
 
     double getB();
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -58,7 +58,7 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
 
     protected LfShunt controllerShunt;
 
-    protected final LfLoads lfLoads = new LfLoads();
+    protected final LfLoadsImpl lfLoads = new LfLoadsImpl();
 
     protected boolean ensurePowerFactorConstantByLoad = false;
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -397,7 +397,7 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     }
 
     @Override
-    public LfLoads getLfLoads() {
+    public LfLoads getLoads() {
         return lfLoads;
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
@@ -53,6 +53,11 @@ public abstract class AbstractLfGenerator implements LfGenerator {
         this.targetP = targetP;
     }
 
+    @Override
+    public String getOriginalId() {
+        return getId();
+    }
+
     public LfBus getBus() {
         return bus;
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
@@ -138,7 +138,7 @@ public class LfBranchImpl extends AbstractLfBranch {
 
     @Override
     public BranchType getBranchType() {
-        return BranchType.LINE_OR_TRANSFO_2;
+        return branch instanceof Line ? BranchType.LINE : BranchType.TRANSFO_2;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
@@ -137,6 +137,11 @@ public class LfBranchImpl extends AbstractLfBranch {
     }
 
     @Override
+    public BranchType getBranchType() {
+        return BranchType.LINE_OR_TRANSFO_2;
+    }
+
+    @Override
     public boolean hasPhaseControlCapability() {
         return branch.getType() == IdentifiableType.TWO_WINDINGS_TRANSFORMER
                 && ((TwoWindingsTransformer) branch).getPhaseTapChanger() != null;

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
@@ -50,6 +50,11 @@ public class LfDanglingLineBranch extends AbstractFictitiousLfBranch {
     }
 
     @Override
+    public BranchType getBranchType() {
+        return BranchType.DANGLING_LINE;
+    }
+
+    @Override
     public boolean hasPhaseControlCapability() {
         return false;
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBus.java
@@ -9,6 +9,7 @@ package com.powsybl.openloadflow.network.impl;
 import com.powsybl.iidm.network.DanglingLine;
 import com.powsybl.openloadflow.network.LfNetwork;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -34,6 +35,11 @@ public class LfDanglingLineBus extends AbstractLfBus {
 
     public static String getId(DanglingLine danglingLine) {
         return danglingLine.getId() + "_BUS";
+    }
+
+    @Override
+    public List<String> getOriginalIds() {
+        return List.of(danglingLine.getId());
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineGenerator.java
@@ -40,6 +40,11 @@ public class LfDanglingLineGenerator extends AbstractLfGenerator {
     }
 
     @Override
+    public String getOriginalId() {
+        return danglingLine.getId();
+    }
+
+    @Override
     public OptionalDouble getRemoteControlReactiveKey() {
         return OptionalDouble.empty();
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfHvdcImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfHvdcImpl.java
@@ -18,33 +18,44 @@ import static com.powsybl.openloadflow.util.EvaluableConstants.NAN;
 /**
  * @author Anne Tilloy <anne.tilloy at rte-france.com>
  */
-public final class LfHvdcImpl extends AbstractElement implements LfHvdc {
+public class LfHvdcImpl extends AbstractElement implements LfHvdc {
 
-    private String id;
+    private final String id;
 
-    private LfBus bus1;
+    private final LfBus bus1;
 
-    private LfBus bus2;
+    private final LfBus bus2;
 
     private Evaluable p1 = NAN;
 
     private Evaluable p2 = NAN;
 
-    private double droop;
+    private final double droop;
 
-    private double p0;
+    private final double p0;
 
     private LfVscConverterStationImpl vsc1;
 
     private LfVscConverterStationImpl vsc2;
 
-    public LfHvdcImpl(HvdcAngleDroopActivePowerControl control, LfBus bus1, LfBus bus2, LfNetwork network, String hvdcId) {
+    public LfHvdcImpl(String id, LfBus bus1, LfBus bus2, LfNetwork network, HvdcAngleDroopActivePowerControl control) {
         super(network);
-        this.id = hvdcId;
+        this.id = Objects.requireNonNull(id);
         this.bus1 = bus1;
         this.bus2 = bus2;
+        Objects.requireNonNull(control);
         droop = control.getDroop();
         p0 = control.getP0();
+    }
+
+    @Override
+    public ElementType getType() {
+        return ElementType.HVDC;
+    }
+
+    @Override
+    public String getId() {
+        return id;
     }
 
     @Override
@@ -107,16 +118,6 @@ public final class LfHvdcImpl extends AbstractElement implements LfHvdc {
     public void setConverterStation2(LfVscConverterStationImpl converterStation2) {
         this.vsc2 = converterStation2;
         converterStation2.setTargetP(0);
-    }
-
-    @Override
-    public ElementType getType() {
-        return ElementType.HVDC;
-    }
-
-    @Override
-    public String getId() {
-        return id;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
@@ -106,7 +106,13 @@ public class LfLegBranch extends AbstractFictitiousLfBranch {
 
     @Override
     public BranchType getBranchType() {
-        return BranchType.TRANSFO_3_LEG;
+        if (leg == twt.getLeg1()) {
+            return BranchType.TRANSFO_3_LEG_1;
+        } else if (leg == twt.getLeg2()) {
+            return BranchType.TRANSFO_3_LEG_2;
+        } else {
+            return BranchType.TRANSFO_3_LEG_3;
+        }
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
@@ -105,6 +105,16 @@ public class LfLegBranch extends AbstractFictitiousLfBranch {
     }
 
     @Override
+    public BranchType getBranchType() {
+        return BranchType.TRANSFO_3_LEG;
+    }
+
+    @Override
+    public List<String> getOriginalIds() {
+        return List.of(twt.getId());
+    }
+
+    @Override
     public boolean hasPhaseControlCapability() {
         return leg.getPhaseTapChanger() != null;
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLoadsImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLoadsImpl.java
@@ -6,17 +6,20 @@
  */
 package com.powsybl.openloadflow.network.impl;
 
+import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Load;
 import com.powsybl.iidm.network.extensions.LoadDetail;
+import com.powsybl.openloadflow.network.LfLoads;
 import com.powsybl.openloadflow.util.PerUnit;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author Anne Tilloy <anne.tilloy at rte-france.com>
  */
-public class LfLoads {
+public class LfLoadsImpl implements LfLoads {
 
     private final List<Load> loads = new ArrayList<>();
 
@@ -28,16 +31,23 @@ public class LfLoads {
 
     private boolean isInitialized;
 
-    public void add(Load load, boolean distributedOnConformLoad) {
+    @Override
+    public List<String> getOriginalIds() {
+        return loads.stream().map(Identifiable::getId).collect(Collectors.toList());
+    }
+
+    void add(Load load, boolean distributedOnConformLoad) {
         loads.add(load);
         this.distributedOnConformLoad = distributedOnConformLoad; // TODO: put in constructor instead
     }
 
+    @Override
     public double getAbsVariableLoadTargetP() {
         init();
         return absVariableLoadTargetP;
     }
 
+    @Override
     public void setAbsVariableLoadTargetP(double absVariableLoadTargetP) {
         this.absVariableLoadTargetP = absVariableLoadTargetP;
     }
@@ -69,11 +79,12 @@ public class LfLoads {
         isInitialized = true;
     }
 
+    @Override
     public double getLoadCount() {
         return loads.size();
     }
 
-    public void updateState(double diffLoadTargetP, boolean loadPowerFactorConstant) {
+    void updateState(double diffLoadTargetP, boolean loadPowerFactorConstant) {
         init();
         for (int i = 0; i < loads.size(); i++) {
             Load load = loads.get(i);
@@ -84,6 +95,7 @@ public class LfLoads {
         }
     }
 
+    @Override
     public double getLoadTargetQ(double diffLoadTargetP) {
         init();
         double newLoadTargetQ = 0;

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -381,7 +381,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
                 if (control != null && control.isEnabled()) {
                     LfBus lfBus1 = getLfBus(hvdcLine.getConverterStation1().getTerminal(), lfNetwork, parameters.isBreakers());
                     LfBus lfBus2 = getLfBus(hvdcLine.getConverterStation2().getTerminal(), lfNetwork, parameters.isBreakers());
-                    LfHvdc lfHvdc = new LfHvdcImpl(control, lfBus1, lfBus2, lfNetwork, hvdcLine.getId());
+                    LfHvdc lfHvdc = new LfHvdcImpl(hvdcLine.getId(), lfBus1, lfBus2, lfNetwork, control);
                     LfVscConverterStationImpl cs1 = (LfVscConverterStationImpl) lfNetwork.getGeneratorById(hvdcLine.getConverterStation1().getId());
                     LfVscConverterStationImpl cs2 = (LfVscConverterStationImpl) lfNetwork.getGeneratorById(hvdcLine.getConverterStation2().getId());
                     if (cs1 != null && cs2 != null) {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfShuntImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfShuntImpl.java
@@ -141,6 +141,11 @@ public class LfShuntImpl extends AbstractElement implements LfShunt {
     }
 
     @Override
+    public List<String> getOriginalIds() {
+        return getIds();
+    }
+
+    @Override
     public double getB() {
         return b;
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfShuntImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfShuntImpl.java
@@ -136,13 +136,8 @@ public class LfShuntImpl extends AbstractElement implements LfShunt {
     }
 
     @Override
-    public List<String> getIds() {
-        return shuntCompensators.stream().map(ShuntCompensator::getId).collect(Collectors.toList());
-    }
-
-    @Override
     public List<String> getOriginalIds() {
-        return getIds();
+        return shuntCompensators.stream().map(ShuntCompensator::getId).collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfStarBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfStarBus.java
@@ -9,6 +9,8 @@ package com.powsybl.openloadflow.network.impl;
 import com.powsybl.iidm.network.ThreeWindingsTransformer;
 import com.powsybl.openloadflow.network.LfNetwork;
 
+import java.util.List;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
@@ -27,6 +29,11 @@ public class LfStarBus extends AbstractLfBus {
     @Override
     public String getId() {
         return t3wt.getId() + "_BUS0";
+    }
+
+    @Override
+    public List<String> getOriginalIds() {
+        return List.of(t3wt.getId());
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfSwitch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfSwitch.java
@@ -37,6 +37,11 @@ public class LfSwitch extends AbstractLfBranch {
     }
 
     @Override
+    public BranchType getBranchType() {
+        return BranchType.SWITCH;
+    }
+
+    @Override
     public boolean hasPhaseControlCapability() {
         return false;
     }

--- a/src/main/java/com/powsybl/openloadflow/network/util/LoadActivePowerDistributionStep.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/LoadActivePowerDistributionStep.java
@@ -37,13 +37,13 @@ public class LoadActivePowerDistributionStep implements ActivePowerDistribution.
     @Override
     public List<ParticipatingElement> getParticipatingElements(Collection<LfBus> buses) {
         return buses.stream()
-                .filter(bus -> bus.getLfLoads().getLoadCount() > 0 && bus.isParticipating() && !bus.isDisabled() && !bus.isFictitious())
+                .filter(bus -> bus.getLoads().getLoadCount() > 0 && bus.isParticipating() && !bus.isDisabled() && !bus.isFictitious())
                 .map(bus -> new ParticipatingElement(bus, getParticipationFactor(bus)))
                 .collect(Collectors.toList());
     }
 
     private double getParticipationFactor(LfBus bus) {
-        return bus.getLfLoads().getAbsVariableLoadTargetP();
+        return bus.getLoads().getAbsVariableLoadTargetP();
     }
 
     @Override
@@ -89,7 +89,7 @@ public class LoadActivePowerDistributionStep implements ActivePowerDistribution.
         // we have to keep the power factor constant by updating targetQ.
         double newLoadTargetQ;
         if (bus.ensurePowerFactorConstantByLoad()) {
-            newLoadTargetQ = bus.getLfLoads().getLoadTargetQ(newLoadTargetP - bus.getInitialLoadTargetP());
+            newLoadTargetQ = bus.getLoads().getLoadTargetQ(newLoadTargetP - bus.getInitialLoadTargetP());
         } else {
             newLoadTargetQ = newLoadTargetP * bus.getLoadTargetQ() / bus.getLoadTargetP();
         }

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -625,7 +625,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
                 PowerShift shift = e.getValue();
                 double p0 = shift.getActive();
                 lfBus.setLoadTargetP(lfBus.getLoadTargetP() - LfContingency.getUpdatedLoadP0(lfBus, lfParameters.getBalanceType(), p0, shift.getVariableActive()));
-                lfBus.getLfLoads().setAbsVariableLoadTargetP(lfBus.getLfLoads().getAbsVariableLoadTargetP() - Math.abs(shift.getVariableActive()) * PerUnit.SB);
+                lfBus.getLoads().setAbsVariableLoadTargetP(lfBus.getLoads().getAbsVariableLoadTargetP() - Math.abs(shift.getVariableActive()) * PerUnit.SB);
             }
         }
     }

--- a/src/test/java/com/powsybl/openloadflow/network/OriginalIdsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/OriginalIdsTest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.network;
+
+import com.powsybl.openloadflow.network.impl.LfNetworkLoaderImpl;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+class OriginalIdsTest {
+
+    @Test
+    void test() {
+        var network = T3wtFactory.create();
+        LfNetwork lfNetwork = LfNetwork.load(network, new LfNetworkLoaderImpl(), new FirstSlackBusSelector()).get(0);
+        assertEquals(List.of("3wt"), lfNetwork.getBranchById("3wt_leg_1").getOriginalIds());
+        assertEquals(LfBranch.BranchType.TRANSFO_3_LEG_1, lfNetwork.getBranchById("3wt_leg_1").getBranchType());
+        assertEquals(LfBranch.BranchType.TRANSFO_3_LEG_2, lfNetwork.getBranchById("3wt_leg_2").getBranchType());
+        assertEquals(LfBranch.BranchType.TRANSFO_3_LEG_3, lfNetwork.getBranchById("3wt_leg_3").getBranchType());
+        assertEquals(List.of("vl1_0"), lfNetwork.getBusById("vl1_0").getOriginalIds());
+        assertEquals("g1", lfNetwork.getGeneratorById("g1").getOriginalId());
+        assertEquals(List.of("ld2"), lfNetwork.getBusById("vl2_0").getLoads().getOriginalIds());
+    }
+}

--- a/src/test/java/com/powsybl/openloadflow/network/OriginalIdsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/OriginalIdsTest.java
@@ -41,5 +41,6 @@ class OriginalIdsTest {
         assertEquals(List.of("dl1"), lfNetwork.getBranchById("dl1").getOriginalIds());
         assertEquals(LfBranch.BranchType.DANGLING_LINE, lfNetwork.getBranchById("dl1").getBranchType());
         assertEquals(List.of("dl1"), lfNetwork.getBusById("dl1_BUS").getOriginalIds());
+        assertEquals("dl1", lfNetwork.getGeneratorById("dl1_GEN").getOriginalId());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/network/OriginalIdsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/OriginalIdsTest.java
@@ -19,15 +19,27 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class OriginalIdsTest {
 
     @Test
-    void test() {
+    void testWith3wtNetwork() {
         var network = T3wtFactory.create();
         LfNetwork lfNetwork = LfNetwork.load(network, new LfNetworkLoaderImpl(), new FirstSlackBusSelector()).get(0);
         assertEquals(List.of("3wt"), lfNetwork.getBranchById("3wt_leg_1").getOriginalIds());
         assertEquals(LfBranch.BranchType.TRANSFO_3_LEG_1, lfNetwork.getBranchById("3wt_leg_1").getBranchType());
         assertEquals(LfBranch.BranchType.TRANSFO_3_LEG_2, lfNetwork.getBranchById("3wt_leg_2").getBranchType());
         assertEquals(LfBranch.BranchType.TRANSFO_3_LEG_3, lfNetwork.getBranchById("3wt_leg_3").getBranchType());
+        assertEquals(List.of("3wt"), lfNetwork.getBusById("3wt_BUS0").getOriginalIds());
         assertEquals(List.of("vl1_0"), lfNetwork.getBusById("vl1_0").getOriginalIds());
         assertEquals("g1", lfNetwork.getGeneratorById("g1").getOriginalId());
         assertEquals(List.of("ld2"), lfNetwork.getBusById("vl2_0").getLoads().getOriginalIds());
+    }
+
+    @Test
+    void testWithBoundaryNetwork() {
+        var network = BoundaryFactory.create();
+        LfNetwork lfNetwork = LfNetwork.load(network, new LfNetworkLoaderImpl(), new FirstSlackBusSelector()).get(0);
+        assertEquals(List.of("l1"), lfNetwork.getBranchById("l1").getOriginalIds());
+        assertEquals(LfBranch.BranchType.LINE, lfNetwork.getBranchById("l1").getBranchType());
+        assertEquals(List.of("dl1"), lfNetwork.getBranchById("dl1").getOriginalIds());
+        assertEquals(LfBranch.BranchType.DANGLING_LINE, lfNetwork.getBranchById("dl1").getBranchType());
+        assertEquals(List.of("dl1"), lfNetwork.getBusById("dl1_BUS").getOriginalIds());
     }
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
There is no strict equivalence between IIDM elements and Lf Network ones. Some elements like loads and shunts are aggregated and some other one a split (3 windings transformers and dangling lines).


**What is the new behavior (if this is a feature change)?**
We can get list of original IDs for each of the element and for branches a type to get original part of the IIDM element.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
