### PR TITLE
Check NR state validity

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphson.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphson.java
@@ -179,20 +179,20 @@ public class NewtonRaphson {
         }
     }
 
-    private boolean checkSolutionValidity() {
-        List<String> busesOutOfNormalVoltageMagRange = new ArrayList<>();
+    private boolean isStateUnrealistic() {
+        List<String> busesOutOfNormalVoltageRange = new ArrayList<>();
         for (Variable<AcVariableType> v : equationSystem.getIndex().getSortedVariablesToFind()) {
             if (v.getType() == AcVariableType.BUS_V) {
                 double value = equationSystem.getStateVector().get(v.getRow());
-                if (value < 0.5 || value > 1.5) {
-                    busesOutOfNormalVoltageMagRange.add(network.getBus(v.getElementNum()).getId());
+                if (value < parameters.getMinRealisticVoltage() || value > parameters.getMaxRealisticVoltage()) {
+                    busesOutOfNormalVoltageRange.add(network.getBus(v.getElementNum()).getId());
                 }
             }
         }
-        if (!busesOutOfNormalVoltageMagRange.isEmpty()) {
-            LOGGER.warn("{} buses have a voltage magnitude out of range [0.5, 1.5]: {}", busesOutOfNormalVoltageMagRange.size(), busesOutOfNormalVoltageMagRange);
+        if (!busesOutOfNormalVoltageRange.isEmpty()) {
+            LOGGER.warn("{} buses have a voltage magnitude out of range [0.5, 1.5]: {}", busesOutOfNormalVoltageRange.size(), busesOutOfNormalVoltageRange);
         }
-        return !busesOutOfNormalVoltageMagRange.isEmpty();
+        return !busesOutOfNormalVoltageRange.isEmpty();
     }
 
     public NewtonRaphsonResult run(VoltageInitializer voltageInitializer) {
@@ -218,8 +218,8 @@ public class NewtonRaphson {
 
         // update network state variable
         if (status == NewtonRaphsonStatus.CONVERGED) {
-            if (checkSolutionValidity()) {
-                status = NewtonRaphsonStatus.INVALID_SOLUTION;
+            if (isStateUnrealistic()) {
+                status = NewtonRaphsonStatus.UNREALISTIC_STATE;
             }
 
             updateNetwork();

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphson.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphson.java
@@ -190,7 +190,8 @@ public class NewtonRaphson {
             }
         }
         if (!busesOutOfNormalVoltageRange.isEmpty()) {
-            LOGGER.warn("{} buses have a voltage magnitude out of range [0.5, 1.5]: {}", busesOutOfNormalVoltageRange.size(), busesOutOfNormalVoltageRange);
+            LOGGER.error("{} buses have a voltage magnitude out of range [{}, {}]: {}",
+                    busesOutOfNormalVoltageRange.size(), parameters.getMinRealisticVoltage(), parameters.getMaxRealisticVoltage(), busesOutOfNormalVoltageRange);
         }
         return !busesOutOfNormalVoltageRange.isEmpty();
     }

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonParameters.java
@@ -14,8 +14,14 @@ import java.util.Objects;
 public class NewtonRaphsonParameters {
 
     public static final int DEFAULT_MAX_ITERATION = 30;
+    public static final double DEFAULT_MIN_REALISTIC_VOLTAGE = 0.5;
+    public static final double DEFAULT_MAX_REALISTIC_VOLTAGE = 1.5;
 
     private int maxIteration = DEFAULT_MAX_ITERATION;
+
+    private double minRealisticVoltage = DEFAULT_MIN_REALISTIC_VOLTAGE;
+
+    private double maxRealisticVoltage = DEFAULT_MAX_REALISTIC_VOLTAGE;
 
     public int getMaxIteration() {
         return maxIteration;
@@ -35,6 +41,24 @@ public class NewtonRaphsonParameters {
         return this;
     }
 
+    public double getMinRealisticVoltage() {
+        return minRealisticVoltage;
+    }
+
+    public NewtonRaphsonParameters setMinRealisticVoltage(double minRealisticVoltage) {
+        this.minRealisticVoltage = minRealisticVoltage;
+        return this;
+    }
+
+    public double getMaxRealisticVoltage() {
+        return maxRealisticVoltage;
+    }
+
+    public NewtonRaphsonParameters setMaxRealisticVoltage(double maxRealisticVoltage) {
+        this.maxRealisticVoltage = maxRealisticVoltage;
+        return this;
+    }
+
     public NewtonRaphsonStoppingCriteria getStoppingCriteria() {
         return stoppingCriteria;
     }
@@ -48,6 +72,8 @@ public class NewtonRaphsonParameters {
     public String toString() {
         return "NewtonRaphsonParameters(" +
                 "maxIteration=" + maxIteration +
+                ", minRealisticVoltage=" + minRealisticVoltage +
+                ", maxRealisticVoltage=" + maxRealisticVoltage +
                 ", stoppingCriteria=" + stoppingCriteria.getClass().getSimpleName() +
                 ')';
     }

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonStatus.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonStatus.java
@@ -13,5 +13,6 @@ public enum NewtonRaphsonStatus {
     CONVERGED,
     MAX_ITERATION_REACHED,
     SOLVER_FAILED,
-    NO_CALCULATION
+    NO_CALCULATION,
+    INVALID_SOLUTION
 }

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonStatus.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonStatus.java
@@ -14,5 +14,5 @@ public enum NewtonRaphsonStatus {
     MAX_ITERATION_REACHED,
     SOLVER_FAILED,
     NO_CALCULATION,
-    INVALID_SOLUTION
+    UNREALISTIC_STATE
 }

--- a/src/test/java/com/powsybl/openloadflow/OpenLoadFlowProviderTest.java
+++ b/src/test/java/com/powsybl/openloadflow/OpenLoadFlowProviderTest.java
@@ -58,7 +58,7 @@ class OpenLoadFlowProviderTest {
     void testAcParameters() {
         Network network = Mockito.mock(Network.class);
         AcLoadFlowParameters acParameters = OpenLoadFlowParameters.createAcParameters(network, new LoadFlowParameters().setReadSlackBus(true), new OpenLoadFlowParameters(), new DenseMatrixFactory(), new EvenShiloachGraphDecrementalConnectivityFactory<>(), Reporter.NO_OP, false, false);
-        assertEquals("AcLoadFlowParameters(networkParameters=LfNetworkParameters(slackBusSelector=NetworkSlackBusSelector, connectivityFactory=EvenShiloachGraphDecrementalConnectivityFactory, generatorVoltageRemoteControl=true, minImpedance=false, twtSplitShuntAdmittance=false, breakers=false, plausibleActivePowerLimit=5000.0, addRatioToLinesWithDifferentNominalVoltageAtBothEnds=true, computeMainConnectedComponentOnly=true, countriesToBalance=[], distributedOnConformLoad=false, phaseControl=false, transformerVoltageControl=false, voltagePerReactivePowerControl=false, reactivePowerRemoteControl=false, isDc=false, reactiveLimits=true, hvdcAcEmulation=true, minPlausibleTargetVoltage=0.8, maxPlausibleTargetVoltage=1.2, loaderPostProcessorSelection=[]), equationSystemCreationParameters=AcEquationSystemCreationParameters(forceA1Var=false), newtonRaphsonParameters=NewtonRaphsonParameters(maxIteration=30, stoppingCriteria=DefaultNewtonRaphsonStoppingCriteria), outerLoops=[DistributedSlackOuterLoop, ReactiveLimitsOuterLoop], matrixFactory=DenseMatrixFactory, voltageInitializer=UniformValueVoltageInitializer)",
+        assertEquals("AcLoadFlowParameters(networkParameters=LfNetworkParameters(slackBusSelector=NetworkSlackBusSelector, connectivityFactory=EvenShiloachGraphDecrementalConnectivityFactory, generatorVoltageRemoteControl=true, minImpedance=false, twtSplitShuntAdmittance=false, breakers=false, plausibleActivePowerLimit=5000.0, addRatioToLinesWithDifferentNominalVoltageAtBothEnds=true, computeMainConnectedComponentOnly=true, countriesToBalance=[], distributedOnConformLoad=false, phaseControl=false, transformerVoltageControl=false, voltagePerReactivePowerControl=false, reactivePowerRemoteControl=false, isDc=false, reactiveLimits=true, hvdcAcEmulation=true, minPlausibleTargetVoltage=0.8, maxPlausibleTargetVoltage=1.2, loaderPostProcessorSelection=[]), equationSystemCreationParameters=AcEquationSystemCreationParameters(forceA1Var=false), newtonRaphsonParameters=NewtonRaphsonParameters(maxIteration=30, minRealisticVoltage=0.5, maxRealisticVoltage=1.5, stoppingCriteria=DefaultNewtonRaphsonStoppingCriteria), outerLoops=[DistributedSlackOuterLoop, ReactiveLimitsOuterLoop], matrixFactory=DenseMatrixFactory, voltageInitializer=UniformValueVoltageInitializer)",
                      acParameters.toString());
     }
 
@@ -86,7 +86,7 @@ class OpenLoadFlowProviderTest {
     @Test
     void specificParametersTest() {
         OpenLoadFlowProvider provider = new OpenLoadFlowProvider();
-        assertEquals(18, provider.getSpecificParametersNames().size());
+        assertEquals(20, provider.getSpecificParametersNames().size());
         LoadFlowParameters parameters = new LoadFlowParameters();
 
         provider.loadSpecificParameters(Collections.emptyMap())

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowBoundaryTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowBoundaryTest.java
@@ -155,8 +155,8 @@ class AcLoadFlowBoundaryTest {
                 .setVoltageLevel2("VL_3")
                 .setBus1("BUS_2")
                 .setBus2("BUS_3")
-                .setR(1.05)
-                .setX(0.01)
+                .setR(0.0)
+                .setX(100)
                 .setG1(0.)
                 .setG2(0.)
                 .setB1(0.)
@@ -167,15 +167,15 @@ class AcLoadFlowBoundaryTest {
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isOk());
         assertVoltageEquals(135.0, network.getBusBreakerView().getBus("BUS_1"));
-        assertVoltageEquals(134.25, network.getBusBreakerView().getBus("BUS_2"));
-        assertVoltageEquals(33.26, network.getBusBreakerView().getBus("BUS_3"));
+        assertVoltageEquals(134.227, network.getBusBreakerView().getBus("BUS_2"));
+        assertVoltageEquals(28.069, network.getBusBreakerView().getBus("BUS_3"));
 
         parametersExt.setAddRatioToLinesWithDifferentNominalVoltageAtBothEnds(true);
         LoadFlowResult result2 = loadFlowRunner.run(network, parameters);
         assertTrue(result2.isOk());
         assertVoltageEquals(135.0, network.getBusBreakerView().getBus("BUS_1"));
-        assertVoltageEquals(121.62, network.getBusBreakerView().getBus("BUS_2"));
-        assertVoltageEquals(0.04, network.getBusBreakerView().getBus("BUS_3"));
+        assertVoltageEquals(127.198, network.getBusBreakerView().getBus("BUS_2"));
+        assertVoltageEquals(40.19, network.getBusBreakerView().getBus("BUS_3"));
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -450,7 +450,7 @@ class OpenSecurityAnalysisTest {
 
         SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies);
 
-        assertTrue(result.getPostContingencyResults().get(0).getLimitViolationsResult().isComputationOk());
+        assertFalse(result.getPostContingencyResults().get(0).getLimitViolationsResult().isComputationOk());
     }
 
     @Test

--- a/src/test/resources/debug-parameters.json
+++ b/src/test/resources/debug-parameters.json
@@ -34,7 +34,9 @@
         "transformerVoltageControlMode" : "WITH_GENERATOR_VOLTAGE_CONTROL",
         "dcPowerFactor" : 1.0,
         "minPlausibleTargetVoltage" : 0.8,
-        "maxPlausibleTargetVoltage" : 1.2
+        "maxPlausibleTargetVoltage" : 1.2,
+        "minRealisticVoltage" : 0.5,
+        "maxRealisticVoltage" : 1.5
       }
     }
   },

--- a/src/test/resources/saReport.txt
+++ b/src/test/resources/saReport.txt
@@ -20,7 +20,7 @@
            Iteration 0: failed to distribute slack bus active power mismatch, 4.366500677028373 MW remains
         + Outer loop Reactive limits
       + Post-contingency simulation 'NGEN_NHV1'
-         AC load flow complete with NR status 'INVALID_SOLUTION'
+         AC load flow complete with NR status 'UNREALISTIC_STATE'
       + Post-contingency simulation 'NHV2_NLOAD'
          AC load flow complete with NR status 'CONVERGED'
         + Outer loop Distributed slack on generation

--- a/src/test/resources/saReport.txt
+++ b/src/test/resources/saReport.txt
@@ -20,10 +20,7 @@
            Iteration 0: failed to distribute slack bus active power mismatch, 4.366500677028373 MW remains
         + Outer loop Reactive limits
       + Post-contingency simulation 'NGEN_NHV1'
-         AC load flow complete with NR status 'CONVERGED'
-        + Outer loop Distributed slack on generation
-           Iteration 0: failed to distribute slack bus active power mismatch, 602.1113525187852 MW remains
-        + Outer loop Reactive limits
+         AC load flow complete with NR status 'INVALID_SOLUTION'
       + Post-contingency simulation 'NHV2_NLOAD'
          AC load flow complete with NR status 'CONVERGED'
         + Outer loop Distributed slack on generation


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
We don't check state validity after NR, and we sometimes update network buses voltage with negative values


**What is the new behavior (if this is a feature change)?**
A new status UNREALISTIC_STATE has been added


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
