### PR TITLE
Cache main connected component in EvenShiloach connectivity

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/graph/EvenShiloachGraphDecrementalConnectivity.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/EvenShiloachGraphDecrementalConnectivity.java
@@ -36,6 +36,7 @@ public class EvenShiloachGraphDecrementalConnectivity<V, E> implements GraphDecr
 
     private final List<Set<V>> newConnectedComponents;
     private final Map<V, LevelNeighbours> levelNeighboursMap;
+    private Set<V> mainConnectedComponent;
 
     private final List<Triple<V, E, V>> cutEdges;
     private final List<E> edgesToCut;
@@ -83,7 +84,7 @@ public class EvenShiloachGraphDecrementalConnectivity<V, E> implements GraphDecr
         cutEdges.clear();
         edgesToCut.clear();
         newConnectedComponents.clear();
-        invalidateVertexMapCache();
+        invalidateConnectedComponentCache();
     }
 
     @Override
@@ -94,12 +95,13 @@ public class EvenShiloachGraphDecrementalConnectivity<V, E> implements GraphDecr
         if (edgesToCut.contains(edge)) {
             throw new PowsyblException("Edge already cut: " + edge);
         }
-        invalidateVertexMapCache();
+        invalidateConnectedComponentCache();
 
         edgesToCut.add(edge);
     }
 
-    private void invalidateVertexMapCache() {
+    private void invalidateConnectedComponentCache() {
+        mainConnectedComponent = null;
         vertexMapCacheInvalidated = true;
         vertexToConnectedComponent.clear();
     }
@@ -120,7 +122,7 @@ public class EvenShiloachGraphDecrementalConnectivity<V, E> implements GraphDecr
     }
 
     public void reset() {
-        invalidateVertexMapCache();
+        invalidateConnectedComponentCache();
         newConnectedComponents.clear();
         allSavedChangedLevels.descendingIterator().forEachRemaining(levelNeighboursMap::putAll);
         allSavedChangedLevels.clear();
@@ -155,7 +157,10 @@ public class EvenShiloachGraphDecrementalConnectivity<V, E> implements GraphDecr
     }
 
     private Set<V> getMainConnectedComponent() {
-        return vertices.stream().filter(v -> newConnectedComponents.stream().noneMatch(cc -> cc.contains(v))).collect(Collectors.toSet());
+        if (mainConnectedComponent == null) {
+            mainConnectedComponent = vertices.stream().filter(v -> newConnectedComponents.stream().noneMatch(cc -> cc.contains(v))).collect(Collectors.toSet());
+        }
+        return mainConnectedComponent;
     }
 
     @Override


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?**
Bug fix / feature



**What is the current behavior?** *(You can also link to an open issue here)*
Main connected component not cached in EvenShiloach implementation of GraphDecrementalConnectivity


**What is the new behavior (if this is a feature change)?**
Main connected cached lazily in EvenShiloach implementation of GraphDecrementalConnectivity



**Does this PR introduce a breaking change or deprecate an API?** 
No