### PR TITLE
Fix decremental connectivity

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
@@ -486,7 +486,7 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
     }
 
     static LfNetworkParameters getNetworkParameters(LoadFlowParameters parameters, OpenLoadFlowParameters parametersExt,
-                                                    SlackBusSelector slackBusSelector, GraphDecrementalConnectivityFactory<LfBus> connectivityFactory,
+                                                    SlackBusSelector slackBusSelector, GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory,
                                                     boolean breakers) {
         return new LfNetworkParameters(slackBusSelector,
                                        connectivityFactory,
@@ -510,13 +510,13 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
     }
 
     public static AcLoadFlowParameters createAcParameters(Network network, LoadFlowParameters parameters, OpenLoadFlowParameters parametersExt,
-                                                          MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus> connectivityFactory,
+                                                          MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory,
                                                           Reporter reporter) {
         return createAcParameters(network, parameters, parametersExt, matrixFactory, connectivityFactory, reporter, false, false);
     }
 
     public static AcLoadFlowParameters createAcParameters(Network network, LoadFlowParameters parameters, OpenLoadFlowParameters parametersExt,
-                                                          MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus> connectivityFactory,
+                                                          MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory,
                                                           Reporter reporter, boolean breakers, boolean forceA1Var) {
         AcLoadFlowParameters acParameters = createAcParameters(parameters, parametersExt, matrixFactory, connectivityFactory, reporter, breakers, forceA1Var);
         if (parameters.isReadSlackBus()) {
@@ -526,7 +526,7 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
     }
 
     public static AcLoadFlowParameters createAcParameters(LoadFlowParameters parameters, OpenLoadFlowParameters parametersExt,
-                                                          MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus> connectivityFactory,
+                                                          MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory,
                                                           Reporter reporter, boolean breakers, boolean forceA1Var) {
         SlackBusSelector slackBusSelector = SlackBusSelector.fromMode(parametersExt.getSlackBusSelectionMode(), parametersExt.getSlackBusesIds());
 
@@ -552,7 +552,7 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
     }
 
     public static DcLoadFlowParameters createDcParameters(Network network, LoadFlowParameters parameters, OpenLoadFlowParameters parametersExt,
-                                                          MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus> connectivityFactory,
+                                                          MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory,
                                                           boolean forcePhaseControlOffAndAddAngle1Var) {
         var dcParameters = createDcParameters(parameters, parametersExt, matrixFactory, connectivityFactory, forcePhaseControlOffAndAddAngle1Var);
         if (parameters.isReadSlackBus()) {
@@ -562,7 +562,7 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
     }
 
     public static DcLoadFlowParameters createDcParameters(LoadFlowParameters parameters, OpenLoadFlowParameters parametersExt,
-                                                          MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus> connectivityFactory,
+                                                          MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory,
                                                           boolean forcePhaseControlOffAndAddAngle1Var) {
         SlackBusSelector slackBusSelector = SlackBusSelector.fromMode(parametersExt.getSlackBusSelectionMode(), parametersExt.getSlackBusesIds());
 

--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
@@ -60,7 +60,7 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
 
     private final MatrixFactory matrixFactory;
 
-    private final GraphDecrementalConnectivityFactory<LfBus> connectivityFactory;
+    private final GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory;
 
     private boolean forcePhaseControlOffAndAddAngle1Var = false; // just for unit testing
 
@@ -72,7 +72,7 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
         this(matrixFactory, new EvenShiloachGraphDecrementalConnectivityFactory<>());
     }
 
-    public OpenLoadFlowProvider(MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus> connectivityFactory) {
+    public OpenLoadFlowProvider(MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory) {
         this.matrixFactory = Objects.requireNonNull(matrixFactory);
         this.connectivityFactory = Objects.requireNonNull(connectivityFactory);
     }

--- a/src/main/java/com/powsybl/openloadflow/ac/PhaseControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/PhaseControlOuterLoop.java
@@ -57,13 +57,15 @@ public class PhaseControlOuterLoop implements OuterLoop {
                 var connectivity = network.getConnectivity();
 
                 // apply contingency (in case we are inside a security analysis)
-                for (LfBranch disabledBranch : disabledBranches) {
-                    connectivity.cut(disabledBranch.getBus1(), disabledBranch.getBus2());
-                }
+                disabledBranches.stream()
+                        .filter(b -> b.getBus1() != null && b.getBus2() != null)
+                        .forEach(connectivity::cut);
                 int smallComponentsCountBeforePhaseShifterLoss = connectivity.getSmallComponents().size();
 
                 // then the phase shifter controlled branch
-                connectivity.cut(controlledBranch.getBus1(), controlledBranch.getBus2());
+                if (controlledBranch.getBus1() != null && controlledBranch.getBus2() != null) {
+                    connectivity.cut(controlledBranch);
+                }
 
                 if (connectivity.getSmallComponents().size() != smallComponentsCountBeforePhaseShifterLoss) {
                     // phase shifter controlled branch necessary for connectivity, we switch off control

--- a/src/main/java/com/powsybl/openloadflow/graph/EvenShiloachGraphDecrementalConnectivityFactory.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/EvenShiloachGraphDecrementalConnectivityFactory.java
@@ -9,10 +9,10 @@ package com.powsybl.openloadflow.graph;
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public class EvenShiloachGraphDecrementalConnectivityFactory<V> implements GraphDecrementalConnectivityFactory<V> {
+public class EvenShiloachGraphDecrementalConnectivityFactory<V, E> implements GraphDecrementalConnectivityFactory<V, E> {
 
     @Override
-    public GraphDecrementalConnectivity<V> create() {
+    public GraphDecrementalConnectivity<V, E> create() {
         return new EvenShiloachGraphDecrementalConnectivity<>();
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/graph/GraphDecrementalConnectivity.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/GraphDecrementalConnectivity.java
@@ -12,18 +12,16 @@ import java.util.Set;
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public interface GraphDecrementalConnectivity<V> {
+public interface GraphDecrementalConnectivity<V, E> {
 
     void addVertex(V vertex);
 
-    void addEdge(V vertex1, V vertex2);
+    void addEdge(V vertex1, V vertex2, E edge);
 
     /**
-     * Cut one edge between given vertices
-     * @param vertex1 first vertex, from or towards which the edge has been constructed
-     * @param vertex2 second vertex, towards or from which the edge has been constructed
+     * Cut given edge
      */
-    void cut(V vertex1, V vertex2);
+    void cut(E edge);
 
     /**
      * Reset all the cut done previously in the graph

--- a/src/main/java/com/powsybl/openloadflow/graph/GraphDecrementalConnectivityFactory.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/GraphDecrementalConnectivityFactory.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.graph;
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public interface GraphDecrementalConnectivityFactory<V> {
+public interface GraphDecrementalConnectivityFactory<V, E> {
 
-    GraphDecrementalConnectivity<V> create();
+    GraphDecrementalConnectivity<V, E> create();
 }

--- a/src/main/java/com/powsybl/openloadflow/graph/MinimumSpanningTreeGraphDecrementalConnectivity.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/MinimumSpanningTreeGraphDecrementalConnectivity.java
@@ -49,6 +49,9 @@ public class MinimumSpanningTreeGraphDecrementalConnectivity<V, E> implements Gr
 
     @Override
     public void cut(E edge) {
+        if (cutEdges.stream().anyMatch(t -> t.getMiddle().equals(edge))) {
+            throw new PowsyblException("Edge already cut: " + edge);
+        }
         if (!graph.containsEdge(edge)) {
             throw new PowsyblException("No such edge in graph: " + edge);
         }

--- a/src/main/java/com/powsybl/openloadflow/graph/MinimumSpanningTreeGraphDecrementalConnectivity.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/MinimumSpanningTreeGraphDecrementalConnectivity.java
@@ -23,14 +23,14 @@ public class MinimumSpanningTreeGraphDecrementalConnectivity<V, E> implements Gr
 
     private SpanningTrees mstOrigin;
     private SpanningTrees mst;
-    private final Graph<V, Object> graph;
+    private final Graph<V, E> graph;
 
-    private final List<Triple<V, V, Object>> cutEdges;
+    private final List<Triple<V, E, V>> cutEdges;
     private List<V> sortedRoots;
     private Map<V, V> parentMap;
 
     public MinimumSpanningTreeGraphDecrementalConnectivity() {
-        this.graph = new Pseudograph<>(Object.class);
+        this.graph = new Pseudograph<>(null, null, false);
         this.cutEdges = new ArrayList<>();
     }
 
@@ -67,13 +67,13 @@ public class MinimumSpanningTreeGraphDecrementalConnectivity<V, E> implements Gr
         V vertex1 = graph.getEdgeSource(edge);
         V vertex2 = graph.getEdgeTarget(edge);
         graph.removeEdge(edge);
-        cutEdges.add(Triple.of(vertex1, vertex2, edge));
+        cutEdges.add(Triple.of(vertex1, edge, vertex2));
     }
 
     @Override
     public void reset() {
-        for (Triple<V, V, Object> cutEdge : cutEdges) {
-            graph.addEdge(cutEdge.getLeft(), cutEdge.getMiddle(), cutEdge.getRight());
+        for (Triple<V, E, V> cutEdge : cutEdges) {
+            graph.addEdge(cutEdge.getLeft(), cutEdge.getRight(), cutEdge.getMiddle());
         }
         cutEdges.clear();
         resetMst();
@@ -152,7 +152,7 @@ public class MinimumSpanningTreeGraphDecrementalConnectivity<V, E> implements Gr
             MyUnionFind forest = new MyUnionFind(graph.vertexSet());
 
             Set<Object> edgeList = new HashSet<>();
-            for (Object edge : graph.edgeSet()) {
+            for (E edge : graph.edgeSet()) {
                 V source = graph.getEdgeSource(edge);
                 V target = graph.getEdgeTarget(edge);
                 if (forest.find(source).equals(forest.find(target))) {

--- a/src/main/java/com/powsybl/openloadflow/graph/MinimumSpanningTreeGraphDecrementalConnectivityFactory.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/MinimumSpanningTreeGraphDecrementalConnectivityFactory.java
@@ -9,10 +9,10 @@ package com.powsybl.openloadflow.graph;
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public class MinimumSpanningTreeGraphDecrementalConnectivityFactory<V> implements GraphDecrementalConnectivityFactory<V> {
+public class MinimumSpanningTreeGraphDecrementalConnectivityFactory<V, E> implements GraphDecrementalConnectivityFactory<V, E> {
 
     @Override
-    public GraphDecrementalConnectivity<V> create() {
+    public GraphDecrementalConnectivity<V, E> create() {
         return new MinimumSpanningTreeGraphDecrementalConnectivity<>();
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/graph/NaiveGraphDecrementalConnectivity.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/NaiveGraphDecrementalConnectivity.java
@@ -6,7 +6,8 @@
  */
 package com.powsybl.openloadflow.graph;
 
-import org.apache.commons.lang3.tuple.Pair;
+import com.powsybl.commons.PowsyblException;
+import org.apache.commons.lang3.tuple.Triple;
 import org.jgrapht.Graph;
 import org.jgrapht.alg.connectivity.ConnectivityInspector;
 import org.jgrapht.graph.Pseudograph;
@@ -18,11 +19,11 @@ import java.util.stream.Collectors;
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public class NaiveGraphDecrementalConnectivity<V> implements GraphDecrementalConnectivity<V> {
+public class NaiveGraphDecrementalConnectivity<V, E> implements GraphDecrementalConnectivity<V, E> {
 
-    private final Graph<V, Object> graph = new Pseudograph<>(Object.class);
+    private final Graph<V, E> graph = new Pseudograph<>(null, null, false);
 
-    private final List<Pair<V, V>> cutEdges = new ArrayList<>();
+    private final List<Triple<V, E, V>> cutEdges = new ArrayList<>();
 
     private int[] components;
 
@@ -63,28 +64,29 @@ public class NaiveGraphDecrementalConnectivity<V> implements GraphDecrementalCon
     }
 
     @Override
-    public void addEdge(V vertex1, V vertex2) {
-        if (vertex1 == null || vertex2 == null) {
-            return;
-        }
-        graph.addEdge(vertex1, vertex2, new Object());
+    public void addEdge(V vertex1, V vertex2, E edge) {
+        Objects.requireNonNull(vertex1);
+        Objects.requireNonNull(vertex2);
+        graph.addEdge(vertex1, vertex2, edge);
         invalidateComponents();
     }
 
     @Override
-    public void cut(V vertex1, V vertex2) {
-        if (vertex1 == null || vertex2 == null) {
-            return;
+    public void cut(E edge) {
+        if (!graph.containsEdge(edge)) {
+            throw new PowsyblException("No such edge in graph: " + edge);
         }
-        graph.removeEdge(vertex1, vertex2);
-        cutEdges.add(Pair.of(vertex1, vertex2));
+        V vertex1 = graph.getEdgeSource(edge);
+        V vertex2 = graph.getEdgeTarget(edge);
+        graph.removeEdge(edge);
+        cutEdges.add(Triple.of(vertex1, edge, vertex2));
         invalidateComponents();
     }
 
     @Override
     public void reset() {
-        for (Pair<V, V> cutEdge : cutEdges) {
-            graph.addEdge(cutEdge.getLeft(), cutEdge.getRight(), new Object());
+        for (Triple<V, E, V> cutEdge : cutEdges) {
+            graph.addEdge(cutEdge.getLeft(), cutEdge.getRight(), cutEdge.getMiddle());
         }
         cutEdges.clear();
         invalidateComponents();

--- a/src/main/java/com/powsybl/openloadflow/graph/NaiveGraphDecrementalConnectivity.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/NaiveGraphDecrementalConnectivity.java
@@ -73,6 +73,9 @@ public class NaiveGraphDecrementalConnectivity<V, E> implements GraphDecremental
 
     @Override
     public void cut(E edge) {
+        if (cutEdges.stream().anyMatch(t -> t.getMiddle().equals(edge))) {
+            throw new PowsyblException("Edge already cut: " + edge);
+        }
         if (!graph.containsEdge(edge)) {
             throw new PowsyblException("No such edge in graph: " + edge);
         }

--- a/src/main/java/com/powsybl/openloadflow/graph/NaiveGraphDecrementalConnectivityFactory.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/NaiveGraphDecrementalConnectivityFactory.java
@@ -12,7 +12,7 @@ import java.util.function.ToIntFunction;
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public class NaiveGraphDecrementalConnectivityFactory<V> implements GraphDecrementalConnectivityFactory<V> {
+public class NaiveGraphDecrementalConnectivityFactory<V, E> implements GraphDecrementalConnectivityFactory<V, E> {
 
     private final ToIntFunction<V> numGetter;
 
@@ -21,7 +21,7 @@ public class NaiveGraphDecrementalConnectivityFactory<V> implements GraphDecreme
     }
 
     @Override
-    public GraphDecrementalConnectivity<V> create() {
+    public GraphDecrementalConnectivity<V, E> create() {
         return new NaiveGraphDecrementalConnectivity<>(numGetter);
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -76,12 +76,12 @@ public class LfNetwork {
 
     private final Map<String, Object> userObjects = new HashMap<>();
 
-    private final GraphDecrementalConnectivityFactory<LfBus> connectivityFactory;
+    private final GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory;
 
-    private GraphDecrementalConnectivity<LfBus> connectivity;
+    private GraphDecrementalConnectivity<LfBus, LfBranch> connectivity;
 
     public LfNetwork(int numCC, int numSC, SlackBusSelector slackBusSelector,
-                     GraphDecrementalConnectivityFactory<LfBus> connectivityFactory) {
+                     GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory) {
         this.numCC = numCC;
         this.numSC = numSC;
         this.slackBusSelector = Objects.requireNonNull(slackBusSelector);
@@ -562,11 +562,13 @@ public class LfNetwork {
         return subGraph;
     }
 
-    public GraphDecrementalConnectivity<LfBus> getConnectivity() {
+    public GraphDecrementalConnectivity<LfBus, LfBranch> getConnectivity() {
         if (connectivity == null) {
             connectivity = Objects.requireNonNull(connectivityFactory.create());
             getBuses().forEach(connectivity::addVertex);
-            getBranches().forEach(b -> connectivity.addEdge(b.getBus1(), b.getBus2()));
+            getBranches().stream()
+                    .filter(b -> b.getBus1() != null && b.getBus2() != null)
+                    .forEach(b -> connectivity.addEdge(b.getBus1(), b.getBus2(), b));
         }
         return connectivity;
     }

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetworkParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetworkParameters.java
@@ -23,7 +23,7 @@ public class LfNetworkParameters {
 
     private SlackBusSelector slackBusSelector;
 
-    private final GraphDecrementalConnectivityFactory<LfBus> connectivityFactory;
+    private final GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory;
 
     private final boolean generatorVoltageRemoteControl;
 
@@ -67,13 +67,13 @@ public class LfNetworkParameters {
         this(slackBusSelector, new EvenShiloachGraphDecrementalConnectivityFactory<>());
     }
 
-    public LfNetworkParameters(SlackBusSelector slackBusSelector, GraphDecrementalConnectivityFactory<LfBus> connectivityFactory) {
+    public LfNetworkParameters(SlackBusSelector slackBusSelector, GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory) {
         this(slackBusSelector, connectivityFactory, false, false, false, false,
                 PLAUSIBLE_ACTIVE_POWER_LIMIT_DEFAULT_VALUE, false,
                 true, Collections.emptySet(), false, false, false, false, false, false, false, true, false);
     }
 
-    public LfNetworkParameters(SlackBusSelector slackBusSelector, GraphDecrementalConnectivityFactory<LfBus> connectivityFactory,
+    public LfNetworkParameters(SlackBusSelector slackBusSelector, GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory,
                                boolean generatorVoltageRemoteControl, boolean minImpedance, boolean twtSplitShuntAdmittance, boolean breakers,
                                double plausibleActivePowerLimit, boolean addRatioToLinesWithDifferentNominalVoltageAtBothEnds,
                                boolean computeMainConnectedComponentOnly, Set<Country> countriesToBalance, boolean distributedOnConformLoad,
@@ -108,7 +108,7 @@ public class LfNetworkParameters {
         this.slackBusSelector = Objects.requireNonNull(slackBusSelector);
     }
 
-    public GraphDecrementalConnectivityFactory<LfBus> getConnectivityFactory() {
+    public GraphDecrementalConnectivityFactory<LfBus, LfBranch> getConnectivityFactory() {
         return connectivityFactory;
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/PropagatedContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/PropagatedContingency.java
@@ -272,10 +272,10 @@ public class PropagatedContingency {
                 .collect(Collectors.toSet());
 
         // update connectivity with triggered branches
-        GraphDecrementalConnectivity<LfBus> connectivity = network.getConnectivity();
-        for (LfBranch branch : branches) {
-            connectivity.cut(branch.getBus1(), branch.getBus2());
-        }
+        GraphDecrementalConnectivity<LfBus, LfBranch> connectivity = network.getConnectivity();
+        branches.stream()
+                .filter(b -> b.getBus1() != null && b.getBus2() != null)
+                .forEach(connectivity::cut);
 
         // add to contingency description buses and branches that won't be part of the main connected
         // component in post contingency state

--- a/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
@@ -54,12 +54,12 @@ public abstract class AbstractSecurityAnalysis {
 
     protected final MatrixFactory matrixFactory;
 
-    protected final GraphDecrementalConnectivityFactory<LfBus> connectivityFactory;
+    protected final GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory;
 
     protected final StateMonitorIndex monitorIndex;
 
     protected AbstractSecurityAnalysis(Network network, LimitViolationDetector detector, LimitViolationFilter filter,
-                                MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus> connectivityFactory, List<StateMonitor> stateMonitors) {
+                                MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory, List<StateMonitor> stateMonitors) {
         this.network = Objects.requireNonNull(network);
         this.detector = Objects.requireNonNull(detector);
         this.filter = Objects.requireNonNull(filter);

--- a/src/main/java/com/powsybl/openloadflow/sa/AcSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AcSecurityAnalysis.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 public class AcSecurityAnalysis extends AbstractSecurityAnalysis {
 
     protected AcSecurityAnalysis(Network network, LimitViolationDetector detector, LimitViolationFilter filter,
-                                 MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus> connectivityFactory, List<StateMonitor> stateMonitors) {
+                                 MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory, List<StateMonitor> stateMonitors) {
         super(network, detector, filter, matrixFactory, connectivityFactory, stateMonitors);
     }
 

--- a/src/main/java/com/powsybl/openloadflow/sa/DcSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/DcSecurityAnalysis.java
@@ -13,6 +13,7 @@ import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.math.matrix.MatrixFactory;
 import com.powsybl.openloadflow.graph.GraphDecrementalConnectivityFactory;
+import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.sensi.OpenSensitivityAnalysisProvider;
 import com.powsybl.security.*;
@@ -29,7 +30,7 @@ import java.util.*;
 public class DcSecurityAnalysis extends AbstractSecurityAnalysis {
 
     protected DcSecurityAnalysis(final Network network, final LimitViolationDetector detector, final LimitViolationFilter filter,
-                                 final MatrixFactory matrixFactory, final GraphDecrementalConnectivityFactory<LfBus> connectivityFactory, List<StateMonitor> stateMonitors) {
+                                 final MatrixFactory matrixFactory, final GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory, List<StateMonitor> stateMonitors) {
         super(network, detector, filter, matrixFactory, connectivityFactory, stateMonitors);
     }
 

--- a/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProvider.java
@@ -14,6 +14,7 @@ import com.powsybl.math.matrix.MatrixFactory;
 import com.powsybl.math.matrix.SparseMatrixFactory;
 import com.powsybl.openloadflow.graph.EvenShiloachGraphDecrementalConnectivityFactory;
 import com.powsybl.openloadflow.graph.GraphDecrementalConnectivityFactory;
+import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.util.PowsyblOpenLoadFlowVersion;
 import com.powsybl.security.*;
@@ -32,9 +33,9 @@ public class OpenSecurityAnalysisProvider implements SecurityAnalysisProvider {
 
     private final MatrixFactory matrixFactory;
 
-    private final GraphDecrementalConnectivityFactory<LfBus> connectivityFactory;
+    private final GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory;
 
-    public OpenSecurityAnalysisProvider(MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus> connectivityFactory) {
+    public OpenSecurityAnalysisProvider(MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory) {
         this.matrixFactory = matrixFactory;
         this.connectivityFactory = connectivityFactory;
     }

--- a/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
@@ -52,9 +52,9 @@ public abstract class AbstractSensitivityAnalysis<V extends Enum<V> & Quantity, 
 
     protected final MatrixFactory matrixFactory;
 
-    protected final GraphDecrementalConnectivityFactory<LfBus> connectivityFactory;
+    protected final GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory;
 
-    protected AbstractSensitivityAnalysis(MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus> connectivityFactory) {
+    protected AbstractSensitivityAnalysis(MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory) {
         this.matrixFactory = Objects.requireNonNull(matrixFactory);
         this.connectivityFactory = Objects.requireNonNull(connectivityFactory);
     }
@@ -604,10 +604,11 @@ public abstract class AbstractSensitivityAnalysis<V extends Enum<V> & Quantity, 
         }
     }
 
-    public void cutConnectivity(LfNetwork lfNetwork, GraphDecrementalConnectivity<LfBus> connectivity, Collection<String> breakingConnectivityCandidates) {
+    public void cutConnectivity(LfNetwork lfNetwork, GraphDecrementalConnectivity<LfBus, LfBranch> connectivity, Collection<String> breakingConnectivityCandidates) {
         breakingConnectivityCandidates.stream()
             .map(lfNetwork::getBranchById)
-            .forEach(lfBranch -> connectivity.cut(lfBranch.getBus1(), lfBranch.getBus2()));
+            .filter(b -> b.getBus1() != null && b.getBus2() != null)
+            .forEach(connectivity::cut);
     }
 
     protected void setPredefinedResults(Collection<LfSensitivityFactor<V, E>> lfFactors, Set<LfBus> connectedComponent, Set<String> branchIdsToOpen) {

--- a/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
  */
 public class AcSensitivityAnalysis extends AbstractSensitivityAnalysis<AcVariableType, AcEquationType> {
 
-    public AcSensitivityAnalysis(MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus> connectivityFactory) {
+    public AcSensitivityAnalysis(MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory) {
         super(matrixFactory, connectivityFactory);
     }
 

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -166,7 +166,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
         }
     }
 
-    public DcSensitivityAnalysis(MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus> connectivityFactory) {
+    public DcSensitivityAnalysis(MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory) {
         super(matrixFactory, connectivityFactory);
     }
 
@@ -412,7 +412,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
         private final Set<LfBus> slackConnectedComponent;
 
         ConnectivityAnalysisResult(Collection<LfSensitivityFactor<DcVariableType, DcEquationType>> factors, Set<ComputedContingencyElement> elementsBreakingConnectivity,
-                                   GraphDecrementalConnectivity<LfBus> connectivity, LfNetwork lfNetwork) {
+                                   GraphDecrementalConnectivity<LfBus, LfBranch> connectivity, LfNetwork lfNetwork) {
             elementsToReconnect = computeElementsToReconnect(connectivity, elementsBreakingConnectivity);
             disabledBuses = connectivity.getNonConnectedVertices(lfNetwork.getSlackBus());
             slackConnectedComponent = new HashSet<>(lfNetwork.getBuses());
@@ -476,7 +476,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
             return slackConnectedComponent;
         }
 
-        private static Set<String> computeElementsToReconnect(GraphDecrementalConnectivity<LfBus> connectivity, Set<ComputedContingencyElement> breakingConnectivityCandidates) {
+        private static Set<String> computeElementsToReconnect(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity, Set<ComputedContingencyElement> breakingConnectivityCandidates) {
             Set<String> elementsToReconnect = new LinkedHashSet<>();
 
             Map<Pair<Integer, Integer>, ComputedContingencyElement> elementByConnectedComponents = new LinkedHashMap<>();
@@ -520,7 +520,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
             return connectivityAnalysisResults;
         }
 
-        GraphDecrementalConnectivity<LfBus> connectivity = lfNetwork.getConnectivity();
+        GraphDecrementalConnectivity<LfBus, LfBranch> connectivity = lfNetwork.getConnectivity();
         for (Map.Entry<Set<ComputedContingencyElement>, List<PropagatedContingency>> groupOfElementPotentiallyBreakingConnectivity : contingenciesByGroupOfElementsBreakingConnectivity.entrySet()) {
             Set<ComputedContingencyElement> breakingConnectivityCandidates = groupOfElementPotentiallyBreakingConnectivity.getKey();
             List<PropagatedContingency> contingencyList = groupOfElementPotentiallyBreakingConnectivity.getValue();

--- a/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProvider.java
@@ -28,6 +28,7 @@ import com.powsybl.math.matrix.SparseMatrixFactory;
 import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.graph.EvenShiloachGraphDecrementalConnectivityFactory;
 import com.powsybl.openloadflow.graph.GraphDecrementalConnectivityFactory;
+import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.network.impl.PropagatedContingency;
 import com.powsybl.sensitivity.*;
@@ -68,7 +69,7 @@ public class OpenSensitivityAnalysisProvider implements SensitivityAnalysisProvi
         this(matrixFactory, new EvenShiloachGraphDecrementalConnectivityFactory<>());
     }
 
-    public OpenSensitivityAnalysisProvider(MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus> connectivityFactory) {
+    public OpenSensitivityAnalysisProvider(MatrixFactory matrixFactory, GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory) {
         dcSensitivityAnalysis = new DcSensitivityAnalysis(matrixFactory, connectivityFactory);
         acSensitivityAnalysis = new AcSensitivityAnalysis(matrixFactory, connectivityFactory);
     }

--- a/src/test/java/com/powsybl/openloadflow/graph/BridgesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/graph/BridgesTest.java
@@ -115,7 +115,7 @@ class BridgesTest {
         assertEquals(bridgesSetReference, bridges);
     }
 
-    private Set<String> testBridgesOnConnectivity(LfNetwork lfNetwork, GraphDecrementalConnectivity<LfBus> connectivity, String method) {
+    private Set<String> testBridgesOnConnectivity(LfNetwork lfNetwork, GraphDecrementalConnectivity<LfBus, LfBranch> connectivity, String method) {
         long start = System.currentTimeMillis();
         initGraphDc(lfNetwork, connectivity);
         LOGGER.info("Graph init for {} in {} ms", method, System.currentTimeMillis() - start);
@@ -125,13 +125,13 @@ class BridgesTest {
         return bridgesSet;
     }
 
-    private static Set<String> getBridges(LfNetwork lfNetwork, GraphDecrementalConnectivity<LfBus> connectivity) {
+    private static Set<String> getBridges(LfNetwork lfNetwork, GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
         Set<String> bridgesSet = new HashSet<>();
         for (LfBranch branch : lfNetwork.getBranches()) {
             LfBus bus1 = branch.getBus1();
             LfBus bus2 = branch.getBus2();
             if (bus1 != null && bus2 != null) {
-                connectivity.cut(bus1, bus2);
+                connectivity.cut(branch);
                 boolean connected = connectivity.getComponentNumber(bus1) == connectivity.getComponentNumber(bus2);
                 if (!connected) {
                     bridgesSet.add(branch.getId());
@@ -157,7 +157,7 @@ class BridgesTest {
         return graph;
     }
 
-    private static void initGraphDc(LfNetwork lfNetwork, GraphDecrementalConnectivity<LfBus> connectivity) {
+    private static void initGraphDc(LfNetwork lfNetwork, GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
         for (LfBus bus : lfNetwork.getBuses()) {
             connectivity.addVertex(bus);
         }
@@ -165,7 +165,7 @@ class BridgesTest {
             LfBus bus1 = branch.getBus1();
             LfBus bus2 = branch.getBus2();
             if (bus1 != null && bus2 != null) {
-                connectivity.addEdge(bus1, bus2);
+                connectivity.addEdge(bus1, bus2, branch);
             }
         }
     }

--- a/src/test/java/com/powsybl/openloadflow/graph/ConnectivityTest.java
+++ b/src/test/java/com/powsybl/openloadflow/graph/ConnectivityTest.java
@@ -60,13 +60,13 @@ class ConnectivityTest {
     @Test
     void testNonConnected() {
         // Testing with a non-connected graph
-        GraphDecrementalConnectivity<LfBus> connectivity = new EvenShiloachGraphDecrementalConnectivity<>();
+        GraphDecrementalConnectivity<LfBus, LfBranch> connectivity = new EvenShiloachGraphDecrementalConnectivity<>();
         for (LfBus lfBus : lfNetwork.getBuses()) {
             connectivity.addVertex(lfBus);
         }
         for (LfBranch lfBranch : lfNetwork.getBranches()) {
             if (!lfBranch.getId().equals("l48")) {
-                connectivity.addEdge(lfBranch.getBus1(), lfBranch.getBus2());
+                connectivity.addEdge(lfBranch.getBus1(), lfBranch.getBus2(), lfBranch);
             }
         }
         PowsyblException e = assertThrows(PowsyblException.class, connectivity::getSmallComponents);
@@ -87,7 +87,7 @@ class ConnectivityTest {
         testConnectedComponents(new MinimumSpanningTreeGraphDecrementalConnectivity<>());
     }
 
-    private void testConnectivity(GraphDecrementalConnectivity<LfBus> connectivity) {
+    private void testConnectivity(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
         updateConnectivity(connectivity);
         cutBranches(connectivity, "l34", "l48");
 
@@ -100,7 +100,7 @@ class ConnectivityTest {
         assertEquals("given vertex null is not in the graph", e.getMessage());
     }
 
-    private void testReducedMainComponent(GraphDecrementalConnectivity<LfBus> connectivity) {
+    private void testReducedMainComponent(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
         updateConnectivity(connectivity);
         cutBranches(connectivity, "l34", "l48", "l56", "l57", "l67");
 
@@ -110,7 +110,7 @@ class ConnectivityTest {
         assertEquals(4, connectivity.getSmallComponents().size());
     }
 
-    private void testReaddEdge(GraphDecrementalConnectivity<LfBus> connectivity) {
+    private void testReaddEdge(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
         updateConnectivity(connectivity);
 
         String branchId = "l34";
@@ -121,7 +121,7 @@ class ConnectivityTest {
         assertEquals(1, connectivity.getComponentNumber(lfNetwork.getBusById("b1_vl_0")));
         assertEquals(0, connectivity.getComponentNumber(lfNetwork.getBusById("b8_vl_0")));
 
-        connectivity.addEdge(lfBranch.getBus1(), lfBranch.getBus2());
+        connectivity.addEdge(lfBranch.getBus1(), lfBranch.getBus2(), lfBranch);
         assertEquals(0, connectivity.getSmallComponents().size());
         assertEquals(0, connectivity.getComponentNumber(lfNetwork.getBusById("b1_vl_0")));
         assertEquals(0, connectivity.getComponentNumber(lfNetwork.getBusById("b8_vl_0")));
@@ -132,7 +132,7 @@ class ConnectivityTest {
         assertEquals(1, connectivity.getComponentNumber(lfNetwork.getBusById("b8_vl_0")));
     }
 
-    private void testNonConnectedComponents(GraphDecrementalConnectivity<LfBus> connectivity) {
+    private void testNonConnectedComponents(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
         updateConnectivity(connectivity);
         cutBranches(connectivity, "l34", "l48");
 
@@ -147,7 +147,7 @@ class ConnectivityTest {
         assertEquals("given vertex null is not in the graph", e.getMessage());
     }
 
-    private void testConnectedComponents(GraphDecrementalConnectivity<LfBus> connectivity) {
+    private void testConnectedComponents(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
         updateConnectivity(connectivity);
         cutBranches(connectivity, "l34", "l56", "l57");
 
@@ -162,16 +162,16 @@ class ConnectivityTest {
         assertEquals("given vertex null is not in the graph", e.getMessage());
     }
 
-    private void cutBranches(GraphDecrementalConnectivity<LfBus> connectivity, String... branches) {
-        Arrays.stream(branches).map(lfNetwork::getBranchById).forEach(lfBranch -> connectivity.cut(lfBranch.getBus2(), lfBranch.getBus1()));
+    private void cutBranches(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity, String... branches) {
+        Arrays.stream(branches).map(lfNetwork::getBranchById).forEach(connectivity::cut);
     }
 
-    private void updateConnectivity(GraphDecrementalConnectivity<LfBus> connectivity) {
+    private void updateConnectivity(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
         for (LfBus lfBus : lfNetwork.getBuses()) {
             connectivity.addVertex(lfBus);
         }
         for (LfBranch lfBranch : lfNetwork.getBranches()) {
-            connectivity.addEdge(lfBranch.getBus1(), lfBranch.getBus2());
+            connectivity.addEdge(lfBranch.getBus1(), lfBranch.getBus2(), lfBranch);
         }
     }
 

--- a/src/test/java/com/powsybl/openloadflow/graph/ConnectivityTest.java
+++ b/src/test/java/com/powsybl/openloadflow/graph/ConnectivityTest.java
@@ -58,6 +58,14 @@ class ConnectivityTest {
     }
 
     @Test
+    void testDoubleCut() {
+        // Testing cutting twice an edge
+        testDoubleCut(new NaiveGraphDecrementalConnectivity<>(LfBus::getNum), "No such edge in graph: l34");
+        testDoubleCut(new EvenShiloachGraphDecrementalConnectivity<>(), "Edge already cut: l34");
+        testDoubleCut(new MinimumSpanningTreeGraphDecrementalConnectivity<>(), "No such edge in graph: l34");
+    }
+
+    @Test
     void testNonConnected() {
         // Testing with a non-connected graph
         GraphDecrementalConnectivity<LfBus, LfBranch> connectivity = new EvenShiloachGraphDecrementalConnectivity<>();
@@ -130,6 +138,13 @@ class ConnectivityTest {
         assertEquals(1, connectivity.getSmallComponents().size());
         assertEquals(0, connectivity.getComponentNumber(lfNetwork.getBusById("b4_vl_0")));
         assertEquals(1, connectivity.getComponentNumber(lfNetwork.getBusById("b8_vl_0")));
+    }
+
+    private void testDoubleCut(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity, String expectedErrorMessage) {
+        updateConnectivity(connectivity);
+
+        PowsyblException e = assertThrows(PowsyblException.class, () -> cutBranches(connectivity, "l34", "l48", "l34"));
+        assertEquals(expectedErrorMessage, e.getMessage());
     }
 
     private void testNonConnectedComponents(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {

--- a/src/test/java/com/powsybl/openloadflow/sa/LfContingencyTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/LfContingencyTest.java
@@ -61,7 +61,7 @@ class LfContingencyTest extends AbstractConverterTest {
     void test() throws IOException {
         Network network = FourSubstationsNodeBreakerFactory.create();
 
-        GraphDecrementalConnectivityFactory<LfBus> connectivityFactory = new EvenShiloachGraphDecrementalConnectivityFactory<>();
+        GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory = new EvenShiloachGraphDecrementalConnectivityFactory<>();
 
         List<LfNetwork> lfNetworks = Networks.load(network, new LfNetworkParameters(new MostMeshedSlackBusSelector(), connectivityFactory));
         LfNetwork mainNetwork = lfNetworks.get(0);
@@ -97,7 +97,7 @@ class LfContingencyTest extends AbstractConverterTest {
         LfNetwork mainNetwork = lfNetworks.get(0);
         assertEquals(2, lfNetworks.size());
 
-        GraphDecrementalConnectivityFactory<LfBus> connectivityFactory = new EvenShiloachGraphDecrementalConnectivityFactory<>();
+        GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory = new EvenShiloachGraphDecrementalConnectivityFactory<>();
         new AcSecurityAnalysis(network, new DefaultLimitViolationDetector(),
                 new LimitViolationFilter(), new DenseMatrixFactory(), connectivityFactory, Collections.emptyList());
 
@@ -115,7 +115,7 @@ class LfContingencyTest extends AbstractConverterTest {
         LfNetwork mainNetwork = lfNetworks.get(0);
         assertEquals(2, lfNetworks.size());
 
-        GraphDecrementalConnectivityFactory<LfBus> connectivityFactory = new EvenShiloachGraphDecrementalConnectivityFactory<>();
+        GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory = new EvenShiloachGraphDecrementalConnectivityFactory<>();
         new AcSecurityAnalysis(network, new DefaultLimitViolationDetector(),
                 new LimitViolationFilter(), new DenseMatrixFactory(), connectivityFactory, Collections.emptyList());
 

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisGraphTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisGraphTest.java
@@ -136,7 +136,7 @@ class OpenSecurityAnalysisGraphTest {
         }
     }
 
-    List<List<LfContingency>> getLoadFlowContingencies(GraphDecrementalConnectivityFactory<LfBus> connectivityFactory) {
+    List<List<LfContingency>> getLoadFlowContingencies(GraphDecrementalConnectivityFactory<LfBus, LfBranch> connectivityFactory) {
 
         var matrixFactory = new DenseMatrixFactory();
         AcSecurityAnalysis securityAnalysis = new AcSecurityAnalysis(network, new DefaultLimitViolationDetector(),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?** 
The edges are not identified, therefore removing several times an edge by calling `connectivity.remove(vertex1, vertex2)` cannot be interpreted as either an error or a removal of two parallel edges.


**What is the new behavior (if this is a feature change)?**
The decremental connectivity takes an edge as argument when the edge is added and removal is done by giving the edge as argument.



**Does this PR introduce a breaking change or deprecate an API?**
No, internal API