### PR TITLE
Loops in Even-Shiloach GraphDecrementalConnectivity

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/graph/EvenShiloachGraphDecrementalConnectivity.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/EvenShiloachGraphDecrementalConnectivity.java
@@ -69,11 +69,7 @@ public class EvenShiloachGraphDecrementalConnectivity<V, E> implements GraphDecr
     public void addEdge(V vertex1, V vertex2, E edge) {
         Objects.requireNonNull(vertex1);
         Objects.requireNonNull(vertex2);
-        if (vertex1 != vertex2) {
-            graph.addEdge(vertex1, vertex2, edge);
-        } else {
-            LOGGER.warn("Loop on vertex {}: problem in input graph", vertex1);
-        }
+        graph.addEdge(vertex1, vertex2, edge);
         invalidateInit();
     }
 

--- a/src/test/java/com/powsybl/openloadflow/graph/ConnectivityTest.java
+++ b/src/test/java/com/powsybl/openloadflow/graph/ConnectivityTest.java
@@ -6,211 +6,35 @@
  */
 package com.powsybl.openloadflow.graph;
 
-import com.powsybl.commons.PowsyblException;
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.test.BatteryNetworkFactory;
-import com.powsybl.openloadflow.network.*;
-import com.powsybl.openloadflow.network.impl.Networks;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Gaël Macherel <gael.macherel at artelys.com>
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
 class ConnectivityTest {
 
-    private LfNetwork lfNetwork;
-
-    @BeforeEach
-    void setup() {
-        Network network = ConnectedComponentNetworkFactory.createThreeCcLinkedByASingleBus();
-        List<LfNetwork> lfNetworks = Networks.load(network, new FirstSlackBusSelector());
-        lfNetwork = lfNetworks.get(0);
-    }
-
     @Test
-    void testConnectivity() {
-        testConnectivity(new NaiveGraphDecrementalConnectivity<>(LfBus::getNum));
-        testConnectivity(new EvenShiloachGraphDecrementalConnectivity<>());
-    }
-
-    @Test
-    void testReducedMainComponent() {
-        // Testing the connectivity when the main component is suffering cuts so that it becomes smaller than a newly
-        // created connected component.
-        testReducedMainComponent(new NaiveGraphDecrementalConnectivity<>(LfBus::getNum));
-        testReducedMainComponent(new EvenShiloachGraphDecrementalConnectivity<>());
-    }
-
-    @Test
-    void testReaddEdge() {
-        // Testing cutting an edge then adding it back
-        testReaddEdge(new NaiveGraphDecrementalConnectivity<>(LfBus::getNum));
-        testReaddEdge(new EvenShiloachGraphDecrementalConnectivity<>());
-    }
-
-    @Test
-    void testDoubleCut() {
-        // Testing cutting twice an edge
-        testDoubleCut(new NaiveGraphDecrementalConnectivity<>(LfBus::getNum));
-        testDoubleCut(new EvenShiloachGraphDecrementalConnectivity<>());
-        testDoubleCut(new MinimumSpanningTreeGraphDecrementalConnectivity<>());
-    }
-
-    @Test
-    void testUnknownCut() {
-        // Testing cutting unknown edge
-        Network otherNetwork = BatteryNetworkFactory.create();
-        LfNetwork otherLfNetwork = Networks.load(otherNetwork, new FirstSlackBusSelector()).get(0);
-        LfBranch otherNetworkBranch = otherLfNetwork.getBranchById("NHV1_NHV2_1");
-
-        testUnknownCut(new NaiveGraphDecrementalConnectivity<>(LfBus::getNum), otherNetworkBranch);
-        testUnknownCut(new EvenShiloachGraphDecrementalConnectivity<>(), otherNetworkBranch);
-        testUnknownCut(new MinimumSpanningTreeGraphDecrementalConnectivity<>(), otherNetworkBranch);
-    }
-
-    @Test
-    void testNonConnected() {
-        // Testing with a non-connected graph
-        GraphDecrementalConnectivity<LfBus, LfBranch> connectivity = new EvenShiloachGraphDecrementalConnectivity<>();
-        for (LfBus lfBus : lfNetwork.getBuses()) {
-            connectivity.addVertex(lfBus);
-        }
-        for (LfBranch lfBranch : lfNetwork.getBranches()) {
-            if (!lfBranch.getId().equals("l48")) {
-                connectivity.addEdge(lfBranch.getBus1(), lfBranch.getBus2(), lfBranch);
-            }
-        }
-        PowsyblException e = assertThrows(PowsyblException.class, connectivity::getSmallComponents);
-        assertEquals("Algorithm not implemented for a network with several connected components at start", e.getMessage());
-    }
-
-    @Test
-    void testNonConnectedComponents() {
-        testNonConnectedComponents(new NaiveGraphDecrementalConnectivity<>(LfBus::getNum));
-        testNonConnectedComponents(new EvenShiloachGraphDecrementalConnectivity<>());
-        testNonConnectedComponents(new MinimumSpanningTreeGraphDecrementalConnectivity<>());
-    }
-
-    @Test
-    void testConnectedComponents() {
-        testConnectedComponents(new NaiveGraphDecrementalConnectivity<>(LfBus::getNum));
-        testConnectedComponents(new EvenShiloachGraphDecrementalConnectivity<>());
-        testConnectedComponents(new MinimumSpanningTreeGraphDecrementalConnectivity<>());
-    }
-
-    private void testConnectivity(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
-        updateConnectivity(connectivity);
-        cutBranches(connectivity, "l34", "l48");
-
-        assertEquals(1, connectivity.getComponentNumber(lfNetwork.getBusById("b3_vl_0")));
-        assertEquals(0, connectivity.getComponentNumber(lfNetwork.getBusById("b4_vl_0")));
-        assertEquals(2, connectivity.getComponentNumber(lfNetwork.getBusById("b8_vl_0")));
-        assertEquals(2, connectivity.getSmallComponents().size());
-
-        AssertionError e = assertThrows(AssertionError.class, () -> connectivity.getComponentNumber(null));
-        assertEquals("given vertex null is not in the graph", e.getMessage());
-    }
-
-    private void testReducedMainComponent(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
-        updateConnectivity(connectivity);
-        cutBranches(connectivity, "l34", "l48", "l56", "l57", "l67");
-
-        assertEquals(0, connectivity.getComponentNumber(lfNetwork.getBusById("b3_vl_0")));
-        assertEquals(2, connectivity.getComponentNumber(lfNetwork.getBusById("b4_vl_0")));
-        assertEquals(1, connectivity.getComponentNumber(lfNetwork.getBusById("b8_vl_0")));
-        assertEquals(4, connectivity.getSmallComponents().size());
-    }
-
-    private void testReaddEdge(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
-        updateConnectivity(connectivity);
-
-        String branchId = "l34";
-        LfBranch lfBranch = lfNetwork.getBranchById(branchId);
-        cutBranches(connectivity, branchId);
-
-        assertEquals(1, connectivity.getSmallComponents().size());
-        assertEquals(1, connectivity.getComponentNumber(lfNetwork.getBusById("b1_vl_0")));
-        assertEquals(0, connectivity.getComponentNumber(lfNetwork.getBusById("b8_vl_0")));
-
-        connectivity.addEdge(lfBranch.getBus1(), lfBranch.getBus2(), lfBranch);
-        assertEquals(0, connectivity.getSmallComponents().size());
-        assertEquals(0, connectivity.getComponentNumber(lfNetwork.getBusById("b1_vl_0")));
-        assertEquals(0, connectivity.getComponentNumber(lfNetwork.getBusById("b8_vl_0")));
-
-        cutBranches(connectivity, "l48");
-        assertEquals(1, connectivity.getSmallComponents().size());
-        assertEquals(0, connectivity.getComponentNumber(lfNetwork.getBusById("b4_vl_0")));
-        assertEquals(1, connectivity.getComponentNumber(lfNetwork.getBusById("b8_vl_0")));
-    }
-
-    private void testDoubleCut(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
-        updateConnectivity(connectivity);
-
-        PowsyblException e = assertThrows(PowsyblException.class, () -> cutBranches(connectivity, "l34", "l48", "l34"));
-        assertEquals("Edge already cut: l34", e.getMessage());
-    }
-
-    private void testUnknownCut(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity, LfBranch unknownBranch) {
-        updateConnectivity(connectivity);
-
-        PowsyblException e = assertThrows(PowsyblException.class, () -> connectivity.cut(unknownBranch));
-        assertEquals("No such edge in graph: NHV1_NHV2_1", e.getMessage());
-    }
-
-    private void testNonConnectedComponents(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
-        updateConnectivity(connectivity);
-        cutBranches(connectivity, "l34", "l48");
-
-        assertEquals(createVerticesSet("b4_vl_0", "b5_vl_0", "b6_vl_0", "b7_vl_0", "b8_vl_0", "b9_vl_0", "b10_vl_0"),
-            connectivity.getNonConnectedVertices(lfNetwork.getBusById("b3_vl_0")));
-        assertEquals(createVerticesSet("b1_vl_0", "b2_vl_0", "b3_vl_0", "b8_vl_0", "b9_vl_0", "b10_vl_0"),
-            connectivity.getNonConnectedVertices(lfNetwork.getBusById("b6_vl_0")));
-        assertEquals(createVerticesSet("b4_vl_0", "b5_vl_0", "b6_vl_0", "b7_vl_0", "b1_vl_0", "b2_vl_0", "b3_vl_0"),
-            connectivity.getNonConnectedVertices(lfNetwork.getBusById("b10_vl_0")));
-
-        AssertionError e = assertThrows(AssertionError.class, () -> connectivity.getNonConnectedVertices(null));
-        assertEquals("given vertex null is not in the graph", e.getMessage());
-    }
-
-    private void testConnectedComponents(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
-        updateConnectivity(connectivity);
-        cutBranches(connectivity, "l34", "l56", "l57");
-
-        assertEquals(createVerticesSet("b1_vl_0", "b2_vl_0", "b3_vl_0"),
-            connectivity.getConnectedComponent(lfNetwork.getBusById("b3_vl_0")));
-        assertEquals(createVerticesSet("b6_vl_0", "b7_vl_0"),
-            connectivity.getConnectedComponent(lfNetwork.getBusById("b6_vl_0")));
-        assertEquals(createVerticesSet("b4_vl_0", "b5_vl_0", "b8_vl_0", "b9_vl_0", "b10_vl_0"),
-            connectivity.getConnectedComponent(lfNetwork.getBusById("b10_vl_0")));
-
-        AssertionError e = assertThrows(AssertionError.class, () -> connectivity.getConnectedComponent(null));
-        assertEquals("given vertex null is not in the graph", e.getMessage());
-    }
-
-    private void cutBranches(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity, String... branches) {
-        Arrays.stream(branches).map(lfNetwork::getBranchById).forEach(connectivity::cut);
-    }
-
-    private void updateConnectivity(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
-        for (LfBus lfBus : lfNetwork.getBuses()) {
-            connectivity.addVertex(lfBus);
-        }
-        for (LfBranch lfBranch : lfNetwork.getBranches()) {
-            connectivity.addEdge(lfBranch.getBus1(), lfBranch.getBus2(), lfBranch);
-        }
-    }
-
-    private Set<LfBus> createVerticesSet(String... busIds) {
-        return Arrays.stream(busIds).map(lfNetwork::getBusById).collect(Collectors.toSet());
+    public void circleTest() {
+        GraphDecrementalConnectivity<String, String> dc = new EvenShiloachGraphDecrementalConnectivity<>();
+        String o1 = "1";
+        String o2 = "2";
+        String o3 = "3";
+        String o4 = "4";
+        String e12 = "1-2";
+        String e23 = "2-3";
+        String e34 = "3-4";
+        String e41 = "4-1";
+        dc.addVertex(o1);
+        dc.addVertex(o2);
+        dc.addVertex(o3);
+        dc.addVertex(o4);
+        dc.addEdge(o1, o2, e12);
+        dc.addEdge(o2, o3, e23);
+        dc.addEdge(o3, o4, e34);
+        dc.addEdge(o4, o1, e41);
+        dc.cut(e12);
+        assertTrue(dc.getSmallComponents().isEmpty());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/graph/ConnectivityTest.java
+++ b/src/test/java/com/powsybl/openloadflow/graph/ConnectivityTest.java
@@ -8,6 +8,7 @@ package com.powsybl.openloadflow.graph;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -36,5 +37,34 @@ class ConnectivityTest {
         dc.addEdge(o4, o1, e41);
         dc.cut(e12);
         assertTrue(dc.getSmallComponents().isEmpty());
+    }
+
+    @Test
+    public void loopCircleTest() {
+        GraphDecrementalConnectivity<String, String> dc = new EvenShiloachGraphDecrementalConnectivity<>();
+        String o1 = "1";
+        String o2 = "2";
+        String o3 = "3";
+        String e11 = "1-1";
+        String e12 = "1-2";
+        String e23 = "2-3";
+        String e31 = "3-1";
+        dc.addVertex(o1);
+        dc.addVertex(o2);
+        dc.addVertex(o3);
+        dc.addEdge(o1, o1, e11);
+        dc.addEdge(o1, o2, e12);
+        dc.addEdge(o2, o3, e23);
+        dc.addEdge(o3, o1, e31);
+
+        dc.cut(e11);
+        assertTrue(dc.getSmallComponents().isEmpty());
+
+        dc.reset();
+        dc.cut(e12);
+        assertTrue(dc.getSmallComponents().isEmpty());
+
+        dc.cut(e31);
+        assertFalse(dc.getSmallComponents().isEmpty());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/graph/NetworkConnectivityTest.java
+++ b/src/test/java/com/powsybl/openloadflow/graph/NetworkConnectivityTest.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.graph;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.BatteryNetworkFactory;
+import com.powsybl.openloadflow.network.*;
+import com.powsybl.openloadflow.network.impl.Networks;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author Gaël Macherel <gael.macherel at artelys.com>
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+class NetworkConnectivityTest {
+
+    private LfNetwork lfNetwork;
+
+    @BeforeEach
+    void setup() {
+        Network network = ConnectedComponentNetworkFactory.createThreeCcLinkedByASingleBus();
+        List<LfNetwork> lfNetworks = Networks.load(network, new FirstSlackBusSelector());
+        lfNetwork = lfNetworks.get(0);
+    }
+
+    @Test
+    void testConnectivity() {
+        testConnectivity(new NaiveGraphDecrementalConnectivity<>(LfBus::getNum));
+        testConnectivity(new EvenShiloachGraphDecrementalConnectivity<>());
+    }
+
+    @Test
+    void testReducedMainComponent() {
+        // Testing the connectivity when the main component is suffering cuts so that it becomes smaller than a newly
+        // created connected component.
+        testReducedMainComponent(new NaiveGraphDecrementalConnectivity<>(LfBus::getNum));
+        testReducedMainComponent(new EvenShiloachGraphDecrementalConnectivity<>());
+    }
+
+    @Test
+    void testReaddEdge() {
+        // Testing cutting an edge then adding it back
+        testReaddEdge(new NaiveGraphDecrementalConnectivity<>(LfBus::getNum));
+        testReaddEdge(new EvenShiloachGraphDecrementalConnectivity<>());
+    }
+
+    @Test
+    void testDoubleCut() {
+        // Testing cutting twice an edge
+        testDoubleCut(new NaiveGraphDecrementalConnectivity<>(LfBus::getNum));
+        testDoubleCut(new EvenShiloachGraphDecrementalConnectivity<>());
+        testDoubleCut(new MinimumSpanningTreeGraphDecrementalConnectivity<>());
+    }
+
+    @Test
+    void testUnknownCut() {
+        // Testing cutting unknown edge
+        Network otherNetwork = BatteryNetworkFactory.create();
+        LfNetwork otherLfNetwork = Networks.load(otherNetwork, new FirstSlackBusSelector()).get(0);
+        LfBranch otherNetworkBranch = otherLfNetwork.getBranchById("NHV1_NHV2_1");
+
+        testUnknownCut(new NaiveGraphDecrementalConnectivity<>(LfBus::getNum), otherNetworkBranch);
+        testUnknownCut(new EvenShiloachGraphDecrementalConnectivity<>(), otherNetworkBranch);
+        testUnknownCut(new MinimumSpanningTreeGraphDecrementalConnectivity<>(), otherNetworkBranch);
+    }
+
+    @Test
+    void testNonConnected() {
+        // Testing with a non-connected graph
+        GraphDecrementalConnectivity<LfBus, LfBranch> connectivity = new EvenShiloachGraphDecrementalConnectivity<>();
+        for (LfBus lfBus : lfNetwork.getBuses()) {
+            connectivity.addVertex(lfBus);
+        }
+        for (LfBranch lfBranch : lfNetwork.getBranches()) {
+            if (!lfBranch.getId().equals("l48")) {
+                connectivity.addEdge(lfBranch.getBus1(), lfBranch.getBus2(), lfBranch);
+            }
+        }
+        PowsyblException e = assertThrows(PowsyblException.class, connectivity::getSmallComponents);
+        assertEquals("Algorithm not implemented for a network with several connected components at start", e.getMessage());
+    }
+
+    @Test
+    void testNonConnectedComponents() {
+        testNonConnectedComponents(new NaiveGraphDecrementalConnectivity<>(LfBus::getNum));
+        testNonConnectedComponents(new EvenShiloachGraphDecrementalConnectivity<>());
+        testNonConnectedComponents(new MinimumSpanningTreeGraphDecrementalConnectivity<>());
+    }
+
+    @Test
+    void testConnectedComponents() {
+        testConnectedComponents(new NaiveGraphDecrementalConnectivity<>(LfBus::getNum));
+        testConnectedComponents(new EvenShiloachGraphDecrementalConnectivity<>());
+        testConnectedComponents(new MinimumSpanningTreeGraphDecrementalConnectivity<>());
+    }
+
+    private void testConnectivity(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
+        updateConnectivity(connectivity);
+        cutBranches(connectivity, "l34", "l48");
+
+        assertEquals(1, connectivity.getComponentNumber(lfNetwork.getBusById("b3_vl_0")));
+        assertEquals(0, connectivity.getComponentNumber(lfNetwork.getBusById("b4_vl_0")));
+        assertEquals(2, connectivity.getComponentNumber(lfNetwork.getBusById("b8_vl_0")));
+        assertEquals(2, connectivity.getSmallComponents().size());
+
+        AssertionError e = assertThrows(AssertionError.class, () -> connectivity.getComponentNumber(null));
+        assertEquals("given vertex null is not in the graph", e.getMessage());
+    }
+
+    private void testReducedMainComponent(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
+        updateConnectivity(connectivity);
+        cutBranches(connectivity, "l34", "l48", "l56", "l57", "l67");
+
+        assertEquals(0, connectivity.getComponentNumber(lfNetwork.getBusById("b3_vl_0")));
+        assertEquals(2, connectivity.getComponentNumber(lfNetwork.getBusById("b4_vl_0")));
+        assertEquals(1, connectivity.getComponentNumber(lfNetwork.getBusById("b8_vl_0")));
+        assertEquals(4, connectivity.getSmallComponents().size());
+    }
+
+    private void testReaddEdge(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
+        updateConnectivity(connectivity);
+
+        String branchId = "l34";
+        LfBranch lfBranch = lfNetwork.getBranchById(branchId);
+        cutBranches(connectivity, branchId);
+
+        assertEquals(1, connectivity.getSmallComponents().size());
+        assertEquals(1, connectivity.getComponentNumber(lfNetwork.getBusById("b1_vl_0")));
+        assertEquals(0, connectivity.getComponentNumber(lfNetwork.getBusById("b8_vl_0")));
+
+        connectivity.addEdge(lfBranch.getBus1(), lfBranch.getBus2(), lfBranch);
+        assertEquals(0, connectivity.getSmallComponents().size());
+        assertEquals(0, connectivity.getComponentNumber(lfNetwork.getBusById("b1_vl_0")));
+        assertEquals(0, connectivity.getComponentNumber(lfNetwork.getBusById("b8_vl_0")));
+
+        cutBranches(connectivity, "l48");
+        assertEquals(1, connectivity.getSmallComponents().size());
+        assertEquals(0, connectivity.getComponentNumber(lfNetwork.getBusById("b4_vl_0")));
+        assertEquals(1, connectivity.getComponentNumber(lfNetwork.getBusById("b8_vl_0")));
+    }
+
+    private void testDoubleCut(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
+        updateConnectivity(connectivity);
+
+        PowsyblException e = assertThrows(PowsyblException.class, () -> cutBranches(connectivity, "l34", "l48", "l34"));
+        assertEquals("Edge already cut: l34", e.getMessage());
+    }
+
+    private void testUnknownCut(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity, LfBranch unknownBranch) {
+        updateConnectivity(connectivity);
+
+        PowsyblException e = assertThrows(PowsyblException.class, () -> connectivity.cut(unknownBranch));
+        assertEquals("No such edge in graph: NHV1_NHV2_1", e.getMessage());
+    }
+
+    private void testNonConnectedComponents(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
+        updateConnectivity(connectivity);
+        cutBranches(connectivity, "l34", "l48");
+
+        assertEquals(createVerticesSet("b4_vl_0", "b5_vl_0", "b6_vl_0", "b7_vl_0", "b8_vl_0", "b9_vl_0", "b10_vl_0"),
+            connectivity.getNonConnectedVertices(lfNetwork.getBusById("b3_vl_0")));
+        assertEquals(createVerticesSet("b1_vl_0", "b2_vl_0", "b3_vl_0", "b8_vl_0", "b9_vl_0", "b10_vl_0"),
+            connectivity.getNonConnectedVertices(lfNetwork.getBusById("b6_vl_0")));
+        assertEquals(createVerticesSet("b4_vl_0", "b5_vl_0", "b6_vl_0", "b7_vl_0", "b1_vl_0", "b2_vl_0", "b3_vl_0"),
+            connectivity.getNonConnectedVertices(lfNetwork.getBusById("b10_vl_0")));
+
+        AssertionError e = assertThrows(AssertionError.class, () -> connectivity.getNonConnectedVertices(null));
+        assertEquals("given vertex null is not in the graph", e.getMessage());
+    }
+
+    private void testConnectedComponents(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
+        updateConnectivity(connectivity);
+        cutBranches(connectivity, "l34", "l56", "l57");
+
+        assertEquals(createVerticesSet("b1_vl_0", "b2_vl_0", "b3_vl_0"),
+            connectivity.getConnectedComponent(lfNetwork.getBusById("b3_vl_0")));
+        assertEquals(createVerticesSet("b6_vl_0", "b7_vl_0"),
+            connectivity.getConnectedComponent(lfNetwork.getBusById("b6_vl_0")));
+        assertEquals(createVerticesSet("b4_vl_0", "b5_vl_0", "b8_vl_0", "b9_vl_0", "b10_vl_0"),
+            connectivity.getConnectedComponent(lfNetwork.getBusById("b10_vl_0")));
+
+        AssertionError e = assertThrows(AssertionError.class, () -> connectivity.getConnectedComponent(null));
+        assertEquals("given vertex null is not in the graph", e.getMessage());
+    }
+
+    private void cutBranches(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity, String... branches) {
+        Arrays.stream(branches).map(lfNetwork::getBranchById).forEach(connectivity::cut);
+    }
+
+    private void updateConnectivity(GraphDecrementalConnectivity<LfBus, LfBranch> connectivity) {
+        for (LfBus lfBus : lfNetwork.getBuses()) {
+            connectivity.addVertex(lfBus);
+        }
+        for (LfBranch lfBranch : lfNetwork.getBranches()) {
+            connectivity.addEdge(lfBranch.getBus1(), lfBranch.getBus2(), lfBranch);
+        }
+    }
+
+    private Set<LfBus> createVerticesSet(String... busIds) {
+        return Arrays.stream(busIds).map(lfNetwork::getBusById).collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?**
Refactor


**What is the current behavior?**
Loops are not accepted, whereas the algorithm could.


**What is the new behavior (if this is a feature change)?**
Loops are accepted and the algorithm is slightly changed
- to have it more understandable
- when a loop is cut, to make it detect it from the start oft the process A that both traversers start at the same vertex


**Does this PR introduce a breaking change or deprecate an API?**
No