### PR TITLE
Fix security analysis behaviour when network is invalid

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sa/AcSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AcSecurityAnalysis.java
@@ -7,7 +7,6 @@
 package com.powsybl.openloadflow.sa;
 
 import com.google.common.base.Stopwatch;
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.reporter.Reporter;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.contingency.ContingenciesProvider;
@@ -32,10 +31,7 @@ import com.powsybl.openloadflow.network.impl.PropagatedContingency;
 import com.powsybl.openloadflow.network.util.PreviousValueVoltageInitializer;
 import com.powsybl.security.*;
 import com.powsybl.security.monitor.StateMonitor;
-import com.powsybl.security.results.BranchResult;
-import com.powsybl.security.results.BusResults;
-import com.powsybl.security.results.PostContingencyResult;
-import com.powsybl.security.results.ThreeWindingsTransformerResult;
+import com.powsybl.security.results.*;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.*;
@@ -46,6 +42,14 @@ public class AcSecurityAnalysis extends AbstractSecurityAnalysis {
     protected AcSecurityAnalysis(Network network, LimitViolationDetector detector, LimitViolationFilter filter,
                                  MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus> connectivityFactory, List<StateMonitor> stateMonitors) {
         super(network, detector, filter, matrixFactory, connectivityFactory, stateMonitors);
+    }
+
+    private static SecurityAnalysisResult createNoResult() {
+        return new SecurityAnalysisResult(new PreContingencyResult(new LimitViolationsResult(false, Collections.emptyList()),
+                                                                   Collections.emptyList(),
+                                                                   Collections.emptyList(),
+                                                                   Collections.emptyList()),
+                                          Collections.emptyList());
     }
 
     @Override
@@ -73,14 +77,17 @@ public class AcSecurityAnalysis extends AbstractSecurityAnalysis {
         List<LfNetwork> lfNetworks = createNetworks(allSwitchesToOpen, acParameters.getNetworkParameters());
 
         // run simulation on largest network
+        SecurityAnalysisResult result;
         if (lfNetworks.isEmpty()) {
-            throw new PowsyblException("Empty network list");
+            result = createNoResult();
+        } else {
+            LfNetwork largestNetwork = lfNetworks.get(0);
+            if (largestNetwork.isValid()) {
+                result = runSimulations(largestNetwork, propagatedContingencies, acParameters, securityAnalysisParameters);
+            } else {
+                result = createNoResult();
+            }
         }
-        LfNetwork largestNetwork = lfNetworks.get(0);
-        if (!largestNetwork.isValid()) {
-            throw new PowsyblException("Largest network is invalid");
-        }
-        SecurityAnalysisResult result = runSimulations(largestNetwork, propagatedContingencies, acParameters, securityAnalysisParameters);
 
         stopwatch.stop();
         LOGGER.info("Security analysis {} in {} ms", Thread.currentThread().isInterrupted() ? "cancelled" : "done",

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
@@ -381,4 +381,11 @@ class AcLoadFlowEurostagTutorialExample1Test {
         assertReactivePowerEquals(0, network.getShuntCompensator("SC").getTerminal());
         assertReactivePowerEquals(0, network.getShuntCompensator("SC2").getTerminal());
     }
+
+    @Test
+    void testEmptyNetwork() {
+        Network network = Network.create("empty", "");
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.getComponentResults().isEmpty());
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -1317,4 +1317,13 @@ class OpenSecurityAnalysisTest {
         SecurityAnalysisResult result = runSecurityAnalysis(network);
         assertFalse(result.getPreContingencyResult().getLimitViolationsResult().isComputationOk());
     }
+
+    @Test
+    void testDivergenceStatus() {
+        Network network = EurostagTutorialExample1Factory.create();
+        network.getLine("NHV1_NHV2_1").setR(100).setX(-999);
+        network.getLine("NHV1_NHV2_2").setR(100).setX(-999);
+        SecurityAnalysisResult result = runSecurityAnalysis(network);
+        assertFalse(result.getPreContingencyResult().getLimitViolationsResult().isComputationOk());
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -391,8 +391,8 @@ class OpenSecurityAnalysisTest {
         Network network = EurostagTutorialExample1Factory.create();
         network.getGenerator("GEN").getTerminal().disconnect();
 
-        CompletionException exception = assertThrows(CompletionException.class, () -> runSecurityAnalysis(network));
-        assertEquals("Largest network is invalid", exception.getCause().getMessage());
+        SecurityAnalysisResult result = runSecurityAnalysis(network);
+        assertFalse(result.getPreContingencyResult().getLimitViolationsResult().isComputationOk());
     }
 
     @Test
@@ -1309,5 +1309,12 @@ class OpenSecurityAnalysisTest {
         // post-contingency tests
         PostContingencyResult g1ContingencyResult = getPostContingencyResult(result, "g1");
         assertEquals(-0.696, g1ContingencyResult.getBranchResult("l25").getP1(), LoadFlowAssert.DELTA_POWER);
+    }
+
+    @Test
+    void testEmptyNetwork() {
+        Network network = Network.create("empty", "");
+        SecurityAnalysisResult result = runSecurityAnalysis(network);
+        assertFalse(result.getPreContingencyResult().getLimitViolationsResult().isComputationOk());
     }
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
An exception is thrown when network is invalid (not PV bus for instance) during a security analysis.


**What is the new behavior (if this is a feature change)?**
No more exception but a computationOk to false in pre contingency result.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
