### PR TITLE
Remove reset of variant ID in security and sensitivity analysis

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
@@ -58,13 +58,8 @@ public abstract class AbstractSecurityAnalysis {
         Objects.requireNonNull(securityAnalysisParameters);
         Objects.requireNonNull(contingenciesProvider);
         return CompletableFutureTask.runAsync(() -> {
-            String oldWorkingVariantId = network.getVariantManager().getWorkingVariantId();
             network.getVariantManager().setWorkingVariant(workingVariantId);
-            try {
-                return runSync(workingVariantId, securityAnalysisParameters, contingenciesProvider, computationManager);
-            } finally {
-                network.getVariantManager().setWorkingVariant(oldWorkingVariantId);
-            }
+            return runSync(workingVariantId, securityAnalysisParameters, contingenciesProvider, computationManager);
         }, computationManager.getExecutor());
     }
 


### PR DESCRIPTION
Remove useless reset of variant ID, fixing exception when trying to access an uninitialized variant id from a child thread.

Signed-off-by: Bertrand Rix <bertrand.rix@artelys.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
