### PR TITLE
Determinist branchesToOpen order

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/PropagatedContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/PropagatedContingency.java
@@ -139,7 +139,7 @@ public class PropagatedContingency {
                                                 boolean withBreakers, boolean slackDistributionOnConformLoad) {
         Set<Switch> switchesToOpen = new HashSet<>();
         Set<Terminal> terminalsToDisconnect =  new HashSet<>();
-        Set<String> branchIdsToOpen = new HashSet<>();
+        Set<String> branchIdsToOpen = new LinkedHashSet<>();
         Set<String> hvdcIdsToOpen = new HashSet<>();
         Set<Load> loadsToLose = new HashSet<>();
         Set<Generator> generatorsToLose = new HashSet<>();

--- a/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
@@ -610,10 +610,10 @@ public abstract class AbstractSensitivityAnalysis<V extends Enum<V> & Quantity, 
             .forEach(lfBranch -> connectivity.cut(lfBranch.getBus1(), lfBranch.getBus2()));
     }
 
-    protected void setPredefinedResults(Collection<LfSensitivityFactor<V, E>> lfFactors, Set<LfBus> connectedComponent, Collection<String> branchIdsToOpen) {
+    protected void setPredefinedResults(Collection<LfSensitivityFactor<V, E>> lfFactors, Set<LfBus> connectedComponent, Set<String> branchIdsToOpen) {
         for (LfSensitivityFactor<V, E> factor : lfFactors) {
             String functionBranchId = factor.getFunctionElement().getId();
-            if (branchIdsToOpen.stream().anyMatch(id -> id.equals(functionBranchId))) {
+            if (branchIdsToOpen.contains(functionBranchId)) {
                 factor.setSensitivityValuePredefinedResult(0d);
                 factor.setFunctionPredefinedResult(0d);
                 continue;

--- a/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
@@ -201,7 +201,7 @@ public class AcSensitivityAnalysis extends AbstractSensitivityAnalysis<AcVariabl
         checkContingencies(lfNetwork, contingencies);
         checkLoadFlowParameters(lfParameters);
         Map<String, Set<String>> propagatedContingencyMap = contingencies.stream().collect(
-                Collectors.toMap(contingency -> contingency.getContingency().getId(), contingency -> new HashSet<>(contingency.getBranchIdsToOpen()))
+                Collectors.toMap(contingency -> contingency.getContingency().getId(), contingency -> new LinkedHashSet<>(contingency.getBranchIdsToOpen()))
         );
 
         Map<String, SensitivityVariableSet> variableSetsById = variableSets.stream().collect(Collectors.toMap(SensitivityVariableSet::getId, Function.identity()));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?** 
Bug fix (even though the order of branches to remove should not have any impact)

**What is the current behavior?** *(You can also link to an open issue here)*
The branches to open set has no determinist order, hence the edges to cut for connectivity computation is in a random order


**What is the new behavior (if this is a feature change)?**
The branches to open set has a determinist order


**Does this PR introduce a breaking change or deprecate an API?**
No
