### PR TITLE
Replace p0 and q0 of batteries by targetP and targetQ

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBatteryImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBatteryImpl.java
@@ -26,7 +26,7 @@ public final class LfBatteryImpl extends AbstractLfGenerator {
     private double droop;
 
     private LfBatteryImpl(Battery battery, double plausibleActivePowerLimit, LfNetworkLoadingReport report) {
-        super(battery.getP0());
+        super(battery.getTargetP());
         this.battery = battery;
         participating = true;
         droop = DEFAULT_DROOP;
@@ -39,7 +39,7 @@ public final class LfBatteryImpl extends AbstractLfGenerator {
             }
         }
 
-        if (!checkActivePowerControl(battery.getP0(), battery.getMinP(), battery.getMaxP(), plausibleActivePowerLimit, report)) {
+        if (!checkActivePowerControl(battery.getTargetP(), battery.getMinP(), battery.getMaxP(), plausibleActivePowerLimit, report)) {
             participating = false;
         }
     }
@@ -57,7 +57,7 @@ public final class LfBatteryImpl extends AbstractLfGenerator {
 
     @Override
     public double getTargetQ() {
-        return battery.getQ0() / PerUnit.SB;
+        return battery.getTargetQ() / PerUnit.SB;
     }
 
     @Override
@@ -94,6 +94,6 @@ public final class LfBatteryImpl extends AbstractLfGenerator {
     public void updateState() {
         battery.getTerminal()
                 .setP(-targetP)
-                .setQ(-battery.getQ0());
+                .setQ(-battery.getTargetQ());
     }
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Technical debt


**What is the current behavior?** *(You can also link to an open issue here)*
We still use deprecated p0 and q0 for batteries.


**What is the new behavior (if this is a feature change)?**
We now use new methods targetP and targetQ


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
