### PR TITLE
Light support of generators connected to the same bus but controlling different buses

### DIFF
--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
@@ -435,4 +435,23 @@ class AcLoadFlowEurostagTutorialExample1Test {
         assertEquals(-120, network.getGenerator("GEN").getTerminal().getQ());
         assertEquals(-160, network.getGenerator("GEN1").getTerminal().getQ(), 0.01);
     }
+
+    @Test
+    void testGeneratorsConnectedToSameBusNotControllingSameBus() {
+        var network = EurostagTutorialExample1Factory.create();
+        network.getVoltageLevel("VLGEN").newGenerator()
+                .setId("GEN2")
+                .setConnectableBus("NGEN")
+                .setBus("NGEN")
+                .setMinP(0)
+                .setMaxP(100)
+                .setTargetP(1)
+                .setVoltageRegulatorOn(true)
+                .setTargetV(148)
+                .setRegulatingTerminal(network.getLoad("LOAD").getTerminal())
+                .add();
+        loadFlowRunner.run(network);
+        assertVoltageEquals(24.5, network.getBusBreakerView().getBus("NGEN"));
+        assertVoltageEquals(147.57, network.getBusBreakerView().getBus("NLOAD"));
+    }
 }


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <anne.tilloy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

Yes, issue #552.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

We have removed the exception and log just an error. The first regulating terminal is kept (and the first targetV). 

**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
