### PR TITLE
Catch MatrixException instead of Exception

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphson.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphson.java
@@ -7,6 +7,7 @@
 package com.powsybl.openloadflow.ac.nr;
 
 import com.powsybl.commons.reporter.Reporter;
+import com.powsybl.math.matrix.MatrixException;
 import com.powsybl.openloadflow.ac.equations.AcEquationType;
 import com.powsybl.openloadflow.ac.equations.AcVariableType;
 import com.powsybl.openloadflow.equations.*;
@@ -55,7 +56,7 @@ public class NewtonRaphson {
             // solve f(x) = j * dx
             try {
                 j.solveTransposed(fx);
-            } catch (Exception e) {
+            } catch (MatrixException e) {
                 LOGGER.error(e.toString(), e);
                 return NewtonRaphsonStatus.SOLVER_FAILED;
             }

--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
@@ -11,6 +11,7 @@ import com.powsybl.commons.reporter.Reporter;
 import com.powsybl.commons.reporter.TypedValue;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.LoadFlowResult;
+import com.powsybl.math.matrix.MatrixException;
 import com.powsybl.openloadflow.dc.equations.DcEquationSystem;
 import com.powsybl.openloadflow.dc.equations.DcEquationType;
 import com.powsybl.openloadflow.dc.equations.DcVariableType;
@@ -195,7 +196,7 @@ public class DcLoadFlowEngine {
         try {
             j.solveTransposed(targetVector);
             status = LoadFlowResult.ComponentResult.Status.CONVERGED;
-        } catch (Exception e) {
+        } catch (MatrixException e) {
             status = LoadFlowResult.ComponentResult.Status.FAILED;
             reporter.report(Report.builder()
                 .withKey("loadFlowFailure")


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
We catch `Exception` to detect solver failure


**What is the new behavior (if this is a feature change)?**
Thanks to https://github.com/powsybl/powsybl-core/pull/1961 and https://github.com/powsybl/powsybl-math-native/pull/21 we can catch a more accurate `MatrixException`


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
