### PR TITLE
Fix Even Shiloach algorithm

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/graph/EvenShiloachGraphDecrementalConnectivity.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/EvenShiloachGraphDecrementalConnectivity.java
@@ -180,19 +180,21 @@ public class EvenShiloachGraphDecrementalConnectivity<V> implements GraphDecreme
             V vertex2 = cutEdge.getRight();
             graph.removeEdge(vertex1, vertex2);
 
-            GraphProcess processA = new GraphProcessA(vertex1, vertex2);
-            GraphProcessB processB = new GraphProcessB(vertex1, vertex2);
-            while (!processA.isHalted() && !processB.isHalted()) {
-                processA.next();
-                if (!processA.isHalted()) {
-                    processB.next();
+            if (graph.getAllEdges(vertex1, vertex2).isEmpty()) {
+                GraphProcess processA = new GraphProcessA(vertex1, vertex2);
+                GraphProcessB processB = new GraphProcessB(vertex1, vertex2);
+                while (!processA.isHalted() && !processB.isHalted()) {
+                    processA.next();
+                    if (!processA.isHalted()) {
+                        processB.next();
+                    }
                 }
-            }
 
-            if (processA.isHalted()) {
-                processB.undoChanges();
-            } else { // processB halted
-                allSavedChangedLevels.add(processB.savedChangedLevels);
+                if (processA.isHalted()) {
+                    processB.undoChanges();
+                } else { // processB halted
+                    allSavedChangedLevels.add(processB.savedChangedLevels);
+                }
             }
         }
         unprocessedCutEdges.clear();
@@ -332,7 +334,7 @@ public class EvenShiloachGraphDecrementalConnectivity<V> implements GraphDecreme
 
                 nLowLevel.upperLevel.remove(vertexBigLevel);
                 nBigLevel.lowerLevel.remove(vertexLowLevel);
-                if (nBigLevel.lowerLevel.isEmpty() && graph.getAllEdges(vertex1, vertex2).isEmpty()) {
+                if (nBigLevel.lowerLevel.isEmpty()) {
                     this.verticesToUpdate.add(vertexBigLevel);
                 }
             }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The Even Shiloach algorithm is run even if we do not disconnect all the edges between v1 and v2. This seems to cause the algorithm to sometimes never end.


**What is the new behavior (if this is a feature change)?**
The algorithm is now run only if we disconnect all edges between two vertices.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
