### PR TITLE
Fix contingency generator for AC computations

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/LfContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfContingency.java
@@ -123,7 +123,7 @@ public class LfContingency {
             }
         }
         for (LfBus bus : generatorBuses) {
-            if (bus.getGenerators().stream().filter(gen -> gen.getGeneratorControlType() == LfGenerator.GeneratorControlType.VOLTAGE).findAny().isEmpty()) {
+            if (bus.getGenerators().stream().noneMatch(gen -> gen.getGeneratorControlType() == LfGenerator.GeneratorControlType.VOLTAGE)) {
                 bus.setVoltageControlEnabled(false);
             }
         }

--- a/src/main/java/com/powsybl/openloadflow/network/LfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfGenerator.java
@@ -23,8 +23,6 @@ public interface LfGenerator {
 
     void setBus(LfBus bus);
 
-    boolean hasVoltageControl();
-
     boolean hasRemoteReactivePowerControl();
 
     GeneratorControlType getGeneratorControlType();

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -335,7 +335,7 @@ public class LfNetwork {
         if (!Double.isNaN(generator.getTargetQ())) {
             jsonGenerator.writeNumberField("targetQ", generator.getTargetQ());
         }
-        jsonGenerator.writeBooleanField("voltageControl", generator.hasVoltageControl());
+        jsonGenerator.writeBooleanField("voltageControl", generator.getGeneratorControlType() == LfGenerator.GeneratorControlType.VOLTAGE);
         jsonGenerator.writeNumberField("minP", generator.getMinP());
         jsonGenerator.writeNumberField("maxP", generator.getMaxP());
     }

--- a/src/main/java/com/powsybl/openloadflow/network/VoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/VoltageControl.java
@@ -63,7 +63,8 @@ public class VoltageControl {
      * @return true if the voltage control is shared, false otherwise
      */
     public boolean isSharedControl() {
-        return controllers.stream().flatMap(lfBus -> lfBus.getGenerators().stream()).filter(LfGenerator::hasVoltageControl).count() > 1;
+        return controllers.stream().flatMap(lfBus -> lfBus.getGenerators().stream())
+                .filter(gen -> gen.getGeneratorControlType() == LfGenerator.GeneratorControlType.VOLTAGE).count() > 1;
     }
 
     public void updateReactiveKeys() {
@@ -91,7 +92,8 @@ public class VoltageControl {
         double[] qKeys = new double[controllerBuses.size()];
         for (int i = 0; i < controllerBuses.size(); i++) {
             LfBus controllerBus = controllerBuses.get(i);
-            qKeys[i] = controllerBus.getGenerators().stream().filter(LfGenerator::hasVoltageControl).count();
+            qKeys[i] = controllerBus.getGenerators().stream()
+                    .filter(gen -> gen.getGeneratorControlType() == LfGenerator.GeneratorControlType.VOLTAGE).count();
         }
         return qKeys;
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -155,7 +155,7 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
 
     @Override
     public List<LfGenerator> getGeneratorsControllingVoltageWithSlope() {
-        return generators.stream().filter(gen -> gen.hasVoltageControl() && gen.getSlope() != 0).collect(Collectors.toList());
+        return generators.stream().filter(gen -> gen.getGeneratorControlType() == LfGenerator.GeneratorControlType.VOLTAGE && gen.getSlope() != 0).collect(Collectors.toList());
     }
 
     @Override
@@ -220,7 +220,7 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     protected void add(LfGenerator generator) {
         generators.add(generator);
         generator.setBus(this);
-        if (!generator.hasVoltageControl() && !Double.isNaN(generator.getTargetQ())) {
+        if (generator.getGeneratorControlType() != LfGenerator.GeneratorControlType.VOLTAGE && !Double.isNaN(generator.getTargetQ())) {
             generationTargetQ += generator.getTargetQ() * PerUnit.SB;
         }
     }
@@ -336,9 +336,8 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
 
     private double getLimitQ(ToDoubleFunction<LfGenerator> limitQ) {
         return generators.stream()
-                .mapToDouble(generator -> generator.hasVoltageControl() ? limitQ.applyAsDouble(generator)
-                                                                        : generator.getTargetQ())
-                .sum();
+                .mapToDouble(generator -> generator.getGeneratorControlType() == LfGenerator.GeneratorControlType.VOLTAGE ?
+                        limitQ.applyAsDouble(generator) : generator.getTargetQ()).sum();
     }
 
     @Override
@@ -441,7 +440,7 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
         double qToDispatch = generationQ / PerUnit.SB;
         List<LfGenerator> generatorsThatControlVoltage = new LinkedList<>();
         for (LfGenerator generator : generators) {
-            if (generator.hasVoltageControl()) {
+            if (generator.getGeneratorControlType() == LfGenerator.GeneratorControlType.VOLTAGE) {
                 generatorsThatControlVoltage.add(generator);
             } else {
                 qToDispatch -= generator.getTargetQ();

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
@@ -84,11 +84,6 @@ public abstract class AbstractLfGenerator implements LfGenerator {
     }
 
     @Override
-    public boolean hasVoltageControl() {
-        return generatorControlType == GeneratorControlType.VOLTAGE;
-    }
-
-    @Override
     public GeneratorControlType getGeneratorControlType() {
         return generatorControlType;
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -68,7 +68,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         // set controller -> controlled link
         for (LfBus controllerBus : lfBuses) {
 
-            List<LfGenerator> voltageControlGenerators = controllerBus.getGenerators().stream().filter(LfGenerator::hasVoltageControl).collect(Collectors.toList());
+            List<LfGenerator> voltageControlGenerators = controllerBus.getGenerators().stream().filter(gen -> gen.getGeneratorControlType() == LfGenerator.GeneratorControlType.VOLTAGE).collect(Collectors.toList());
             if (!voltageControlGenerators.isEmpty()) {
 
                 LfGenerator lfGenerator0 = voltageControlGenerators.get(0);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No. Bug fix.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

In case of a generator contingency, changing the generator control type is not enough because there is no link with the equation system. The link is between the status of the controller bus and the equation system.

**What is the current behavior?** *(You can also link to an open issue here)*

After applying a generator contingency, we have to check that all generators have switch off the voltage control or not. If yes, we change the controller bus status, that will lead to the update of the equation system.  

**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
