### PR TITLE
[Transformer voltage control] Incremental transformer outerloop

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/DefaultOuterLoopConfig.java
+++ b/src/main/java/com/powsybl/openloadflow/DefaultOuterLoopConfig.java
@@ -37,6 +37,8 @@ public class DefaultOuterLoopConfig implements OuterLoopConfig {
                 outerLoops.add(new SimpleTransformerVoltageControlOuterLoop());
             } else if (parametersExt.getTransformerVoltageControlMode() == OpenLoadFlowParameters.TransformerVoltageControlMode.AFTER_GENERATOR_VOLTAGE_CONTROL) {
                 outerLoops.add(new TransformerVoltageControlOuterLoop());
+            } else if (parametersExt.getTransformerVoltageControlMode() == OpenLoadFlowParameters.TransformerVoltageControlMode.INCREMENTAL_VOLTAGE_CONTROL) {
+                outerLoops.add(new IncrementalTransformerVoltageControlOuterLoop());
             } else {
                 throw new IllegalStateException("Unknown transformer voltage control mode: " + parametersExt.getTransformerVoltageControlMode());
             }

--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
@@ -122,7 +122,8 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
 
     public enum TransformerVoltageControlMode {
         WITH_GENERATOR_VOLTAGE_CONTROL,
-        AFTER_GENERATOR_VOLTAGE_CONTROL
+        AFTER_GENERATOR_VOLTAGE_CONTROL,
+        INCREMENTAL_VOLTAGE_CONTROL
     }
 
     public static final TransformerVoltageControlMode TRANSFORMER_VOLTAGE_CONTROL_MODE_DEFAULT_VALUE = TransformerVoltageControlMode.WITH_GENERATOR_VOLTAGE_CONTROL;

--- a/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
@@ -29,10 +29,6 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
 
     public static final double EPS = Math.pow(10, -2);
 
-    public boolean hasIncreased = false;
-
-    public boolean hasDecreased = false;
-
     List<LfBranch> controllerBranches = new ArrayList<>();
 
     @Override
@@ -70,33 +66,8 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
                 double sensitivity = ((EquationTerm<AcVariableType, AcEquationType>) transformerVoltageControl.get().getControlled().getCalculatedV())
                         .calculateSensi(sensitivities, controllerBranches.indexOf(controllerBranch));
                 PiModel piModel = controllerBranch.getPiModel();
-                if (difference > 0) {
-                    // we need to increase the voltage at controlled bus.
-                    if (sensitivity > 0 && !this.hasDecreased) {
-                        success = piModel.updateTapPositionR(PiModel.Direction.INCREASE);
-                        if (success) {
-                            this.hasIncreased = true;
-                        }
-                    } else if (sensitivity < 0 && !this.hasIncreased) {
-                        success = piModel.updateTapPositionR(PiModel.Direction.DECREASE);
-                        if (success) {
-                            this.hasDecreased = true;
-                        }
-                    }
-                } else if (difference < 0) {
-                    // we need to decrease the voltage at controlled bus.
-                    if (sensitivity > 0 && !this.hasIncreased) {
-                        success = piModel.updateTapPositionR(PiModel.Direction.DECREASE);
-                        if (success) {
-                            this.hasDecreased = true;
-                        }
-                    } else if (sensitivity < 0 && !this.hasDecreased) {
-                        success = piModel.updateTapPositionR(PiModel.Direction.INCREASE);
-                        if (success) {
-                            this.hasIncreased = true;
-                        }
-                    }
-                }
+                double deltaR = difference / sensitivity;
+                success = piModel.updateTapPositionR(deltaR);
             }
         }
         return success ? OuterLoopStatus.UNSTABLE : OuterLoopStatus.STABLE;

--- a/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
@@ -68,30 +68,33 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
                     double difference = targetV - voltage;
                     List<LfBranch> controllers = voltageControl.getControllers();
                     if (controllers.size() == 1) {
-                        double sensitivity = ((EquationTerm<AcVariableType, AcEquationType>) bus.getCalculatedV())
-                                .calculateSensi(sensitivities, controllers.indexOf(controllers.get(0)));
-                        PiModel piModel = controllers.get(0).getPiModel();
-                        double deltaR = difference / sensitivity;
-                        Pair<Boolean, Double> result = piModel.updateTapPositionR(deltaR, MAX_INCREMENT);
-                        if (result.getLeft()) {
-                            status.set(OuterLoopStatus.UNSTABLE);
+                        if (difference > controllers.get(0).getTargetDeadBand().get()) {
+                            double sensitivity = ((EquationTerm<AcVariableType, AcEquationType>) bus.getCalculatedV())
+                                    .calculateSensi(sensitivities, controllers.indexOf(controllers.get(0)));
+                            PiModel piModel = controllers.get(0).getPiModel();
+                            double deltaR = difference / sensitivity;
+                            Pair<Boolean, Double> result = piModel.updateTapPositionR(deltaR, MAX_INCREMENT);
+                            if (result.getLeft()) {
+                                status.set(OuterLoopStatus.UNSTABLE);
+                            }
                         }
                     } else {
                         // several transformers control the same bus.
                         boolean hasChanged = true;
                         while (hasChanged) {
+                            hasChanged = false;
                             for (LfBranch controller : controllers) {
-                                double sensitivity = ((EquationTerm<AcVariableType, AcEquationType>) voltageControl.getControlled().getCalculatedV())
-                                        .calculateSensi(sensitivities, controllerBranches.indexOf(controller));
-                                PiModel piModel = controller.getPiModel();
-                                double deltaR = difference / sensitivity;
-                                Pair<Boolean, Double> result = piModel.updateTapPositionR(deltaR, 1);
-                                difference = difference - result.getRight() * sensitivity;
-                                if (result.getLeft()) {
-                                    hasChanged = true;
-                                    status.set(OuterLoopStatus.UNSTABLE);
-                                } else {
-                                    hasChanged = false;
+                                if (difference > controller.getTargetDeadBand().get()) {
+                                    double sensitivity = ((EquationTerm<AcVariableType, AcEquationType>) voltageControl.getControlled().getCalculatedV())
+                                            .calculateSensi(sensitivities, controllerBranches.indexOf(controller));
+                                    PiModel piModel = controller.getPiModel();
+                                    double deltaR = difference / sensitivity;
+                                    Pair<Boolean, Double> result = piModel.updateTapPositionR(deltaR, 1);
+                                    difference = difference - result.getRight() * sensitivity;
+                                    if (result.getLeft()) {
+                                        hasChanged = true;
+                                        status.set(OuterLoopStatus.UNSTABLE);
+                                    }
                                 }
                             }
                         }

--- a/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.ac;
+
+import com.powsybl.commons.reporter.Reporter;
+import com.powsybl.math.matrix.DenseMatrix;
+import com.powsybl.openloadflow.ac.equations.*;
+import com.powsybl.openloadflow.ac.outerloop.OuterLoopContext;
+import com.powsybl.openloadflow.ac.outerloop.OuterLoopStatus;
+import com.powsybl.openloadflow.equations.*;
+import com.powsybl.openloadflow.network.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ */
+public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTransformerVoltageControlOuterLoop {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IncrementalTransformerVoltageControlOuterLoop.class);
+
+    public static final double EPS = Math.pow(10, -2);
+
+    List<LfBranch> controllerBranches = new ArrayList<>();
+
+    @Override
+    public String getType() {
+        return "Incremental transformer voltage control";
+    }
+
+    @Override
+    public void initialize(LfNetwork network) {
+        // All transformer voltage control are disabled for the first equation system resolution.
+        for (LfBranch branch : network.getBranches()) {
+            branch.getVoltageControl().ifPresent(voltageControl -> {
+                branch.setVoltageControlEnabled(false);
+                controllerBranches.add(branch);
+            });
+        }
+    }
+
+    @Override
+    public OuterLoopStatus check(OuterLoopContext context, Reporter reporter) {
+        OuterLoopStatus status =  changeTapPositions(controllerBranches, context.getAcLoadFlowContext().getEquationSystem(), context.getAcLoadFlowContext().getJacobianMatrix());
+        return status;
+    }
+
+    private OuterLoopStatus changeTapPositions(List<LfBranch> controllerBranches, EquationSystem<AcVariableType, AcEquationType> equationSystem,
+                                               JacobianMatrix<AcVariableType, AcEquationType> j) {
+        DenseMatrix sensitivities = getSensitivityValues(controllerBranches, equationSystem, j);
+        sensitivities.print(System.out);
+        boolean success = false;
+        for (LfBranch controllerBranch : controllerBranches) {
+            Optional<TransformerVoltageControl> transformerVoltageControl = controllerBranch.getVoltageControl();
+            if (transformerVoltageControl.isPresent()) {
+                double targetV = transformerVoltageControl.get().getTargetValue();
+                double voltage = transformerVoltageControl.get().getControlled().getV();
+                double difference = targetV - voltage;
+                double sensitivity = ((EquationTerm<AcVariableType, AcEquationType>) transformerVoltageControl.get().getControlled().getCalculatedV())
+                        .calculateSensi(sensitivities, controllerBranches.indexOf(controllerBranch));
+                System.out.println(sensitivity);
+                PiModel piModel = controllerBranch.getPiModel();
+                if (difference > 0) {
+                    // we need to increase the voltage at controlled bus.
+                    success = sensitivity > 0 ? piModel.updateTapPosition(PiModel.Direction.INCREASE) : piModel.updateTapPosition(PiModel.Direction.DECREASE);
+                } else if (difference < 0) {
+                    // we need to decrease the voltage at controlled bus.
+                    success = sensitivity > 0 ? piModel.updateTapPosition(PiModel.Direction.DECREASE) : piModel.updateTapPosition(PiModel.Direction.INCREASE);
+                }
+            }
+        }
+        return success ? OuterLoopStatus.UNSTABLE : OuterLoopStatus.STABLE;
+    }
+
+    DenseMatrix getSensitivityValues(List<LfBranch> controllerBranches, EquationSystem<AcVariableType, AcEquationType> equationSystem,
+                                  JacobianMatrix<AcVariableType, AcEquationType> j) {
+        DenseMatrix rhs = new DenseMatrix(equationSystem.getSortedEquationsToSolve().size(), controllerBranches.size());
+        for (LfBranch branch : controllerBranches) {
+            Variable var = equationSystem.getVariable(branch.getNum(), AcVariableType.BRANCH_RHO1);
+            for (Equation<AcVariableType, AcEquationType> equation : equationSystem.getSortedEquationsToSolve().keySet()) {
+                equation.getTerms().stream().filter(term -> term.getVariables().stream().filter(v -> v.equals(var)).findAny().isPresent()).forEach(t -> {
+                    rhs.set(equation.getColumn(), controllerBranches.indexOf(branch), t.der(var));
+                });
+            }
+        }
+        j.solveTransposed(rhs);
+        return rhs;
+    }
+}

--- a/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
@@ -48,8 +48,7 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
 
     @Override
     public OuterLoopStatus check(OuterLoopContext context, Reporter reporter) {
-        OuterLoopStatus status =  changeTapPositions(context.getNetwork(), context.getAcLoadFlowContext().getEquationSystem(), context.getAcLoadFlowContext().getJacobianMatrix());
-        return status;
+        return changeTapPositions(context.getNetwork(), context.getAcLoadFlowContext().getEquationSystem(), context.getAcLoadFlowContext().getJacobianMatrix());
     }
 
     private OuterLoopStatus changeTapPositions(LfNetwork network, EquationSystem<AcVariableType, AcEquationType> equationSystem,
@@ -59,39 +58,37 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
         DenseMatrix sensitivities = getSensitivityValues(controllerBranches, equationSystem, j);
 
         for (LfBus bus : network.getBuses()) {
-            if (bus.isTransformerVoltageControlled()) {
-                if (bus.getTransformerVoltageControl().isPresent()) {
-                    TransformerVoltageControl voltageControl = bus.getTransformerVoltageControl().get();
-                    double targetV = voltageControl.getTargetValue();
-                    double voltage = voltageControl.getControlled().getV();
-                    double difference = targetV - voltage;
-                    List<LfBranch> controllers = voltageControl.getControllers();
-                    if (controllers.size() == 1) {
-                        double sensitivity = ((EquationTerm<AcVariableType, AcEquationType>) bus.getCalculatedV())
-                                .calculateSensi(sensitivities, controllers.indexOf(controllers.get(0)));
-                        PiModel piModel = controllers.get(0).getPiModel();
-                        double deltaR = difference / sensitivity;
-                        Pair<Boolean, Double> result = piModel.updateTapPositionR(deltaR, MAX_INCREMENT);
-                        if (result.getLeft()) {
-                            status = OuterLoopStatus.UNSTABLE;
-                        }
-                    } else {
-                        // several transformers control the same bus.
-                        boolean hasChanged = true;
-                        while (hasChanged) {
-                            for (LfBranch controller : controllers) {
-                                double sensitivity = ((EquationTerm<AcVariableType, AcEquationType>) voltageControl.getControlled().getCalculatedV())
-                                        .calculateSensi(sensitivities, controllerBranches.indexOf(controller));
-                                PiModel piModel = controller.getPiModel();
-                                double deltaR = difference / sensitivity;
-                                Pair<Boolean, Double> result = piModel.updateTapPositionR(deltaR, 1);
-                                difference = difference - result.getRight() * sensitivity;
-                                if (result.getLeft()) {
-                                    hasChanged = true;
-                                    status = OuterLoopStatus.UNSTABLE;
-                                } else {
-                                    hasChanged = false;
-                                }
+            if (bus.isTransformerVoltageControlled() && bus.getTransformerVoltageControl().isPresent()) {
+                TransformerVoltageControl voltageControl = bus.getTransformerVoltageControl().get();
+                double targetV = voltageControl.getTargetValue();
+                double voltage = voltageControl.getControlled().getV();
+                double difference = targetV - voltage;
+                List<LfBranch> controllers = voltageControl.getControllers();
+                if (controllers.size() == 1) {
+                    double sensitivity = ((EquationTerm<AcVariableType, AcEquationType>) bus.getCalculatedV())
+                            .calculateSensi(sensitivities, controllers.indexOf(controllers.get(0)));
+                    PiModel piModel = controllers.get(0).getPiModel();
+                    double deltaR = difference / sensitivity;
+                    Pair<Boolean, Double> result = piModel.updateTapPositionR(deltaR, MAX_INCREMENT);
+                    if (result.getLeft()) {
+                        status = OuterLoopStatus.UNSTABLE;
+                    }
+                } else {
+                    // several transformers control the same bus.
+                    boolean hasChanged = true;
+                    while (hasChanged) {
+                        for (LfBranch controller : controllers) {
+                            double sensitivity = ((EquationTerm<AcVariableType, AcEquationType>) voltageControl.getControlled().getCalculatedV())
+                                    .calculateSensi(sensitivities, controllerBranches.indexOf(controller));
+                            PiModel piModel = controller.getPiModel();
+                            double deltaR = difference / sensitivity;
+                            Pair<Boolean, Double> result = piModel.updateTapPositionR(deltaR, 1);
+                            difference = difference - result.getRight() * sensitivity;
+                            if (result.getLeft()) {
+                                hasChanged = true;
+                                status = OuterLoopStatus.UNSTABLE;
+                            } else {
+                                hasChanged = false;
                             }
                         }
                     }
@@ -108,7 +105,7 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
         for (LfBranch branch : controllerBranches) {
             Variable var = equationSystem.getVariable(branch.getNum(), AcVariableType.BRANCH_RHO1);
             for (Equation<AcVariableType, AcEquationType> equation : equationSystem.getSortedEquationsToSolve().keySet()) {
-                equation.getTerms().stream().filter(term -> term.getVariables().stream().filter(v -> v.equals(var)).findAny().isPresent()).forEach(t -> {
+                equation.getTerms().stream().filter(term -> term.getVariables().stream().anyMatch(v -> v.equals(var))).forEach(t -> {
                     if (equation.getType().equals(AcEquationType.BRANCH_TARGET_RHO1)) {
                         rhs.set(equation.getColumn(), controllerBranches.indexOf(branch), t.der(var));
                     }

--- a/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
@@ -34,7 +34,7 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IncrementalTransformerVoltageControlOuterLoop.class);
 
-    private static final int MAX_TAP_SHIFT = 5;
+    private static final int MAX_TAP_SHIFT = 3;
     private static final int MAX_DIRECTION_CHANGE = 2;
 
     private static final class ControllerContext {

--- a/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
@@ -108,12 +108,12 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
                                     piModelAndTapPositionDirection.get(controller.getId()));
                             piModelAndTapPositionDirection.put(controller.getId(), getDirection(previousR1,
                                     controller.getPiModel().getR1(), piModelAndTapPositionDirection.get(controller.getId())));
-                            LOGGER.error("Round voltage ratio of '{}': {} -> {}", controller.getId(), previousR1, controller.getPiModel().getR1());
+                            LOGGER.info("Round voltage ratio of '{}': {} -> {}", controller.getId(), previousR1, controller.getPiModel().getR1());
                             if (hasChanged) {
                                 status.setValue(OuterLoopStatus.UNSTABLE);
                             }
                         } else {
-                            LOGGER.error("Controller branch '{}' is in its deadband: deadband {} vs voltage difference {}", controller.getId(), targetDeadband, Math.abs(difference));
+                            LOGGER.info("Controller branch '{}' is in its deadband: deadband {} vs voltage difference {}", controller.getId(), targetDeadband, Math.abs(difference));
                         }
                     } else {
                         // several transformers control the same bus.
@@ -132,12 +132,12 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
                                     piModelAndTapPositionDirection.put(controller.getId(), getDirection(previousR1,
                                             controller.getPiModel().getR1(), piModelAndTapPositionDirection.get(controller.getId())));
                                     difference -= (controller.getPiModel().getR1() - previousR1) * sensitivity;
-                                    LOGGER.error("[Shared control] round voltage ratio of '{}': {} -> {}", controller.getId(), previousR1, controller.getPiModel().getR1());
+                                    LOGGER.info("[Shared control] round voltage ratio of '{}': {} -> {}", controller.getId(), previousR1, controller.getPiModel().getR1());
                                     if (hasChanged) {
                                         status.setValue(OuterLoopStatus.UNSTABLE);
                                     }
                                 } else {
-                                    LOGGER.error("Controller branch '{}' is in its deadband: deadband {} vs voltage difference {}", controller.getId(), targetDeadband, Math.abs(difference));
+                                    LOGGER.info("Controller branch '{}' is in its deadband: deadband {} vs voltage difference {}", controller.getId(), targetDeadband, Math.abs(difference));
                                 }
                             }
                         }

--- a/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
@@ -104,8 +104,8 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
                     haschanged = false;
                     for (LfBranch lfBranch : controllerBrchs) {
                         double sensitivity = ((EquationTerm<AcVariableType, AcEquationType>) transformerVoltageControl.get().getControlled().getCalculatedV())
-                                .calculateSensi(sensitivities, controllerBranches.indexOf(controllerBranch0));
-                        PiModel piModel = controllerBranch0.getPiModel();
+                                .calculateSensi(sensitivities, controllerBranches.indexOf(lfBranch));
+                        PiModel piModel = lfBranch.getPiModel();
                         double deltaR = difference / sensitivity;
                         Pair<Boolean, Double> result = piModel.updateTapPositionR(deltaR, 1);
                         difference = difference - result.getRight() * sensitivity;

--- a/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
@@ -70,10 +70,10 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
                 PiModel piModel = controllerBranch.getPiModel();
                 if (difference > 0) {
                     // we need to increase the voltage at controlled bus.
-                    success = sensitivity > 0 ? piModel.updateTapPosition(PiModel.Direction.INCREASE) : piModel.updateTapPosition(PiModel.Direction.DECREASE);
+                    success = sensitivity > 0 ? piModel.increaseTapPosition() : piModel.decreaseTapPosition();
                 } else if (difference < 0) {
                     // we need to decrease the voltage at controlled bus.
-                    success = sensitivity > 0 ? piModel.updateTapPosition(PiModel.Direction.DECREASE) : piModel.updateTapPosition(PiModel.Direction.INCREASE);
+                    success = sensitivity > 0 ? piModel.decreaseTapPosition() : piModel.increaseTapPosition();
                 }
             }
         }
@@ -87,7 +87,9 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
             Variable var = equationSystem.getVariable(branch.getNum(), AcVariableType.BRANCH_RHO1);
             for (Equation<AcVariableType, AcEquationType> equation : equationSystem.getSortedEquationsToSolve().keySet()) {
                 equation.getTerms().stream().filter(term -> term.getVariables().stream().filter(v -> v.equals(var)).findAny().isPresent()).forEach(t -> {
-                    rhs.set(equation.getColumn(), controllerBranches.indexOf(branch), t.der(var));
+                    if (equation.getType().equals(AcEquationType.BRANCH_TARGET_RHO1)) {
+                        rhs.set(equation.getColumn(), controllerBranches.indexOf(branch), t.der(var));
+                    }
                 });
             }
         }

--- a/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
@@ -35,7 +35,7 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
     private static final Logger LOGGER = LoggerFactory.getLogger(IncrementalTransformerVoltageControlOuterLoop.class);
 
     private static final int MAX_TAP_SHIFT = 5;
-    private static final int MAX_DIRECTION_CHANGE = 1;
+    private static final int MAX_DIRECTION_CHANGE = 2;
 
     private static final class ControllerContext {
 
@@ -83,10 +83,15 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
     }
 
     private static void updateAllowedDirection(ControllerContext controllerContext, PiModel.Direction direction) {
-        if (controllerContext.getDirectionChangeCount().getValue() >= MAX_DIRECTION_CHANGE) {
+        if (controllerContext.getDirectionChangeCount().getValue() <= MAX_DIRECTION_CHANGE) {
+            if (!controllerContext.getAllowedDirection().equals(direction.getAllowedDirection())) {
+                // both vs increase or decrease
+                // increase vs decrease
+                // decrease vs increase
+                controllerContext.getDirectionChangeCount().increment();
+            }
             controllerContext.setAllowedDirection(direction.getAllowedDirection());
         }
-        controllerContext.getDirectionChangeCount().increment();
     }
 
     private void adjustWithOneController(LfBranch controllerBranch, LfBus controlledBus, ContextData contextData, int[] controllerBranchIndex,

--- a/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
@@ -18,11 +18,12 @@ import com.powsybl.openloadflow.equations.JacobianMatrix;
 import com.powsybl.openloadflow.equations.Variable;
 import com.powsybl.openloadflow.network.*;
 import org.apache.commons.lang3.mutable.MutableObject;
-import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Anne Tilloy <anne.tilloy at rte-france.com>
@@ -31,7 +32,24 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IncrementalTransformerVoltageControlOuterLoop.class);
 
-    private static final int MAX_INCREMENT = 100;
+    private static final class ContextData {
+
+        private static final int MAX_TAP_INCREMENT = 5;
+
+        private Map<String, PiModel.Direction> piModelAndTapPositionDirection = new LinkedHashMap<>();
+
+        public int getMaxIncrement() {
+            return MAX_TAP_INCREMENT;
+        }
+
+        public Map<String, PiModel.Direction> getPiModelAndTapPositionDirection() {
+            return piModelAndTapPositionDirection;
+        }
+
+        public void setPiModelAndTapPositionDirection(Map<String, PiModel.Direction> piModelAndTapPositionDirection) {
+            this.piModelAndTapPositionDirection = piModelAndTapPositionDirection;
+        }
+    }
 
     @Override
     public String getType() {
@@ -40,10 +58,15 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
 
     @Override
     public void initialize(OuterLoopContext context) {
+        context.setData(new ContextData());
+
+        Map<String, PiModel.Direction> piModelAndTapPositionDirection = new LinkedHashMap<>();
         // All transformer voltage control are disabled for the first equation system resolution.
         for (LfBranch branch : getControllerBranches(context.getNetwork())) {
             branch.getVoltageControl().ifPresent(voltageControl -> branch.setVoltageControlEnabled(false));
+            piModelAndTapPositionDirection.put(branch.getId(), PiModel.Direction.NONE);
         }
+        ((ContextData) context.getData()).setPiModelAndTapPositionDirection(piModelAndTapPositionDirection);
     }
 
     @Override
@@ -62,6 +85,8 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
                                                                context.getAcLoadFlowContext().getEquationSystem(),
                                                                context.getAcLoadFlowContext().getJacobianMatrix());
 
+        Map<String, PiModel.Direction> piModelAndTapPositionDirection = ((ContextData) context.getData()).getPiModelAndTapPositionDirection();
+
         network.getBuses().stream()
                 .filter(LfBus::isTransformerVoltageControlled)
                 .forEach(bus -> {
@@ -74,14 +99,21 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
                         // only one transformer controls a bus
                         LfBranch controller = controllers.get(0);
                         Double targetDeadband = controller.getTransformerVoltageControlTargetDeadband().orElse(null);
-                        if (targetDeadband != null && difference > targetDeadband) {
+                        if (targetDeadband != null && Math.abs(difference) > targetDeadband / 2) {
                             double sensitivity = ((EquationTerm<AcVariableType, AcEquationType>) bus.getCalculatedV())
                                     .calculateSensi(sensitivities, controllerBranchIndex[controller.getNum()]);
-                            double deltaR = difference / sensitivity;
-                            Pair<Boolean, Double> result = controller.getPiModel().updateTapPositionR(deltaR, MAX_INCREMENT);
-                            if (result.getLeft()) {
+                            double previousR1 = controller.getPiModel().getR1();
+                            double deltaR1 = difference / sensitivity;
+                            boolean hasChanged = controller.getPiModel().updateTapPositionR1(deltaR1, ((ContextData) context.getData()).getMaxIncrement(),
+                                    piModelAndTapPositionDirection.get(controller.getId()));
+                            piModelAndTapPositionDirection.put(controller.getId(), getDirection(previousR1,
+                                    controller.getPiModel().getR1(), piModelAndTapPositionDirection.get(controller.getId())));
+                            LOGGER.error("Round voltage ratio of '{}': {} -> {}", controller.getId(), previousR1, controller.getPiModel().getR1());
+                            if (hasChanged) {
                                 status.setValue(OuterLoopStatus.UNSTABLE);
                             }
+                        } else {
+                            LOGGER.error("Controller branch '{}' is in its deadband: deadband {} vs voltage difference {}", controller.getId(), targetDeadband, Math.abs(difference));
                         }
                     } else {
                         // several transformers control the same bus.
@@ -90,22 +122,28 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
                             hasChanged = false;
                             for (LfBranch controller : controllers) {
                                 Double targetDeadband = controller.getTransformerVoltageControlTargetDeadband().orElse(null);
-                                if (targetDeadband != null && difference > targetDeadband) {
+                                if (targetDeadband != null && Math.abs(difference) > targetDeadband / 2) {
                                     double sensitivity = ((EquationTerm<AcVariableType, AcEquationType>) bus.getCalculatedV())
                                             .calculateSensi(sensitivities, controllerBranchIndex[controller.getNum()]);
-                                    double deltaR = difference / sensitivity;
-                                    Pair<Boolean, Double> result = controller.getPiModel().updateTapPositionR(deltaR, 1);
-                                    difference -= result.getRight() * sensitivity;
-                                    if (result.getLeft()) {
-                                        hasChanged = true;
+                                    double previousR1 = controller.getPiModel().getR1();
+                                    double deltaR1 = difference / sensitivity;
+                                    hasChanged = controller.getPiModel().updateTapPositionR1(deltaR1, 1,
+                                            piModelAndTapPositionDirection.get(controller.getId()));
+                                    piModelAndTapPositionDirection.put(controller.getId(), getDirection(previousR1,
+                                            controller.getPiModel().getR1(), piModelAndTapPositionDirection.get(controller.getId())));
+                                    difference -= (controller.getPiModel().getR1() - previousR1) * sensitivity;
+                                    LOGGER.error("[Shared control] round voltage ratio of '{}': {} -> {}", controller.getId(), previousR1, controller.getPiModel().getR1());
+                                    if (hasChanged) {
                                         status.setValue(OuterLoopStatus.UNSTABLE);
                                     }
+                                } else {
+                                    LOGGER.error("Controller branch '{}' is in its deadband: deadband {} vs voltage difference {}", controller.getId(), targetDeadband, Math.abs(difference));
                                 }
                             }
                         }
                     }
                 });
-
+        ((ContextData) context.getData()).setPiModelAndTapPositionDirection(piModelAndTapPositionDirection);
         return status.getValue();
     }
 
@@ -122,5 +160,37 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
         }
         j.solveTransposed(rhs);
         return rhs;
+    }
+
+    private PiModel.Direction getDirection(double previousR1, double r1, PiModel.Direction previousDirection) {
+        if (previousDirection == PiModel.Direction.INCREASE_THEN_DECREASE || previousDirection == PiModel.Direction.DECREASE_THEN_INCREASE) {
+            return previousDirection;
+        }
+        if (r1 > previousR1) {
+            // increasing.
+            switch (previousDirection) {
+                case NONE:
+                case INCREASE:
+                    return PiModel.Direction.INCREASE;
+                case DECREASE:
+                case DECREASE_THEN_INCREASE:
+                    return PiModel.Direction.DECREASE_THEN_INCREASE;
+                case INCREASE_THEN_DECREASE:
+                    LOGGER.error("We want to increase R1 of a PiModel that has already increased then decreased. It should never happen.");
+            }
+        } else if (r1 < previousR1) {
+            // decreasing.
+            switch (previousDirection) {
+                case NONE:
+                case DECREASE:
+                    return PiModel.Direction.DECREASE;
+                case INCREASE:
+                case INCREASE_THEN_DECREASE:
+                    return PiModel.Direction.INCREASE_THEN_DECREASE;
+                case DECREASE_THEN_INCREASE:
+                    LOGGER.error("We want to decrease R1 of a PiModel that has already decreased then increased. It should never happen.");
+            }
+        }
+        return PiModel.Direction.NONE;
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
@@ -33,7 +33,7 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IncrementalTransformerVoltageControlOuterLoop.class);
 
-    private static final int MAX_TAP_INCREMENT = 5;
+    private static final int MAX_TAP_SHIFT = 5;
 
     private static final class ControllerContext {
 
@@ -110,7 +110,7 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
                                     .calculateSensi(sensitivities, controllerBranchIndex[controller.getNum()]);
                             double previousR1 = controller.getPiModel().getR1();
                             double deltaR1 = difference / sensitivity;
-                            controller.getPiModel().updateTapPositionR1(deltaR1, MAX_TAP_INCREMENT, controllerContext.getAllowedDirection()).ifPresent(direction -> {
+                            controller.getPiModel().updateTapPositionR1(deltaR1, MAX_TAP_SHIFT, controllerContext.getAllowedDirection()).ifPresent(direction -> {
                                 controllerContext.setAllowedDirection(direction.getAllowedDirection());
                                 LOGGER.info("Round voltage ratio of '{}': {} -> {}", controller.getId(), previousR1, controller.getPiModel().getR1());
                                 status.setValue(OuterLoopStatus.UNSTABLE);

--- a/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
@@ -108,10 +108,10 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
 
     DenseMatrix getSensitivityValues(List<LfBranch> controllerBranches, EquationSystem<AcVariableType, AcEquationType> equationSystem,
                                   JacobianMatrix<AcVariableType, AcEquationType> j) {
-        DenseMatrix rhs = new DenseMatrix(equationSystem.getSortedEquationsToSolve().size(), controllerBranches.size());
+        DenseMatrix rhs = new DenseMatrix(equationSystem.getIndex().getSortedEquationsToSolve().size(), controllerBranches.size());
         for (LfBranch branch : controllerBranches) {
             Variable var = equationSystem.getVariable(branch.getNum(), AcVariableType.BRANCH_RHO1);
-            for (Equation<AcVariableType, AcEquationType> equation : equationSystem.getSortedEquationsToSolve().keySet()) {
+            for (Equation<AcVariableType, AcEquationType> equation : equationSystem.getIndex().getSortedEquationsToSolve()) {
                 equation.getTerms().stream().filter(term -> term.getVariables().stream().anyMatch(v -> v.equals(var))).forEach(t -> {
                     if (equation.getType().equals(AcEquationType.BRANCH_TARGET_RHO1)) {
                         rhs.set(equation.getColumn(), controllerBranches.indexOf(branch), t.der(var));

--- a/src/main/java/com/powsybl/openloadflow/ac/PhaseControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/PhaseControlOuterLoop.java
@@ -139,10 +139,10 @@ public class PhaseControlOuterLoop implements OuterLoop {
         PiModel piModel = controllerBranch.getPiModel();
         if (phaseControl.getControlledSide() == DiscretePhaseControl.ControlledSide.ONE && currentLimit < controllerBranch.getI1().eval()) {
             boolean isSensibilityPositive = isSensitivityCurrentPerA1Positive(controllerBranch, DiscretePhaseControl.ControlledSide.ONE);
-            return isSensibilityPositive ? piModel.updateTapPosition(PiModel.Direction.DECREASE) : piModel.updateTapPosition(PiModel.Direction.INCREASE);
+            return isSensibilityPositive ? piModel.updateTapPositionA1(PiModel.Direction.DECREASE) : piModel.updateTapPositionA1(PiModel.Direction.INCREASE);
         } else if (phaseControl.getControlledSide() == DiscretePhaseControl.ControlledSide.TWO && currentLimit < controllerBranch.getI2().eval()) {
             boolean isSensibilityPositive = isSensitivityCurrentPerA1Positive(controllerBranch, DiscretePhaseControl.ControlledSide.TWO);
-            return isSensibilityPositive ? piModel.updateTapPosition(PiModel.Direction.DECREASE) : piModel.updateTapPosition(PiModel.Direction.INCREASE);
+            return isSensibilityPositive ? piModel.updateTapPositionA1(PiModel.Direction.DECREASE) : piModel.updateTapPositionA1(PiModel.Direction.INCREASE);
         }
         return false;
     }

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcloadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcloadFlowEngine.java
@@ -62,6 +62,7 @@ public class AcloadFlowEngine {
             // check outer loop status
             outerLoopContext.setIteration(outerLoopIteration.getValue());
             outerLoopContext.setLastNewtonRaphsonResult(runningContext.lastNrResult);
+            outerLoopContext.setAcLoadFlowContext(context);
             outerLoopStatus = outerLoop.check(outerLoopContext, olReporter);
 
             if (outerLoopStatus == OuterLoopStatus.UNSTABLE) {

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/OuterLoopContext.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/OuterLoopContext.java
@@ -23,4 +23,8 @@ public interface OuterLoopContext {
     Object getData();
 
     void setData(Object data);
+
+    AcLoadFlowContext getAcLoadFlowContext();
+
+    void setAcLoadFlowContext(AcLoadFlowContext acLoadFlowContext);
 }

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/OuterLoopContextImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/OuterLoopContextImpl.java
@@ -24,6 +24,8 @@ public class OuterLoopContextImpl implements OuterLoopContext {
 
     private Object data;
 
+    private AcLoadFlowContext acLoadFlowContext;
+
     OuterLoopContextImpl(LfNetwork network) {
         this.network = Objects.requireNonNull(network);
     }
@@ -59,5 +61,15 @@ public class OuterLoopContextImpl implements OuterLoopContext {
     @Override
     public void setData(Object data) {
         this.data = data;
+    }
+
+    @Override
+    public AcLoadFlowContext getAcLoadFlowContext() {
+        return acLoadFlowContext;
+    }
+
+    @Override
+    public void setAcLoadFlowContext(AcLoadFlowContext acLoadFlowContext) {
+        this.acLoadFlowContext = acLoadFlowContext;
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/equations/TargetVector.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/TargetVector.java
@@ -49,7 +49,12 @@ public class TargetVector<V extends Enum<V> & Quantity, E extends Enum<E> & Quan
         }
 
         @Override
-        public void onDiscretePhaseControlTapPositionChange(LfBranch controllerBranch, int oldPosition, int newPosition) {
+        public void onTransformerPhaseControlTapPositionChange(LfBranch controllerBranch, int oldPosition, int newPosition) {
+            invalidateValues();
+        }
+
+        @Override
+        public void onTransformerVoltageControlTapPositionChange(LfBranch controllerBranch, int oldPosition, int newPosition) {
             invalidateValues();
         }
     };

--- a/src/main/java/com/powsybl/openloadflow/network/AbstractLfNetworkListener.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractLfNetworkListener.java
@@ -52,7 +52,12 @@ public abstract class AbstractLfNetworkListener implements LfNetworkListener {
     }
 
     @Override
-    public void onDiscretePhaseControlTapPositionChange(LfBranch controllerBranch, int oldPosition, int newPosition) {
+    public void onTransformerPhaseControlTapPositionChange(LfBranch controllerBranch, int oldPosition, int newPosition) {
+        // empty
+    }
+
+    @Override
+    public void onTransformerVoltageControlTapPositionChange(LfBranch controllerBranch, int oldPosition, int newPosition) {
         // empty
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
@@ -121,7 +121,7 @@ public interface LfBranch extends LfElement {
 
     Optional<TransformerVoltageControl> getVoltageControl();
 
-    Optional<Double> getTargetDeadBand();
+    Optional<Double> getTransformerVoltageControlTargetDeadband();
 
     boolean isVoltageControlEnabled();
 
@@ -131,7 +131,7 @@ public interface LfBranch extends LfElement {
 
     void setVoltageControl(TransformerVoltageControl transformerVoltageControl);
 
-    void setDeadBand(double deadbandValue);
+    void setTransformerVoltageControlTargetDeadband(double transformerVoltageControlTargetDeadband);
 
     BranchResult createBranchResult(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension);
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
@@ -121,6 +121,8 @@ public interface LfBranch extends LfElement {
 
     Optional<TransformerVoltageControl> getVoltageControl();
 
+    Optional<Double> getTargetDeadBand();
+
     boolean isVoltageControlEnabled();
 
     void setVoltageControlEnabled(boolean voltageControlEnabled);
@@ -128,6 +130,8 @@ public interface LfBranch extends LfElement {
     boolean isVoltageController();
 
     void setVoltageControl(TransformerVoltageControl transformerVoltageControl);
+
+    void setDeadBand(double deadbandValue);
 
     BranchResult createBranchResult(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension);
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetworkListener.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetworkListener.java
@@ -27,7 +27,9 @@ public interface LfNetworkListener {
 
     void onGenerationReactivePowerTargetChange(LfBus bus, double oldGenerationTargetQ, double newGenerationTargetQ);
 
-    void onDiscretePhaseControlTapPositionChange(LfBranch controllerBranch, int oldPosition, int newPosition);
+    void onTransformerPhaseControlTapPositionChange(LfBranch controllerBranch, int oldPosition, int newPosition);
+
+    void onTransformerVoltageControlTapPositionChange(LfBranch controllerBranch, int oldPosition, int newPosition);
 
     void onDisableChange(LfElement element, boolean disabled);
 }

--- a/src/main/java/com/powsybl/openloadflow/network/PiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModel.java
@@ -58,9 +58,7 @@ public interface PiModel {
 
     boolean updateTapPosition(Direction direction);
 
-    boolean increaseTapPosition();
-
-    boolean decreaseTapPosition();
+    boolean updateTapPositionR(Direction direction);
 
     boolean setMinZ(double minZ, boolean dc);
 

--- a/src/main/java/com/powsybl/openloadflow/network/PiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModel.java
@@ -76,7 +76,7 @@ public interface PiModel {
 
     boolean updateTapPositionA1(Direction direction);
 
-    Optional<Direction> updateTapPositionR1(double deltaR1, int maxTapIncrement, AllowedDirection allowedDirection);
+    Optional<Direction> updateTapPositionR1(double deltaR1, int maxTapShift, AllowedDirection allowedDirection);
 
     boolean setMinZ(double minZ, boolean dc);
 

--- a/src/main/java/com/powsybl/openloadflow/network/PiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModel.java
@@ -58,6 +58,10 @@ public interface PiModel {
 
     boolean updateTapPosition(Direction direction);
 
+    boolean increaseTapPosition();
+
+    boolean decreaseTapPosition();
+
     boolean setMinZ(double minZ, boolean dc);
 
     void setBranch(LfBranch branch);

--- a/src/main/java/com/powsybl/openloadflow/network/PiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModel.java
@@ -58,7 +58,7 @@ public interface PiModel {
 
     boolean updateTapPosition(Direction direction);
 
-    boolean updateTapPositionR(Direction direction);
+    boolean updateTapPositionR(double deltaR);
 
     boolean setMinZ(double minZ, boolean dc);
 

--- a/src/main/java/com/powsybl/openloadflow/network/PiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModel.java
@@ -6,8 +6,6 @@
  */
 package com.powsybl.openloadflow.network;
 
-import org.apache.commons.lang3.tuple.Pair;
-
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
@@ -54,13 +52,16 @@ public interface PiModel {
     void roundR1ToClosestTap();
 
     enum Direction {
+        NONE,
         INCREASE,
-        DECREASE
+        DECREASE,
+        INCREASE_THEN_DECREASE,
+        DECREASE_THEN_INCREASE
     }
 
     boolean updateTapPosition(Direction direction);
 
-    Pair<Boolean, Double> updateTapPositionR(double deltaR, int maxSwitch);
+    boolean updateTapPositionR1(double deltaR1, int maxTapIncrement, Direction previousVariations);
 
     boolean setMinZ(double minZ, boolean dc);
 

--- a/src/main/java/com/powsybl/openloadflow/network/PiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModel.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.openloadflow.network;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
@@ -58,7 +60,7 @@ public interface PiModel {
 
     boolean updateTapPosition(Direction direction);
 
-    boolean updateTapPositionR(double deltaR);
+    Pair<Boolean, Double> updateTapPositionR(double deltaR, int maxSwitch);
 
     boolean setMinZ(double minZ, boolean dc);
 

--- a/src/main/java/com/powsybl/openloadflow/network/PiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModel.java
@@ -74,7 +74,7 @@ public interface PiModel {
         BOTH
     }
 
-    boolean updateTapPosition(Direction direction);
+    boolean updateTapPositionA1(Direction direction);
 
     Optional<Direction> updateTapPositionR1(double deltaR1, int maxTapIncrement, AllowedDirection allowedDirection);
 

--- a/src/main/java/com/powsybl/openloadflow/network/PiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModel.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.openloadflow.network;
 
+import java.util.Optional;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
@@ -52,16 +54,29 @@ public interface PiModel {
     void roundR1ToClosestTap();
 
     enum Direction {
-        NONE,
+        INCREASE(AllowedDirection.INCREASE),
+        DECREASE(AllowedDirection.DECREASE);
+
+        private final AllowedDirection allowedDirection;
+
+        Direction(AllowedDirection allowedDirection) {
+            this.allowedDirection = allowedDirection;
+        }
+
+        public AllowedDirection getAllowedDirection() {
+            return allowedDirection;
+        }
+    }
+
+    enum AllowedDirection {
         INCREASE,
         DECREASE,
-        INCREASE_THEN_DECREASE,
-        DECREASE_THEN_INCREASE
+        BOTH
     }
 
     boolean updateTapPosition(Direction direction);
 
-    boolean updateTapPositionR1(double deltaR1, int maxTapIncrement, Direction previousVariations);
+    Optional<Direction> updateTapPositionR1(double deltaR1, int maxTapIncrement, AllowedDirection allowedDirection);
 
     boolean setMinZ(double minZ, boolean dc);
 

--- a/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
@@ -211,6 +211,7 @@ public class PiModelArray implements PiModel {
         }
 
         if (oldTapPosition != tapPosition) {
+            r1 = Double.NaN;
             hasChange = true;
         }
 

--- a/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
@@ -161,7 +161,7 @@ public class PiModelArray implements PiModel {
     }
 
     @Override
-    public boolean updateTapPosition(Direction direction) {
+    public boolean updateTapPositionA1(Direction direction) {
         this.a1 = getA1();
         double previousA1 = Double.NaN;
         double nextA1 = Double.NaN;

--- a/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
@@ -187,7 +187,7 @@ public class PiModelArray implements PiModel {
         }
         if (hasChanged) {
             for (LfNetworkListener listener : branch.getNetwork().getListeners()) {
-                listener.onDiscretePhaseControlTapPositionChange(branch, oldTapPosition, tapPosition);
+                listener.onTransformerPhaseControlTapPositionChange(branch, oldTapPosition, tapPosition);
             }
         }
         return hasChanged;
@@ -228,7 +228,7 @@ public class PiModelArray implements PiModel {
         if (hasChanged) {
             r1 = Double.NaN;
             for (LfNetworkListener listener : branch.getNetwork().getListeners()) {
-                listener.onDiscretePhaseControlTapPositionChange(branch, oldTapPosition, tapPosition);
+                listener.onTransformerVoltageControlTapPositionChange(branch, oldTapPosition, tapPosition);
             }
             return Optional.of(tapPosition - oldTapPosition > 0 ? Direction.INCREASE : Direction.DECREASE);
         }

--- a/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
@@ -162,6 +162,8 @@ public class PiModelArray implements PiModel {
 
     @Override
     public boolean updateTapPositionA1(Direction direction) {
+        // an increase direction means that A1 should increase.
+        // a decrease direction means that A1 should decrease.
         this.a1 = getA1();
         double previousA1 = Double.NaN;
         double nextA1 = Double.NaN;
@@ -208,6 +210,8 @@ public class PiModelArray implements PiModel {
 
     @Override
     public Optional<Direction> updateTapPositionR1(double deltaR1, int maxTapShift, AllowedDirection allowedDirection) {
+        // an increase allowed direction means that the tap could increase.
+        // a decrease allowed direction means that the tap could decrease.
         double newR1 = getR1() + deltaR1;
         Range<Integer> positionRange = getAllowedPositionRange(allowedDirection);
 

--- a/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
@@ -141,7 +141,7 @@ public class PiModelArray implements PiModel {
     @Override
     public void roundR1ToClosestTap() {
         if (Double.isNaN(r1)) {
-            return; // nothing to do because a1 has not been modified
+            return; // nothing to do because r1 has not been modified
         }
 
         // find tap position with the closest r1 value
@@ -191,30 +191,16 @@ public class PiModelArray implements PiModel {
     }
 
     @Override
-    public boolean updateTapPositionR(Direction direction) {
-        this.r1 = getR1();
-        double previousR1 = Double.NaN;
-        double nextR1 = Double.NaN;
+    public boolean updateTapPositionR(double deltaR) {
+        this.r1 = getR1() + deltaR;
         boolean hasChange = false;
         int oldTapPosition = tapPosition;
-        if (tapPosition < lowTapPosition + models.size() - 1) {
-            nextR1 = models.get(tapPosition - lowTapPosition + 1).getR1();
-        }
-        if (tapPosition > lowTapPosition) {
-            previousR1 = models.get(tapPosition - lowTapPosition - 1).getR1();
-        }
-        if (!Double.isNaN(previousR1) &&
-                ((direction == Direction.INCREASE && previousR1 > r1) || (direction == Direction.DECREASE && previousR1 < r1))) {
-            tapPosition = tapPosition - 1;
-            r1 = Double.NaN;
+        this.roundR1ToClosestTap();
+
+        if (oldTapPosition != tapPosition) {
             hasChange = true;
         }
-        if (!Double.isNaN(nextR1) &&
-                ((direction == Direction.INCREASE && nextR1 > r1) || (direction == Direction.DECREASE && nextR1 < r1))) {
-            tapPosition = tapPosition + 1;
-            r1 = Double.NaN;
-            hasChange = true;
-        }
+
         if (hasChange) {
             for (LfNetworkListener listener : branch.getNetwork().getListeners()) {
                 listener.onDiscretePhaseControlTapPositionChange(branch, oldTapPosition, tapPosition);

--- a/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.openloadflow.network;
 
+import org.apache.commons.lang3.Range;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -28,13 +30,10 @@ public class PiModelArray implements PiModel {
 
     private LfBranch branch;
 
-    private Direction r1Variation;
-
     public PiModelArray(List<PiModel> models, int lowTapPosition, int tapPosition) {
         this.models = Objects.requireNonNull(models);
         this.lowTapPosition = lowTapPosition;
         this.tapPosition = tapPosition;
-        r1Variation = (models.get(0).getR1() > models.get(models.size() - 1).getR1()) ? Direction.DECREASE : Direction.INCREASE; // FIXME: add a control.
     }
 
     private PiModel getModel() {
@@ -193,12 +192,11 @@ public class PiModelArray implements PiModel {
         return hasChanged;
     }
 
-    @Override
-    public boolean updateTapPositionR1(double deltaR1, int maxTapIncrement, Direction previousVariations) {
-        double newR1 = getR1() + deltaR1;
+    private Range<Integer> getAllowedPositionRange(Direction previousVariations) {
         int pBegin = 0;
         int pEnd = models.size();
         int p0 = tapPosition - lowTapPosition;
+        Direction r1Variation = (models.get(0).getR1() > models.get(models.size() - 1).getR1()) ? Direction.DECREASE : Direction.INCREASE; // FIXME: add a control.
         if (previousVariations == Direction.DECREASE_THEN_INCREASE) {
             // we forbid R1 to decrease again after having already decrease then increase
             if (r1Variation == Direction.INCREASE) {
@@ -215,17 +213,24 @@ public class PiModelArray implements PiModel {
                 pBegin = p0;
             }
         }
+        return Range.between(pBegin, pEnd);
+    }
+
+    @Override
+    public boolean updateTapPositionR1(double deltaR1, int maxTapIncrement, Direction previousVariations) {
+        double newR1 = getR1() + deltaR1;
+        Range<Integer> pRange = getAllowedPositionRange(previousVariations);
 
         int oldTapPosition = tapPosition;
         // find tap position with the closest r1 value without exceeding the maximum of taps to switch.
         double smallestDistance = Math.abs(deltaR1);
-        for (int p = pBegin; p < pEnd; p++) {
-            if (Math.abs(lowTapPosition + p - oldTapPosition) <= maxTapIncrement) {
-                double distance = Math.abs(newR1 - models.get(p).getR1());
-                if (distance < smallestDistance) {
-                    tapPosition = lowTapPosition + p;
-                    smallestDistance = distance;
-                }
+        for (int p = pRange.getMinimum();
+             p < pRange.getMaximum() && Math.abs(lowTapPosition + p - oldTapPosition) <= maxTapIncrement;
+             p++) {
+            double distance = Math.abs(newR1 - models.get(p).getR1());
+            if (distance < smallestDistance) {
+                tapPosition = lowTapPosition + p;
+                smallestDistance = distance;
             }
         }
 

--- a/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
@@ -220,8 +220,7 @@ public class PiModelArray implements PiModel {
                 listener.onDiscretePhaseControlTapPositionChange(branch, oldTapPosition, tapPosition);
             }
         }
-        Pair<Boolean, Double> result = Pair.of(hasChange, getModel().getR1() - models.get(oldTapPosition - lowTapPosition).getR1());
-        return result;
+        return Pair.of(hasChange, getModel().getR1() - models.get(oldTapPosition - lowTapPosition).getR1());
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
@@ -191,6 +191,38 @@ public class PiModelArray implements PiModel {
     }
 
     @Override
+    public boolean increaseTapPosition() {
+        boolean hasChange = false;
+        int oldTapPosition = tapPosition;
+        if (tapPosition < lowTapPosition + models.size() - 1) {
+            tapPosition = tapPosition + 1;
+            hasChange = true;
+        }
+        if (hasChange) {
+            for (LfNetworkListener listener : branch.getNetwork().getListeners()) {
+                listener.onDiscretePhaseControlTapPositionChange(branch, oldTapPosition, tapPosition);
+            }
+        }
+        return hasChange;
+    }
+
+    @Override
+    public boolean decreaseTapPosition() {
+        boolean hasChange = false;
+        int oldTapPosition = tapPosition;
+        if (tapPosition > lowTapPosition) {
+            tapPosition = tapPosition - 1;
+            hasChange = true;
+        }
+        if (hasChange) {
+            for (LfNetworkListener listener : branch.getNetwork().getListeners()) {
+                listener.onDiscretePhaseControlTapPositionChange(branch, oldTapPosition, tapPosition);
+            }
+        }
+        return hasChange;
+    }
+
+    @Override
     public boolean setMinZ(double minZ, boolean dc) {
         boolean done = false;
         for (PiModel model : models) {

--- a/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
@@ -191,27 +191,28 @@ public class PiModelArray implements PiModel {
     }
 
     @Override
-    public boolean increaseTapPosition() {
+    public boolean updateTapPositionR(Direction direction) {
+        this.r1 = getR1();
+        double previousR1 = Double.NaN;
+        double nextR1 = Double.NaN;
         boolean hasChange = false;
         int oldTapPosition = tapPosition;
         if (tapPosition < lowTapPosition + models.size() - 1) {
-            tapPosition = tapPosition + 1;
+            nextR1 = models.get(tapPosition - lowTapPosition + 1).getR1();
+        }
+        if (tapPosition > lowTapPosition) {
+            previousR1 = models.get(tapPosition - lowTapPosition - 1).getR1();
+        }
+        if (!Double.isNaN(previousR1) &&
+                ((direction == Direction.INCREASE && previousR1 > r1) || (direction == Direction.DECREASE && previousR1 < r1))) {
+            tapPosition = tapPosition - 1;
+            r1 = Double.NaN;
             hasChange = true;
         }
-        if (hasChange) {
-            for (LfNetworkListener listener : branch.getNetwork().getListeners()) {
-                listener.onDiscretePhaseControlTapPositionChange(branch, oldTapPosition, tapPosition);
-            }
-        }
-        return hasChange;
-    }
-
-    @Override
-    public boolean decreaseTapPosition() {
-        boolean hasChange = false;
-        int oldTapPosition = tapPosition;
-        if (tapPosition > lowTapPosition) {
-            tapPosition = tapPosition - 1;
+        if (!Double.isNaN(nextR1) &&
+                ((direction == Direction.INCREASE && nextR1 > r1) || (direction == Direction.DECREASE && nextR1 < r1))) {
+            tapPosition = tapPosition + 1;
+            r1 = Double.NaN;
             hasChange = true;
         }
         if (hasChange) {

--- a/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
@@ -207,7 +207,7 @@ public class PiModelArray implements PiModel {
     }
 
     @Override
-    public Optional<Direction> updateTapPositionR1(double deltaR1, int maxTapIncrement, AllowedDirection allowedDirection) {
+    public Optional<Direction> updateTapPositionR1(double deltaR1, int maxTapShift, AllowedDirection allowedDirection) {
         double newR1 = getR1() + deltaR1;
         Range<Integer> positionRange = getAllowedPositionRange(allowedDirection);
 
@@ -215,7 +215,7 @@ public class PiModelArray implements PiModel {
         // find tap position with the closest r1 value without exceeding the maximum of taps to switch.
         double smallestDistance = Math.abs(deltaR1);
         for (int p = positionRange.getMinimum();
-             p < positionRange.getMaximum() && Math.abs(lowTapPosition + p - oldTapPosition) <= maxTapIncrement;
+             p < positionRange.getMaximum() && Math.abs(lowTapPosition + p - oldTapPosition) <= maxTapShift;
              p++) {
             double distance = Math.abs(newR1 - models.get(p).getR1());
             if (distance < smallestDistance) {

--- a/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
@@ -8,6 +8,8 @@ package com.powsybl.openloadflow.network;
 
 import net.jafama.FastMath;
 
+import java.util.Optional;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
@@ -141,7 +143,7 @@ public class SimplePiModel implements PiModel {
     }
 
     @Override
-    public boolean updateTapPositionR1(double deltaR1, int maxTapIncrement, Direction previousVariations) {
+    public Optional<Direction> updateTapPositionR1(double deltaR1, int maxTapIncrement, AllowedDirection allowedDirection) {
         throw new IllegalStateException("No tap position change in simple Pi model implementation");
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
@@ -140,6 +140,16 @@ public class SimplePiModel implements PiModel {
         throw new IllegalStateException("No tap position change in simple Pi model implementation");
     }
 
+    @Override
+    public boolean increaseTapPosition() {
+        throw new IllegalStateException("No tap position change in simple Pi model implementation");
+    }
+
+    @Override
+    public boolean decreaseTapPosition() {
+        throw new IllegalStateException("No tap position change in simple Pi model implementation");
+    }
+
     private void rescaleZ(double z) {
         double ksi = getKsi();
         r = z * FastMath.cos(ksi);

--- a/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
@@ -138,7 +138,7 @@ public class SimplePiModel implements PiModel {
     }
 
     @Override
-    public boolean updateTapPosition(Direction direction) {
+    public boolean updateTapPositionA1(Direction direction) {
         throw new IllegalStateException("No tap position change in simple Pi model implementation");
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
@@ -143,7 +143,7 @@ public class SimplePiModel implements PiModel {
     }
 
     @Override
-    public Optional<Direction> updateTapPositionR1(double deltaR1, int maxTapIncrement, AllowedDirection allowedDirection) {
+    public Optional<Direction> updateTapPositionR1(double deltaR1, int maxTapShift, AllowedDirection allowedDirection) {
         throw new IllegalStateException("No tap position change in simple Pi model implementation");
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
@@ -7,6 +7,7 @@
 package com.powsybl.openloadflow.network;
 
 import net.jafama.FastMath;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -141,7 +142,7 @@ public class SimplePiModel implements PiModel {
     }
 
     @Override
-    public boolean updateTapPositionR(double deltaR) {
+    public Pair<Boolean, Double> updateTapPositionR(double deltaR, int maxSwitch) {
         throw new IllegalStateException("No tap position change in simple Pi model implementation");
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
@@ -141,7 +141,7 @@ public class SimplePiModel implements PiModel {
     }
 
     @Override
-    public boolean updateTapPositionR(Direction direction) {
+    public boolean updateTapPositionR(double deltaR) {
         throw new IllegalStateException("No tap position change in simple Pi model implementation");
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
@@ -141,12 +141,7 @@ public class SimplePiModel implements PiModel {
     }
 
     @Override
-    public boolean increaseTapPosition() {
-        throw new IllegalStateException("No tap position change in simple Pi model implementation");
-    }
-
-    @Override
-    public boolean decreaseTapPosition() {
+    public boolean updateTapPositionR(Direction direction) {
         throw new IllegalStateException("No tap position change in simple Pi model implementation");
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
@@ -7,7 +7,6 @@
 package com.powsybl.openloadflow.network;
 
 import net.jafama.FastMath;
-import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -142,7 +141,7 @@ public class SimplePiModel implements PiModel {
     }
 
     @Override
-    public Pair<Boolean, Double> updateTapPositionR(double deltaR, int maxSwitch) {
+    public boolean updateTapPositionR1(double deltaR1, int maxTapIncrement, Direction previousVariations) {
         throw new IllegalStateException("No tap position change in simple Pi model implementation");
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
@@ -39,6 +39,8 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
 
     protected TransformerVoltageControl voltageControl;
 
+    protected double targetDeadBand;
+
     protected boolean voltageControlEnabled = false;
 
     protected boolean spanningTreeEdge = false;
@@ -195,6 +197,11 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
     }
 
     @Override
+    public Optional<Double> getTargetDeadBand() {
+        return Optional.ofNullable(targetDeadBand);
+    }
+
+    @Override
     public boolean isVoltageController() {
         return voltageControl != null;
     }
@@ -202,6 +209,11 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
     @Override
     public void setVoltageControl(TransformerVoltageControl transformerVoltageControl) {
         this.voltageControl = transformerVoltageControl;
+    }
+
+    @Override
+    public void setDeadBand(double deadbandValue) {
+        this.targetDeadBand = deadbandValue;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
@@ -39,7 +39,7 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
 
     protected TransformerVoltageControl voltageControl;
 
-    protected double targetDeadBand;
+    protected double transformerVoltageControlTargetDeadband;
 
     protected boolean voltageControlEnabled = false;
 
@@ -197,8 +197,8 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
     }
 
     @Override
-    public Optional<Double> getTargetDeadBand() {
-        return Optional.ofNullable(targetDeadBand);
+    public Optional<Double> getTransformerVoltageControlTargetDeadband() {
+        return Optional.ofNullable(transformerVoltageControlTargetDeadband);
     }
 
     @Override
@@ -212,8 +212,8 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
     }
 
     @Override
-    public void setDeadBand(double deadbandValue) {
-        this.targetDeadBand = deadbandValue;
+    public void setTransformerVoltageControlTargetDeadband(double transformerVoltageControlTargetDeadband) {
+        this.transformerVoltageControlTargetDeadband = transformerVoltageControlTargetDeadband;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -617,7 +617,6 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         double regulatingTerminalNominalV = rtc.getRegulationTerminal().getVoltageLevel().getNominalV();
         double targetValue = rtc.getTargetV() / regulatingTerminalNominalV;
         double deadbandValue = rtc.getTargetDeadband() / regulatingTerminalNominalV;
-        System.out.println(deadbandValue);
 
         controlledBus.getTransformerVoltageControl().ifPresentOrElse(vc -> {
             LOGGER.trace("Controlled bus '{}' already has a transformer voltage control: a shared control is created", controlledBus.getId());

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -616,6 +616,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
 
         double regulatingTerminalNominalV = rtc.getRegulationTerminal().getVoltageLevel().getNominalV();
         double targetValue = rtc.getTargetV() / regulatingTerminalNominalV;
+        double deadbandValue = rtc.getTargetDeadband() / regulatingTerminalNominalV;
 
         controlledBus.getTransformerVoltageControl().ifPresentOrElse(vc -> {
             LOGGER.trace("Controlled bus '{}' already has a transformer voltage control: a shared control is created", controlledBus.getId());
@@ -625,10 +626,12 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
             }
             vc.addController(controllerBranch);
             controllerBranch.setVoltageControl(vc);
+            controllerBranch.setDeadBand(deadbandValue);
         }, () -> {
                 TransformerVoltageControl voltageControl = new TransformerVoltageControl(controlledBus, targetValue);
                 voltageControl.addController(controllerBranch);
                 controllerBranch.setVoltageControl(voltageControl);
+                controllerBranch.setDeadBand(deadbandValue);
                 controlledBus.setTransformerVoltageControl(voltageControl);
             });
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -617,6 +617,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         double regulatingTerminalNominalV = rtc.getRegulationTerminal().getVoltageLevel().getNominalV();
         double targetValue = rtc.getTargetV() / regulatingTerminalNominalV;
         double deadbandValue = rtc.getTargetDeadband() / regulatingTerminalNominalV;
+        System.out.println(deadbandValue);
 
         controlledBus.getTransformerVoltageControl().ifPresentOrElse(vc -> {
             LOGGER.trace("Controlled bus '{}' already has a transformer voltage control: a shared control is created", controlledBus.getId());
@@ -626,12 +627,12 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
             }
             vc.addController(controllerBranch);
             controllerBranch.setVoltageControl(vc);
-            controllerBranch.setDeadBand(deadbandValue);
+            controllerBranch.setTransformerVoltageControlTargetDeadband(deadbandValue);
         }, () -> {
                 TransformerVoltageControl voltageControl = new TransformerVoltageControl(controlledBus, targetValue);
                 voltageControl.addController(controllerBranch);
                 controllerBranch.setVoltageControl(voltageControl);
-                controllerBranch.setDeadBand(deadbandValue);
+                controllerBranch.setTransformerVoltageControlTargetDeadband(deadbandValue);
                 controlledBus.setTransformerVoltageControl(voltageControl);
             });
     }

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
@@ -140,6 +140,26 @@ class AcLoadFlowTransformerControlTest {
     }
 
     @Test
+    void voltageControlT2wtTest4() {
+        selectNetwork(VoltageControlNetworkFactory.createNetworkWithT2wt());
+
+        parameters.setTransformerVoltageControlOn(true);
+        parametersExt.setTransformerVoltageControlMode(OpenLoadFlowParameters.TransformerVoltageControlMode.INCREMENTAL_VOLTAGE_CONTROL);
+        t2wt.getRatioTapChanger()
+                .setTargetDeadband(0)
+                .setRegulating(true)
+                .setTapPosition(0)
+                .setRegulationTerminal(t2wt.getTerminal2())
+                .setTargetV(34.0);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertVoltageEquals(134.281, bus2);
+        // assertVoltageEquals(34.433, t2wt.getTerminal2().getBusView().getBus()); //FIXME: should be 34.427
+        assertEquals(3, t2wt.getRatioTapChanger().getTapPosition());
+    }
+
+    @Test
     void remoteVoltageControlT2wtTest() {
         selectNetwork(VoltageControlNetworkFactory.createNetworkWithT2wt());
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
@@ -148,15 +148,15 @@ class AcLoadFlowTransformerControlTest {
         t2wt.getRatioTapChanger()
                 .setTargetDeadband(0)
                 .setRegulating(true)
-                .setTapPosition(0)
+                .setTapPosition(2)
                 .setRegulationTerminal(t2wt.getTerminal2())
-                .setTargetV(34.0);
+                .setTargetV(28.0);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isOk());
         assertVoltageEquals(134.281, bus2);
-        assertVoltageEquals(34.427, t2wt.getTerminal2().getBusView().getBus());
-        assertEquals(3, t2wt.getRatioTapChanger().getTapPosition());
+        assertVoltageEquals(27.003, t2wt.getTerminal2().getBusView().getBus());
+        assertEquals(0, t2wt.getRatioTapChanger().getTapPosition());
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
@@ -197,7 +197,7 @@ class AcLoadFlowTransformerControlTest {
                 .setRegulating(true)
                 .setTapPosition(1)
                 .setRegulationTerminal(t2wt.getTerminal2())
-                .setTargetV(34.0);
+                .setTargetV(32.0);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isOk());
@@ -213,13 +213,13 @@ class AcLoadFlowTransformerControlTest {
         parameters.setTransformerVoltageControlOn(true);
         parametersExt.setTransformerVoltageControlMode(OpenLoadFlowParameters.TransformerVoltageControlMode.INCREMENTAL_VOLTAGE_CONTROL);
         t2wt.getRatioTapChanger()
-                .setTargetDeadband(3.0)
+                .setTargetDeadband(6.0)
                 .setRegulating(true)
                 .setTapPosition(0)
                 .setRegulationTerminal(t2wt.getTerminal2())
                 .setTargetV(34.0);
         t2wt2.getRatioTapChanger()
-                .setTargetDeadband(3.0)
+                .setTargetDeadband(6.0)
                 .setRegulating(true)
                 .setTapPosition(0)
                 .setRegulationTerminal(t2wt2.getTerminal2())

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
@@ -181,11 +181,9 @@ class AcLoadFlowTransformerControlTest {
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isOk());
         assertVoltageEquals(134.281, bus2);
-        assertVoltageEquals(34.427, t2wt.getTerminal2().getBusView().getBus());
-        assertEquals(3, t2wt.getRatioTapChanger().getTapPosition());
-        assertVoltageEquals(134.281, bus4);
-        assertVoltageEquals(34.427, t2wt2.getTerminal2().getBusView().getBus());
-        assertEquals(3, t2wt2.getRatioTapChanger().getTapPosition());
+        assertVoltageEquals(33.989, t2wt.getTerminal2().getBusView().getBus());
+        assertEquals(2, t2wt.getRatioTapChanger().getTapPosition());
+        assertEquals(2, t2wt2.getRatioTapChanger().getTapPosition());
     }
 
     @Test
@@ -722,7 +720,6 @@ class AcLoadFlowTransformerControlTest {
         bus1 = network.getBusBreakerView().getBus("BUS_1");
         bus2 = network.getBusBreakerView().getBus("BUS_2");
         bus3 = network.getBusBreakerView().getBus("BUS_3");
-        bus4 = network.getBusBreakerView().getBus("BUS_4");
 
         t2wt = network.getTwoWindingsTransformer("T2wT1");
         t2wt2 = network.getTwoWindingsTransformer("T2wT2");

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
@@ -160,6 +160,35 @@ class AcLoadFlowTransformerControlTest {
     }
 
     @Test
+    void voltageControlT2wtTest5() {
+        selectNetwork2(VoltageControlNetworkFactory.createNetworkWith2T2wt());
+
+        parameters.setTransformerVoltageControlOn(true);
+        parametersExt.setTransformerVoltageControlMode(OpenLoadFlowParameters.TransformerVoltageControlMode.INCREMENTAL_VOLTAGE_CONTROL);
+        t2wt.getRatioTapChanger()
+                .setTargetDeadband(0)
+                .setRegulating(true)
+                .setTapPosition(0)
+                .setRegulationTerminal(t2wt.getTerminal2())
+                .setTargetV(34.0);
+        t2wt2.getRatioTapChanger()
+                .setTargetDeadband(0)
+                .setRegulating(true)
+                .setTapPosition(0)
+                .setRegulationTerminal(t2wt2.getTerminal2())
+                .setTargetV(34.0);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertVoltageEquals(134.281, bus2);
+        assertVoltageEquals(34.427, t2wt.getTerminal2().getBusView().getBus());
+        assertEquals(3, t2wt.getRatioTapChanger().getTapPosition());
+        assertVoltageEquals(134.281, bus4);
+        assertVoltageEquals(34.427, t2wt2.getTerminal2().getBusView().getBus());
+        assertEquals(3, t2wt2.getRatioTapChanger().getTapPosition());
+    }
+
+    @Test
     void remoteVoltageControlT2wtTest() {
         selectNetwork(VoltageControlNetworkFactory.createNetworkWithT2wt());
 
@@ -685,5 +714,17 @@ class AcLoadFlowTransformerControlTest {
 
         t2wt = network.getTwoWindingsTransformer("T2wT");
         t3wt = network.getThreeWindingsTransformer("T3wT");
+    }
+
+    private void selectNetwork2(Network network) {
+        this.network = network;
+
+        bus1 = network.getBusBreakerView().getBus("BUS_1");
+        bus2 = network.getBusBreakerView().getBus("BUS_2");
+        bus3 = network.getBusBreakerView().getBus("BUS_3");
+        bus4 = network.getBusBreakerView().getBus("BUS_4");
+
+        t2wt = network.getTwoWindingsTransformer("T2wT1");
+        t2wt2 = network.getTwoWindingsTransformer("T2wT2");
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
@@ -187,6 +187,53 @@ class AcLoadFlowTransformerControlTest {
     }
 
     @Test
+    void voltageControlT2wtTest6() {
+        selectNetwork(VoltageControlNetworkFactory.createNetworkWithT2wt());
+
+        parameters.setTransformerVoltageControlOn(true);
+        parametersExt.setTransformerVoltageControlMode(OpenLoadFlowParameters.TransformerVoltageControlMode.INCREMENTAL_VOLTAGE_CONTROL);
+        t2wt.getRatioTapChanger()
+                .setTargetDeadband(4.0)
+                .setRegulating(true)
+                .setTapPosition(1)
+                .setRegulationTerminal(t2wt.getTerminal2())
+                .setTargetV(34.0);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertVoltageEquals(134.281, bus2);
+        assertVoltageEquals(30.766, t2wt.getTerminal2().getBusView().getBus());
+        assertEquals(1, t2wt.getRatioTapChanger().getTapPosition());
+    }
+
+    @Test
+    void voltageControlT2wtTest7() {
+        selectNetwork2(VoltageControlNetworkFactory.createNetworkWith2T2wt());
+
+        parameters.setTransformerVoltageControlOn(true);
+        parametersExt.setTransformerVoltageControlMode(OpenLoadFlowParameters.TransformerVoltageControlMode.INCREMENTAL_VOLTAGE_CONTROL);
+        t2wt.getRatioTapChanger()
+                .setTargetDeadband(3.0)
+                .setRegulating(true)
+                .setTapPosition(0)
+                .setRegulationTerminal(t2wt.getTerminal2())
+                .setTargetV(34.0);
+        t2wt2.getRatioTapChanger()
+                .setTargetDeadband(3.0)
+                .setRegulating(true)
+                .setTapPosition(0)
+                .setRegulationTerminal(t2wt2.getTerminal2())
+                .setTargetV(34.0);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertVoltageEquals(134.281, bus2);
+        assertVoltageEquals(32.242, t2wt.getTerminal2().getBusView().getBus());
+        assertEquals(1, t2wt.getRatioTapChanger().getTapPosition());
+        assertEquals(1, t2wt2.getRatioTapChanger().getTapPosition());
+    }
+
+    @Test
     void remoteVoltageControlT2wtTest() {
         selectNetwork(VoltageControlNetworkFactory.createNetworkWithT2wt());
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
@@ -155,7 +155,7 @@ class AcLoadFlowTransformerControlTest {
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isOk());
         assertVoltageEquals(134.281, bus2);
-        // assertVoltageEquals(34.433, t2wt.getTerminal2().getBusView().getBus()); //FIXME: should be 34.427
+        assertVoltageEquals(34.427, t2wt.getTerminal2().getBusView().getBus());
         assertEquals(3, t2wt.getRatioTapChanger().getTapPosition());
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
@@ -252,6 +252,61 @@ class AcLoadFlowTransformerControlTest {
     }
 
     @Test
+    void remoteVoltageControlT2wtTest2() {
+        selectNetwork(VoltageControlNetworkFactory.createNetworkWithT2wt());
+
+        Substation substation = network.newSubstation()
+                .setId("SUBSTATION4")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl4 = substation.newVoltageLevel()
+                .setId("VL_4")
+                .setNominalV(33.0)
+                .setLowVoltageLimit(0)
+                .setHighVoltageLimit(100)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        Bus bus4 = vl4.getBusBreakerView().newBus()
+                .setId("BUS_4")
+                .add();
+        vl4.newLoad()
+                .setId("LOAD_4")
+                .setBus("BUS_4")
+                .setP0(2.)
+                .setQ0(0.5)
+                .add();
+
+        Line line34 = network.newLine()
+                .setId("LINE_34")
+                .setVoltageLevel1("VL_3")
+                .setVoltageLevel2("VL_4")
+                .setBus1("BUS_3")
+                .setBus2("BUS_4")
+                .setR(1.05)
+                .setX(10.0)
+                .setG1(0.0000005)
+                .setG2(0.)
+                .setB1(0.)
+                .setB2(0.)
+                .add();
+
+        parameters.setTransformerVoltageControlOn(true);
+        parametersExt.setTransformerVoltageControlMode(OpenLoadFlowParameters.TransformerVoltageControlMode.INCREMENTAL_VOLTAGE_CONTROL);
+
+        t2wt.getRatioTapChanger()
+                .setTargetDeadband(0)
+                .setRegulating(true)
+                .setTapPosition(0)
+                .setRegulationTerminal(line34.getTerminal2())
+                .setTargetV(33.0);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertVoltageEquals(32.891, bus4);
+        assertTrue(result.isOk());
+        assertEquals(3, t2wt.getRatioTapChanger().getTapPosition());
+    }
+
+    @Test
     void nonSupportedVoltageControlT2wtTest() {
         selectNetwork(VoltageControlNetworkFactory.createNetworkWithT2wt());
 

--- a/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
@@ -375,106 +375,6 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
         return network;
     }
 
-    public static Network create2TransformersBaseNetwork(String id) {
-
-        Network network = Network.create(id, "test");
-
-        Substation substation1 = network.newSubstation()
-                .setId("SUBSTATION1")
-                .setCountry(Country.FR)
-                .add();
-        VoltageLevel vl1 = substation1.newVoltageLevel()
-                .setId("VL_1")
-                .setNominalV(132.0)
-                .setLowVoltageLimit(118.8)
-                .setHighVoltageLimit(145.2)
-                .setTopologyKind(TopologyKind.BUS_BREAKER)
-                .add();
-        vl1.getBusBreakerView().newBus()
-                .setId("BUS_1")
-                .add();
-        vl1.newGenerator()
-                .setId("GEN_1")
-                .setBus("BUS_1")
-                .setMinP(0.0)
-                .setMaxP(140)
-                .setTargetP(25)
-                .setTargetV(135)
-                .setVoltageRegulatorOn(true)
-                .add();
-
-        Substation substation = network.newSubstation()
-                .setId("SUBSTATION")
-                .setCountry(Country.FR)
-                .add();
-        VoltageLevel vl2 = substation.newVoltageLevel()
-                .setId("VL_2")
-                .setNominalV(132.0)
-                .setLowVoltageLimit(118.8)
-                .setHighVoltageLimit(145.2)
-                .setTopologyKind(TopologyKind.BUS_BREAKER)
-                .add();
-        vl2.getBusBreakerView().newBus()
-                .setId("BUS_2")
-                .add();
-        vl2.newLoad()
-                .setId("LOAD_2")
-                .setBus("BUS_2")
-                .setP0(11.2)
-                .setQ0(7.5)
-                .add();
-
-        VoltageLevel vl3 = substation.newVoltageLevel()
-                .setId("VL_3")
-                .setNominalV(33.0)
-                .setLowVoltageLimit(0)
-                .setHighVoltageLimit(100)
-                .setTopologyKind(TopologyKind.BUS_BREAKER)
-                .add();
-        vl3.getBusBreakerView().newBus()
-                .setId("BUS_3")
-                .add();
-        vl3.newLoad()
-                .setId("LOAD_3")
-                .setBus("BUS_3")
-                .setQ0(0)
-                .setP0(5)
-                .add();
-
-        VoltageLevel vl4 = substation.newVoltageLevel()
-                .setId("VL_4")
-                .setNominalV(132.0)
-                .setLowVoltageLimit(118.8)
-                .setHighVoltageLimit(145.2)
-                .setTopologyKind(TopologyKind.BUS_BREAKER)
-                .add();
-        vl4.getBusBreakerView().newBus()
-                .setId("BUS_4")
-                .add();
-        vl4.newLoad()
-                .setId("LOAD_4")
-                .setBus("BUS_4")
-                .setP0(1.2)
-                .setQ0(0.5)
-                .add();
-
-        network.newLine()
-                .setId("LINE_12")
-                .setVoltageLevel1("VL_1")
-                .setVoltageLevel2("VL_2")
-                .setBus1("BUS_1")
-                .setBus2("BUS_2")
-                .setR(1.05)
-                .setX(10.0)
-                .setG1(0.0000005)
-                .setG2(0.)
-                .setB1(0.)
-                .setB2(0.)
-                .add();
-
-        return network;
-    }
-
     /**
      * A very small network to test with a T2wt.
      *
@@ -543,18 +443,18 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
     }
 
     /**
-     * A very small network to test with a T2wt.
+     * A very small network to test with two T2wt.
      *
-     *     G1        LD2      LD3     LD4
-     *     |    L12   |        |       |
-     *     |  ------- |        |       |
-     *     B1         B2      B3      B4
-     *                 \     /  \     /
-     *                  T2WT1    T2WT2
+     *     G1        LD2         LD3
+     *     |    L12   |  T2WT2    |
+     *     |  ------- | /     \  |
+     *     B1         B2       B3
+     *                 \      /
+     *                  T2WT1
      */
     public static Network createNetworkWith2T2wt() {
 
-        Network network = VoltageControlNetworkFactory.create2TransformersBaseNetwork("two-windings-transformer-control");
+        Network network = VoltageControlNetworkFactory.createTransformerBaseNetwork("two-windings-transformer-control");
 
         TwoWindingsTransformer t2wt1 = network.getSubstation("SUBSTATION").newTwoWindingsTransformer()
                 .setId("T2wT1")
@@ -608,7 +508,7 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
 
         TwoWindingsTransformer t2wt2 = network.getSubstation("SUBSTATION").newTwoWindingsTransformer()
                 .setId("T2wT2")
-                .setVoltageLevel1("VL_4")
+                .setVoltageLevel1("VL_2")
                 .setVoltageLevel2("VL_3")
                 .setRatedU1(132.0)
                 .setRatedU2(33.0)
@@ -616,7 +516,7 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
                 .setX(10.0)
                 .setG(0.00573921028466483)
                 .setB(0.000573921028466483)
-                .setBus1("BUS_4")
+                .setBus1("BUS_2")
                 .setBus2("BUS_3")
                 .add();
 

--- a/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
@@ -375,6 +375,106 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
         return network;
     }
 
+    public static Network create2TransformersBaseNetwork(String id) {
+
+        Network network = Network.create(id, "test");
+
+        Substation substation1 = network.newSubstation()
+                .setId("SUBSTATION1")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl1 = substation1.newVoltageLevel()
+                .setId("VL_1")
+                .setNominalV(132.0)
+                .setLowVoltageLimit(118.8)
+                .setHighVoltageLimit(145.2)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl1.getBusBreakerView().newBus()
+                .setId("BUS_1")
+                .add();
+        vl1.newGenerator()
+                .setId("GEN_1")
+                .setBus("BUS_1")
+                .setMinP(0.0)
+                .setMaxP(140)
+                .setTargetP(25)
+                .setTargetV(135)
+                .setVoltageRegulatorOn(true)
+                .add();
+
+        Substation substation = network.newSubstation()
+                .setId("SUBSTATION")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl2 = substation.newVoltageLevel()
+                .setId("VL_2")
+                .setNominalV(132.0)
+                .setLowVoltageLimit(118.8)
+                .setHighVoltageLimit(145.2)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl2.getBusBreakerView().newBus()
+                .setId("BUS_2")
+                .add();
+        vl2.newLoad()
+                .setId("LOAD_2")
+                .setBus("BUS_2")
+                .setP0(11.2)
+                .setQ0(7.5)
+                .add();
+
+        VoltageLevel vl3 = substation.newVoltageLevel()
+                .setId("VL_3")
+                .setNominalV(33.0)
+                .setLowVoltageLimit(0)
+                .setHighVoltageLimit(100)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl3.getBusBreakerView().newBus()
+                .setId("BUS_3")
+                .add();
+        vl3.newLoad()
+                .setId("LOAD_3")
+                .setBus("BUS_3")
+                .setQ0(0)
+                .setP0(5)
+                .add();
+
+        VoltageLevel vl4 = substation.newVoltageLevel()
+                .setId("VL_4")
+                .setNominalV(132.0)
+                .setLowVoltageLimit(118.8)
+                .setHighVoltageLimit(145.2)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl4.getBusBreakerView().newBus()
+                .setId("BUS_4")
+                .add();
+        vl4.newLoad()
+                .setId("LOAD_4")
+                .setBus("BUS_4")
+                .setP0(1.2)
+                .setQ0(0.5)
+                .add();
+
+        network.newLine()
+                .setId("LINE_12")
+                .setVoltageLevel1("VL_1")
+                .setVoltageLevel2("VL_2")
+                .setBus1("BUS_1")
+                .setBus2("BUS_2")
+                .setR(1.05)
+                .setX(10.0)
+                .setG1(0.0000005)
+                .setG2(0.)
+                .setB1(0.)
+                .setB2(0.)
+                .add();
+
+        return network;
+    }
+
     /**
      * A very small network to test with a T2wt.
      *
@@ -404,6 +504,123 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
                 .add();
 
         t2wt.newRatioTapChanger()
+                .beginStep()
+                .setRho(0.9)
+                .setR(0.1089)
+                .setX(0.01089)
+                .setG(0.8264462809917356)
+                .setB(0.08264462809917356)
+                .endStep()
+                .beginStep()
+                .setRho(1.0)
+                .setR(0.121)
+                .setX(0.0121)
+                .setG(0.8264462809917356)
+                .setB(0.08264462809917356)
+                .endStep()
+                .beginStep()
+                .setRho(1.05)
+                .setR(0.1331)
+                .setX(0.01331)
+                .setG(0.9090909090909092)
+                .setB(0.09090909090909092)
+                .endStep()
+                .beginStep()
+                .setRho(1.1)
+                .setR(0.1331)
+                .setX(0.01331)
+                .setG(0.9090909090909092)
+                .setB(0.09090909090909092)
+                .endStep()
+                .setTapPosition(0)
+                .setLoadTapChangingCapabilities(true)
+                .setRegulating(false)
+                .setTargetV(33.0)
+                .setRegulationTerminal(network.getLoad("LOAD_3").getTerminal())
+                .add();
+
+        return network;
+    }
+
+    /**
+     * A very small network to test with a T2wt.
+     *
+     *     G1        LD2      LD3     LD4
+     *     |    L12   |        |       |
+     *     |  ------- |        |       |
+     *     B1         B2      B3      B4
+     *                 \     /  \     /
+     *                  T2WT1    T2WT2
+     */
+    public static Network createNetworkWith2T2wt() {
+
+        Network network = VoltageControlNetworkFactory.create2TransformersBaseNetwork("two-windings-transformer-control");
+
+        TwoWindingsTransformer t2wt1 = network.getSubstation("SUBSTATION").newTwoWindingsTransformer()
+                .setId("T2wT1")
+                .setVoltageLevel1("VL_2")
+                .setVoltageLevel2("VL_3")
+                .setRatedU1(132.0)
+                .setRatedU2(33.0)
+                .setR(17.0)
+                .setX(10.0)
+                .setG(0.00573921028466483)
+                .setB(0.000573921028466483)
+                .setBus1("BUS_2")
+                .setBus2("BUS_3")
+                .add();
+
+        t2wt1.newRatioTapChanger()
+                .beginStep()
+                .setRho(0.9)
+                .setR(0.1089)
+                .setX(0.01089)
+                .setG(0.8264462809917356)
+                .setB(0.08264462809917356)
+                .endStep()
+                .beginStep()
+                .setRho(1.0)
+                .setR(0.121)
+                .setX(0.0121)
+                .setG(0.8264462809917356)
+                .setB(0.08264462809917356)
+                .endStep()
+                .beginStep()
+                .setRho(1.05)
+                .setR(0.1331)
+                .setX(0.01331)
+                .setG(0.9090909090909092)
+                .setB(0.09090909090909092)
+                .endStep()
+                .beginStep()
+                .setRho(1.1)
+                .setR(0.1331)
+                .setX(0.01331)
+                .setG(0.9090909090909092)
+                .setB(0.09090909090909092)
+                .endStep()
+                .setTapPosition(0)
+                .setLoadTapChangingCapabilities(true)
+                .setRegulating(false)
+                .setTargetV(33.0)
+                .setRegulationTerminal(network.getLoad("LOAD_3").getTerminal())
+                .add();
+
+        TwoWindingsTransformer t2wt2 = network.getSubstation("SUBSTATION").newTwoWindingsTransformer()
+                .setId("T2wT2")
+                .setVoltageLevel1("VL_4")
+                .setVoltageLevel2("VL_3")
+                .setRatedU1(132.0)
+                .setRatedU2(33.0)
+                .setR(17.0)
+                .setX(10.0)
+                .setG(0.00573921028466483)
+                .setB(0.000573921028466483)
+                .setBus1("BUS_4")
+                .setBus2("BUS_3")
+                .add();
+
+        t2wt2.newRatioTapChanger()
                 .beginStep()
                 .setRho(0.9)
                 .setR(0.1089)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

Not exactly, but the transformer voltage control is a complexe feature. We already have two outerloops, but in some cases, it leads to a divergence or a KLU issue. So, we have decided to try an incremental outerloop.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

We add an incremental outerloop. For the moment, at the first resolution, the transformer voltage controls are disabled. The outerloop looks like:
- At each controlled bus, we check if voltage is higher or lower than the target value ;
- If yes, the compute the sensitivity of a rho increase on the controlled bus. Depending on the sign, we move the tap +1 or -1 ;
- We recompute a LF. 

NB:
- Shared controls are not handle ;
- Stopping criteria?

**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
