### PR TITLE
Fix shunt compensator active power in DC mode

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -248,8 +248,8 @@ public class LfNetwork extends AbstractPropertyBag implements PropertyBag {
             for (LfGenerator generator : bus.getGenerators()) {
                 generator.updateState();
             }
-            bus.getShunt().ifPresent(LfShunt::updateState);
-            bus.getControllerShunt().ifPresent(LfShunt::updateState);
+            bus.getShunt().ifPresent(shunt -> shunt.updateState(dc));
+            bus.getControllerShunt().ifPresent(shunt -> shunt.updateState(dc));
         }
         for (LfBranch branch : branches) {
             branch.updateState(phaseShifterRegulationOn, transformerVoltageControlOn, dc);

--- a/src/main/java/com/powsybl/openloadflow/network/LfShunt.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfShunt.java
@@ -23,7 +23,7 @@ public interface LfShunt extends LfElement {
 
     void setG(double g);
 
-    void updateState();
+    void updateState(boolean dc);
 
     boolean hasVoltageControlCapability();
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfShuntImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfShuntImpl.java
@@ -241,19 +241,25 @@ public class LfShuntImpl extends AbstractElement implements LfShunt {
     }
 
     @Override
-    public void updateState() {
-        double vSquare = bus.getV() * bus.getV() * bus.getNominalV() * bus.getNominalV();
-        if (!voltageControlCapability) {
+    public void updateState(boolean dc) {
+        if (dc) {
             for (ShuntCompensator sc : shuntCompensators) {
-                sc.getTerminal().setP(sc.getG() * vSquare);
-                sc.getTerminal().setQ(-sc.getB() * vSquare);
+                sc.getTerminal().setP(0);
             }
         } else {
-            for (int i = 0; i < shuntCompensators.size(); i++) {
-                ShuntCompensator sc = shuntCompensators.get(i);
-                sc.getTerminal().setP(controllers.get(i).getG() * vSquare / zb);
-                sc.getTerminal().setQ(-controllers.get(i).getB() * vSquare / zb);
-                sc.setSectionCount(controllers.get(i).getPosition());
+            double vSquare = bus.getV() * bus.getV() * bus.getNominalV() * bus.getNominalV();
+            if (!voltageControlCapability) {
+                for (ShuntCompensator sc : shuntCompensators) {
+                    sc.getTerminal().setP(sc.getG() * vSquare);
+                    sc.getTerminal().setQ(-sc.getB() * vSquare);
+                }
+            } else {
+                for (int i = 0; i < shuntCompensators.size(); i++) {
+                    ShuntCompensator sc = shuntCompensators.get(i);
+                    sc.getTerminal().setP(controllers.get(i).getG() * vSquare / zb);
+                    sc.getTerminal().setQ(-controllers.get(i).getB() * vSquare / zb);
+                    sc.setSectionCount(controllers.get(i).getPosition());
+                }
             }
         }
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
@@ -53,7 +53,8 @@ public final class Networks {
                     .setQ(Double.NaN);
         }
         for (ShuntCompensator sc : network.getShuntCompensators()) {
-            sc.getTerminal().setQ(Double.NaN);
+            sc.getTerminal().setP(Double.NaN)
+                    .setQ(Double.NaN);
         }
         resetInjectionsState(network.getGenerators());
         resetInjectionsState(network.getStaticVarCompensators());

--- a/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowTest.java
@@ -244,4 +244,20 @@ class DcLoadFlowTest {
         assertEquals(2d, l13.getTerminal1().getP(), 0.01);
         assertEquals(-2d, l13.getTerminal2().getP(), 0.01);
     }
+
+    @Test
+    void shuntCompensatorActivePowerZero() {
+        Network network = EurostagTutorialExample1Factory.create();
+        var sc = network.getVoltageLevel("VLLOAD").newShuntCompensator()
+                .setId("SC")
+                .setBus("NLOAD")
+                .setSectionCount(1)
+                .newLinearModel()
+                    .setBPerSection(0.111)
+                    .setMaximumSectionCount(1)
+                .add()
+                .add();
+        loadFlowRunner.run(network, parameters);
+        LoadFlowAssert.assertActivePowerEquals(0, sc.getTerminal());
+    }
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
In DC mode, active power of shunt compensator is at NaN after calculation.


**What is the new behavior (if this is a feature change)?**
It should be zero.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
