### PR TITLE
Same provider name for LF, SA and Sensi

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
@@ -38,6 +38,7 @@ import com.powsybl.openloadflow.network.impl.Networks;
 import com.powsybl.openloadflow.util.Markers;
 import com.powsybl.openloadflow.util.PerUnit;
 import com.powsybl.openloadflow.util.PowsyblOpenLoadFlowVersion;
+import com.powsybl.openloadflow.util.ProviderConstants;
 import com.powsybl.tools.PowsyblCoreVersion;
 import net.jafama.FastMath;
 import org.slf4j.Logger;
@@ -55,8 +56,6 @@ import java.util.stream.Collectors;
 public class OpenLoadFlowProvider implements LoadFlowProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenLoadFlowProvider.class);
-
-    public static final String NAME = "OpenLoadFlow";
 
     private final MatrixFactory matrixFactory;
 
@@ -83,7 +82,7 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
 
     @Override
     public String getName() {
-        return NAME;
+        return ProviderConstants.NAME;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProvider.java
@@ -16,12 +16,12 @@ import com.powsybl.contingency.ContingenciesProvider;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.math.matrix.MatrixFactory;
 import com.powsybl.math.matrix.SparseMatrixFactory;
-import com.powsybl.openloadflow.OpenLoadFlowProvider;
 import com.powsybl.openloadflow.graph.EvenShiloachGraphDecrementalConnectivityFactory;
 import com.powsybl.openloadflow.graph.GraphDecrementalConnectivityFactory;
 import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.util.PowsyblOpenLoadFlowVersion;
+import com.powsybl.openloadflow.util.ProviderConstants;
 import com.powsybl.security.*;
 import com.powsybl.security.interceptors.SecurityAnalysisInterceptor;
 import com.powsybl.security.monitor.StateMonitor;
@@ -80,7 +80,7 @@ public class OpenSecurityAnalysisProvider implements SecurityAnalysisProvider {
 
     @Override
     public String getName() {
-        return "OpenSecurityAnalysis";
+        return ProviderConstants.NAME;
     }
 
     @Override
@@ -90,7 +90,7 @@ public class OpenSecurityAnalysisProvider implements SecurityAnalysisProvider {
 
     @Override
     public Optional<String> getLoadFlowProviderName() {
-        return Optional.of(OpenLoadFlowProvider.NAME);
+        return Optional.of(ProviderConstants.NAME);
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProvider.java
@@ -29,12 +29,12 @@ import com.powsybl.loadflow.json.LoadFlowParametersJsonModule;
 import com.powsybl.math.matrix.MatrixFactory;
 import com.powsybl.math.matrix.SparseMatrixFactory;
 import com.powsybl.openloadflow.OpenLoadFlowParameters;
-import com.powsybl.openloadflow.OpenLoadFlowProvider;
 import com.powsybl.openloadflow.graph.EvenShiloachGraphDecrementalConnectivityFactory;
 import com.powsybl.openloadflow.graph.GraphDecrementalConnectivityFactory;
 import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.network.impl.PropagatedContingency;
+import com.powsybl.openloadflow.util.ProviderConstants;
 import com.powsybl.sensitivity.*;
 import com.powsybl.sensitivity.json.SensitivityJsonModule;
 import com.powsybl.tools.PowsyblCoreVersion;
@@ -59,8 +59,6 @@ import java.util.concurrent.CompletableFuture;
 @AutoService(SensitivityAnalysisProvider.class)
 public class OpenSensitivityAnalysisProvider implements SensitivityAnalysisProvider {
 
-    private static final String NAME = "OpenSensitivityAnalysis";
-
     public static final String DATE_TIME_FORMAT = "yyyy-dd-M--HH-mm-ss-SSS";
 
     private final DcSensitivityAnalysis dcSensitivityAnalysis;
@@ -82,7 +80,7 @@ public class OpenSensitivityAnalysisProvider implements SensitivityAnalysisProvi
 
     @Override
     public String getName() {
-        return NAME;
+        return ProviderConstants.NAME;
     }
 
     @Override
@@ -92,7 +90,7 @@ public class OpenSensitivityAnalysisProvider implements SensitivityAnalysisProvi
 
     @Override
     public Optional<String> getLoadFlowProviderName() {
-        return Optional.of(OpenLoadFlowProvider.NAME);
+        return Optional.of(ProviderConstants.NAME);
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/util/ProviderConstants.java
+++ b/src/main/java/com/powsybl/openloadflow/util/ProviderConstants.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.util;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public final class ProviderConstants {
+
+    private ProviderConstants() {
+    }
+
+    public static final String NAME = "OpenLoadFlow";
+}

--- a/src/test/java/com/powsybl/openloadflow/OpenLoadFlowProviderTest.java
+++ b/src/test/java/com/powsybl/openloadflow/OpenLoadFlowProviderTest.java
@@ -23,6 +23,7 @@ import com.powsybl.openloadflow.network.SlackBusSelectionMode;
 import com.powsybl.openloadflow.network.util.PreviousValueVoltageInitializer;
 import com.powsybl.openloadflow.network.util.UniformValueVoltageInitializer;
 import com.powsybl.openloadflow.network.util.VoltageInitializer;
+import com.powsybl.openloadflow.util.ProviderConstants;
 import com.powsybl.tools.PowsyblCoreVersion;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -41,7 +42,7 @@ class OpenLoadFlowProviderTest {
     @Test
     void test() {
         LoadFlowProvider loadFlowProvider = new OpenLoadFlowProvider(new DenseMatrixFactory());
-        assertEquals("OpenLoadFlow", loadFlowProvider.getName());
+        assertEquals(ProviderConstants.NAME, loadFlowProvider.getName());
         assertEquals(new PowsyblCoreVersion().getMavenProjectVersion(), loadFlowProvider.getVersion());
     }
 

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProviderTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProviderTest.java
@@ -9,6 +9,7 @@ package com.powsybl.openloadflow.sa;
 import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.config.InMemoryPlatformConfig;
 import com.powsybl.openloadflow.util.PowsyblOpenLoadFlowVersion;
+import com.powsybl.openloadflow.util.ProviderConstants;
 import com.powsybl.security.SecurityAnalysisParameters;
 import com.powsybl.security.json.JsonSecurityAnalysisParameters;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,9 +37,9 @@ class OpenSecurityAnalysisProviderTest extends AbstractConverterTest {
 
     @Test
     void basicTest() {
-        assertEquals("OpenSecurityAnalysis", provider.getName());
+        assertEquals(ProviderConstants.NAME, provider.getName());
         assertEquals(new PowsyblOpenLoadFlowVersion().toString(), provider.getVersion());
-        assertEquals("OpenLoadFlow", provider.getLoadFlowProviderName().orElseThrow());
+        assertEquals(ProviderConstants.NAME, provider.getLoadFlowProviderName().orElseThrow());
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProviderTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProviderTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.openloadflow.sensi;
 
 import com.powsybl.math.matrix.DenseMatrixFactory;
+import com.powsybl.openloadflow.util.ProviderConstants;
 import com.powsybl.sensitivity.SensitivityAnalysisParameters;
 import com.powsybl.tools.PowsyblCoreVersion;
 import org.junit.jupiter.api.Test;
@@ -25,9 +26,9 @@ class OpenSensitivityAnalysisProviderTest extends AbstractSensitivityAnalysisTes
     @Test
     void testGeneralInfos() {
         OpenSensitivityAnalysisProvider provider = new OpenSensitivityAnalysisProvider(new DenseMatrixFactory());
-        assertEquals("OpenSensitivityAnalysis", provider.getName());
+        assertEquals(ProviderConstants.NAME, provider.getName());
         assertEquals(new PowsyblCoreVersion().getMavenProjectVersion(), provider.getVersion());
-        assertEquals("OpenLoadFlow", provider.getLoadFlowProviderName().orElseThrow());
+        assertEquals(ProviderConstants.NAME, provider.getLoadFlowProviderName().orElseThrow());
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
We have 3 differents provider names: OpenLoadFlow, OpenSecurityAnalysis and OpenSensitivityAnalysis


**What is the new behavior (if this is a feature change)?**
All are OpenLoadFlow


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
