### PR TITLE
Fix network variant removal issue

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkList.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkList.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.network.impl;
+
+import com.powsybl.openloadflow.network.LfNetwork;
+
+import java.util.List;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public interface LfNetworkList extends AutoCloseable {
+
+    List<LfNetwork> getList();
+
+    @Override
+    void close();
+}

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkList.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkList.java
@@ -6,17 +6,64 @@
  */
 package com.powsybl.openloadflow.network.impl;
 
+import com.powsybl.iidm.network.Network;
 import com.powsybl.openloadflow.network.LfNetwork;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public interface LfNetworkList extends AutoCloseable {
+public class LfNetworkList implements AutoCloseable {
 
-    List<LfNetwork> getList();
+    public static class VariantCleaner {
+
+        private final Network network;
+
+        private final String workingVariantId;
+
+        private final String tmpVariantId;
+
+        public VariantCleaner(Network network, String workingVariantId, String tmpVariantId) {
+            this.network = Objects.requireNonNull(network);
+            this.workingVariantId = Objects.requireNonNull(workingVariantId);
+            this.tmpVariantId = Objects.requireNonNull(tmpVariantId);
+        }
+
+        public void clean() {
+            network.getVariantManager().removeVariant(tmpVariantId);
+            network.getVariantManager().setWorkingVariant(workingVariantId);
+        }
+    }
+
+    // list of networks sorted by descending size
+    private final List<LfNetwork> list;
+
+    private final VariantCleaner variantCleaner;
+
+    public LfNetworkList(List<LfNetwork> list, VariantCleaner variantCleaner) {
+        this.list = Objects.requireNonNull(list);
+        this.variantCleaner = variantCleaner;
+    }
+
+    public LfNetworkList(List<LfNetwork> list) {
+        this(list, null);
+    }
+
+    public List<LfNetwork> getList() {
+        return list;
+    }
+
+    public Optional<LfNetwork> getLargest() {
+        return list.isEmpty() ? Optional.empty() : Optional.of(list.get(0));
+    }
 
     @Override
-    void close();
+    public void close() {
+        if (variantCleaner != null) {
+            variantCleaner.clean();
+        }
+    }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
@@ -106,36 +106,74 @@ public final class Networks {
         return LfNetwork.load(network, new LfNetworkLoaderImpl(), parameters);
     }
 
-    public static List<LfNetwork> load(Network network, SlackBusSelector slackBusSelector, Reporter reporter) {
-        return LfNetwork.load(network, new LfNetworkLoaderImpl(), slackBusSelector, reporter);
-    }
-
     public static List<LfNetwork> load(Network network, LfNetworkParameters parameters, Reporter reporter) {
         return LfNetwork.load(network, new LfNetworkLoaderImpl(), parameters, reporter);
     }
 
-    public static List<LfNetwork> load(Network network, LfNetworkParameters networkParameters,
-                                       Set<Switch> switchesToOpen, Set<Switch> switchesToClose, Reporter reporter) {
+    static class LfNetworkListImpl implements LfNetworkList {
+
+        private final List<LfNetwork> list;
+
+        LfNetworkListImpl(List<LfNetwork> list) {
+            this.list = Objects.requireNonNull(list);
+        }
+
+        @Override
+        public List<LfNetwork> getList() {
+            return list;
+        }
+
+        @Override
+        public void close() {
+            // nothing to clean
+        }
+    }
+
+    static class LfNetworkListVariantCleanupImpl implements LfNetworkList {
+
+        private final Network network;
+
+        private final String workingVariantId;
+
+        private final String tmpVariantId;
+
+        private final List<LfNetwork> list;
+
+        LfNetworkListVariantCleanupImpl(Network network, String workingVariantId, String tmpVariantId, List<LfNetwork> list) {
+            this.network = Objects.requireNonNull(network);
+            this.workingVariantId = Objects.requireNonNull(workingVariantId);
+            this.tmpVariantId = Objects.requireNonNull(tmpVariantId);
+            this.list = Objects.requireNonNull(list);
+        }
+
+        public List<LfNetwork> getList() {
+            return list;
+        }
+
+        @Override
+        public void close() {
+            network.getVariantManager().removeVariant(tmpVariantId);
+            network.getVariantManager().setWorkingVariant(workingVariantId);
+        }
+    }
+
+    public static LfNetworkList load(Network network, LfNetworkParameters networkParameters,
+                                     Set<Switch> switchesToOpen, Set<Switch> switchesToClose, Reporter reporter) {
         if (switchesToOpen.isEmpty() && switchesToClose.isEmpty()) {
-            return load(network, networkParameters, reporter);
+            return new LfNetworkListImpl(load(network, networkParameters, reporter));
         } else {
             String tmpVariantId = "olf-tmp-" + UUID.randomUUID();
-            String variantId = network.getVariantManager().getWorkingVariantId();
+            String workingVariantId = network.getVariantManager().getWorkingVariantId();
             network.getVariantManager().cloneVariant(network.getVariantManager().getWorkingVariantId(), tmpVariantId);
             network.getVariantManager().setWorkingVariant(tmpVariantId);
-            try {
-                network.getSwitchStream().filter(sw -> sw.getVoltageLevel().getTopologyKind() == TopologyKind.NODE_BREAKER)
-                        .forEach(sw -> sw.setRetained(false));
-                switchesToOpen.stream().filter(sw -> sw.getVoltageLevel().getTopologyKind() == TopologyKind.NODE_BREAKER)
-                        .forEach(sw -> sw.setRetained(true));
-                switchesToClose.stream().filter(sw -> sw.getVoltageLevel().getTopologyKind() == TopologyKind.NODE_BREAKER)
-                        .forEach(sw -> sw.setRetained(true));
-                switchesToClose.forEach(sw -> sw.setOpen(false)); // in order to be present in the network.
-                return load(network, networkParameters, reporter);
-            } finally {
-                network.getVariantManager().removeVariant(tmpVariantId);
-                network.getVariantManager().setWorkingVariant(variantId);
-            }
+            network.getSwitchStream().filter(sw -> sw.getVoltageLevel().getTopologyKind() == TopologyKind.NODE_BREAKER)
+                    .forEach(sw -> sw.setRetained(false));
+            switchesToOpen.stream().filter(sw -> sw.getVoltageLevel().getTopologyKind() == TopologyKind.NODE_BREAKER)
+                    .forEach(sw -> sw.setRetained(true));
+            switchesToClose.stream().filter(sw -> sw.getVoltageLevel().getTopologyKind() == TopologyKind.NODE_BREAKER)
+                    .forEach(sw -> sw.setRetained(true));
+            switchesToClose.forEach(sw -> sw.setOpen(false)); // in order to be present in the network.
+            return new LfNetworkListVariantCleanupImpl(network, workingVariantId, tmpVariantId, load(network, networkParameters, reporter));
         }
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/sa/AcSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AcSecurityAnalysis.java
@@ -96,10 +96,10 @@ public class AcSecurityAnalysis extends AbstractSecurityAnalysis {
 
             // run simulation on largest network
             SecurityAnalysisResult result;
-            if (lfNetworks.getList().isEmpty()) {
+            LfNetwork largestNetwork = lfNetworks.getLargest().orElse(null);
+            if (largestNetwork == null) {
                 result = createNoResult();
             } else {
-                LfNetwork largestNetwork = lfNetworks.getList().get(0);
                 if (largestNetwork.isValid()) {
                     Map<String, LfAction> lfActionsById = createLfActions(largestNetwork, actions);
                     Map<String, List<OperatorStrategy>> operatorStrategiesByContingencyId = indexOperatorStrategiesByContingencyId(propagatedContingencies, operatorStrategies);

--- a/src/main/java/com/powsybl/openloadflow/sa/AcSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AcSecurityAnalysis.java
@@ -25,6 +25,7 @@ import com.powsybl.openloadflow.ac.outerloop.AcLoadFlowResult;
 import com.powsybl.openloadflow.ac.outerloop.AcloadFlowEngine;
 import com.powsybl.openloadflow.graph.GraphConnectivityFactory;
 import com.powsybl.openloadflow.network.*;
+import com.powsybl.openloadflow.network.impl.LfNetworkList;
 import com.powsybl.openloadflow.network.impl.Networks;
 import com.powsybl.openloadflow.network.impl.PropagatedContingency;
 import com.powsybl.openloadflow.network.util.ActivePowerDistribution;
@@ -91,28 +92,29 @@ public class AcSecurityAnalysis extends AbstractSecurityAnalysis {
         AcLoadFlowParameters acParameters = OpenLoadFlowParameters.createAcParameters(network, lfParameters, lfParametersExt, matrixFactory, connectivityFactory, saReporter, breakers, false);
 
         // create networks including all necessary switches
-        List<LfNetwork> lfNetworks = Networks.load(network, acParameters.getNetworkParameters(), allSwitchesToOpen, allSwitchesToClose, saReporter);
+        try (LfNetworkList lfNetworks = Networks.load(network, acParameters.getNetworkParameters(), allSwitchesToOpen, allSwitchesToClose, saReporter)) {
 
-        // run simulation on largest network
-        SecurityAnalysisResult result;
-        if (lfNetworks.isEmpty()) {
-            result = createNoResult();
-        } else {
-            LfNetwork largestNetwork = lfNetworks.get(0);
-            if (largestNetwork.isValid()) {
-                Map<String, LfAction> lfActionsById = createLfActions(largestNetwork, actions);
-                Map<String, List<OperatorStrategy>> operatorStrategiesByContingencyId = indexOperatorStrategiesByContingencyId(propagatedContingencies, operatorStrategies);
-                result = runSimulations(largestNetwork, propagatedContingencies, acParameters, securityAnalysisParameters, operatorStrategiesByContingencyId, lfActionsById, allSwitchesToClose);
-            } else {
+            // run simulation on largest network
+            SecurityAnalysisResult result;
+            if (lfNetworks.getList().isEmpty()) {
                 result = createNoResult();
+            } else {
+                LfNetwork largestNetwork = lfNetworks.getList().get(0);
+                if (largestNetwork.isValid()) {
+                    Map<String, LfAction> lfActionsById = createLfActions(largestNetwork, actions);
+                    Map<String, List<OperatorStrategy>> operatorStrategiesByContingencyId = indexOperatorStrategiesByContingencyId(propagatedContingencies, operatorStrategies);
+                    result = runSimulations(largestNetwork, propagatedContingencies, acParameters, securityAnalysisParameters, operatorStrategiesByContingencyId, lfActionsById, allSwitchesToClose);
+                } else {
+                    result = createNoResult();
+                }
             }
+
+            stopwatch.stop();
+            LOGGER.info("Security analysis {} in {} ms", Thread.currentThread().isInterrupted() ? "cancelled" : "done",
+                    stopwatch.elapsed(TimeUnit.MILLISECONDS));
+
+            return new SecurityAnalysisReport(result);
         }
-
-        stopwatch.stop();
-        LOGGER.info("Security analysis {} in {} ms", Thread.currentThread().isInterrupted() ? "cancelled" : "done",
-                stopwatch.elapsed(TimeUnit.MILLISECONDS));
-
-        return new SecurityAnalysisReport(result);
     }
 
     public static void distributedMismatch(LfNetwork network, double mismatch, LoadFlowParameters loadFlowParameters,

--- a/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
@@ -25,6 +25,7 @@ import com.powsybl.openloadflow.ac.outerloop.AcloadFlowEngine;
 import com.powsybl.openloadflow.equations.Variable;
 import com.powsybl.openloadflow.graph.GraphConnectivityFactory;
 import com.powsybl.openloadflow.network.*;
+import com.powsybl.openloadflow.network.impl.LfNetworkList;
 import com.powsybl.openloadflow.network.impl.Networks;
 import com.powsybl.openloadflow.network.impl.PropagatedContingency;
 import com.powsybl.openloadflow.network.util.ActivePowerDistribution;
@@ -233,143 +234,144 @@ public class AcSensitivityAnalysis extends AbstractSensitivityAnalysis<AcVariabl
                 .setMaxPlausibleTargetVoltage(lfParametersExt.getMaxPlausibleTargetVoltage());
 
         // create networks including all necessary switches
-        List<LfNetwork> lfNetworks = Networks.load(network, lfNetworkParameters, allSwitchesToOpen, Collections.emptySet(), reporter);
-        LfNetwork lfNetwork = lfNetworks.get(0);
-        checkContingencies(lfNetwork, contingencies);
-        checkLoadFlowParameters(lfParameters);
+        try (LfNetworkList lfNetworks = Networks.load(network, lfNetworkParameters, allSwitchesToOpen, Collections.emptySet(), reporter)) {
+            LfNetwork lfNetwork = lfNetworks.getList().get(0);
+            checkContingencies(lfNetwork, contingencies);
+            checkLoadFlowParameters(lfParameters);
 
-        Map<String, SensitivityVariableSet> variableSetsById = variableSets.stream().collect(Collectors.toMap(SensitivityVariableSet::getId, Function.identity()));
-        SensitivityFactorHolder<AcVariableType, AcEquationType> allFactorHolder = readAndCheckFactors(network, variableSetsById, factorReader, lfNetwork, breakers);
-        List<LfSensitivityFactor<AcVariableType, AcEquationType>> allLfFactors = allFactorHolder.getAllFactors();
-        LOGGER.info("Running AC sensitivity analysis with {} factors and {} contingencies", allLfFactors.size(), contingencies.size());
+            Map<String, SensitivityVariableSet> variableSetsById = variableSets.stream().collect(Collectors.toMap(SensitivityVariableSet::getId, Function.identity()));
+            SensitivityFactorHolder<AcVariableType, AcEquationType> allFactorHolder = readAndCheckFactors(network, variableSetsById, factorReader, lfNetwork, breakers);
+            List<LfSensitivityFactor<AcVariableType, AcEquationType>> allLfFactors = allFactorHolder.getAllFactors();
+            LOGGER.info("Running AC sensitivity analysis with {} factors and {} contingencies", allLfFactors.size(), contingencies.size());
 
-        // next we only work with valid and valid only for function factors
-        var validFactorHolder = writeInvalidFactors(allFactorHolder, resultWriter);
-        var validLfFactors = validFactorHolder.getAllFactors();
+            // next we only work with valid and valid only for function factors
+            var validFactorHolder = writeInvalidFactors(allFactorHolder, resultWriter);
+            var validLfFactors = validFactorHolder.getAllFactors();
 
-        // create AC engine
-        AcLoadFlowParameters acParameters = OpenLoadFlowParameters.createAcParameters(network, lfParameters, lfParametersExt, matrixFactory, connectivityFactory, reporter, breakers, true);
+            // create AC engine
+            AcLoadFlowParameters acParameters = OpenLoadFlowParameters.createAcParameters(network, lfParameters, lfParametersExt, matrixFactory, connectivityFactory, reporter, breakers, true);
 
-        try (AcLoadFlowContext context = new AcLoadFlowContext(lfNetwork, acParameters)) {
+            try (AcLoadFlowContext context = new AcLoadFlowContext(lfNetwork, acParameters)) {
 
-            runLoadFlow(context, true);
+                runLoadFlow(context, true);
 
-            // index factors by variable group to compute a minimal number of states
-            SensitivityFactorGroupList<AcVariableType, AcEquationType> factorGroups = createFactorGroups(validLfFactors.stream()
-                    .filter(factor -> factor.getStatus() == LfSensitivityFactor.Status.VALID).collect(Collectors.toList()));
+                // index factors by variable group to compute a minimal number of states
+                SensitivityFactorGroupList<AcVariableType, AcEquationType> factorGroups = createFactorGroups(validLfFactors.stream()
+                        .filter(factor -> factor.getStatus() == LfSensitivityFactor.Status.VALID).collect(Collectors.toList()));
 
-            // compute the participation for each injection factor (+1 on the injection and then -participation factor on all
-            // buses that contain elements participating to slack distribution
+                // compute the participation for each injection factor (+1 on the injection and then -participation factor on all
+                // buses that contain elements participating to slack distribution
 
-            Map<LfBus, Double> slackParticipationByBus;
-            if (lfParameters.isDistributedSlack()) {
-                List<ParticipatingElement> participatingElements = getParticipatingElements(lfNetwork.getBuses(), lfParameters.getBalanceType(), lfParametersExt);
-                slackParticipationByBus = participatingElements.stream().collect(Collectors.toMap(
-                    ParticipatingElement::getLfBus,
-                    element -> -element.getFactor(),
-                    Double::sum
-                ));
-            } else {
-                slackParticipationByBus = Collections.singletonMap(lfNetwork.getSlackBus(), -1d);
-            }
-
-            // if we have at least one bus target voltage linked to a ratio tap changer, we have to rebuild the AC equation
-            // system obtained just before the transformer steps rounding.
-            if (Boolean.TRUE.equals(hasBusTargetVoltage.getRight())) {
-                // switch on regulating transformers
-                for (LfBranch branch : lfNetwork.getBranches()) {
-                    branch.getVoltageControl().ifPresent(vc -> branch.setVoltageControlEnabled(true));
+                Map<LfBus, Double> slackParticipationByBus;
+                if (lfParameters.isDistributedSlack()) {
+                    List<ParticipatingElement> participatingElements = getParticipatingElements(lfNetwork.getBuses(), lfParameters.getBalanceType(), lfParametersExt);
+                    slackParticipationByBus = participatingElements.stream().collect(Collectors.toMap(
+                        ParticipatingElement::getLfBus,
+                        element -> -element.getFactor(),
+                        Double::sum
+                    ));
+                } else {
+                    slackParticipationByBus = Collections.singletonMap(lfNetwork.getSlackBus(), -1d);
                 }
-                lfNetwork.fixTransformerVoltageControls();
+
+                // if we have at least one bus target voltage linked to a ratio tap changer, we have to rebuild the AC equation
+                // system obtained just before the transformer steps rounding.
+                if (Boolean.TRUE.equals(hasBusTargetVoltage.getRight())) {
+                    // switch on regulating transformers
+                    for (LfBranch branch : lfNetwork.getBranches()) {
+                        branch.getVoltageControl().ifPresent(vc -> branch.setVoltageControlEnabled(true));
+                    }
+                    lfNetwork.fixTransformerVoltageControls();
+                }
+
+                // we make the assumption that we ran a loadflow before, and thus this jacobian is the right one
+
+                // otherwise, defining the rhs matrix will result in integer overflow
+                if (factorGroups.getList().size() >= Integer.MAX_VALUE / (context.getEquationSystem().getIndex().getSortedEquationsToSolve().size() * Double.BYTES)) {
+                    throw new PowsyblException("Too many factors!");
+                }
+
+                // initialize right hand side from valid factors
+                DenseMatrix factorsStates = initFactorsRhs(context.getEquationSystem(), factorGroups, slackParticipationByBus); // this is the rhs for the moment
+
+                // solve system
+                context.getJacobianMatrix().solveTransposed(factorsStates);
+
+                // calculate sensitivity values
+                setFunctionReferences(validLfFactors);
+                calculateSensitivityValues(validFactorHolder.getFactorsForBaseNetwork(), factorGroups, factorsStates, -1, resultWriter);
+
+                NetworkState networkState = NetworkState.save(lfNetwork);
+
+                // we always restart from base case voltages for contingency simulation
+                context.getParameters().setVoltageInitializer(new PreviousValueVoltageInitializer());
+
+                contingencies.forEach(contingency -> {
+                    LOGGER.info("Simulate contingency '{}'", contingency.getContingency().getId());
+                    contingency.toLfContingency(lfNetwork)
+                            .ifPresentOrElse(lfContingency -> {
+                                List<LfSensitivityFactor<AcVariableType, AcEquationType>> contingencyFactors = validFactorHolder.getFactorsForContingency(lfContingency.getId());
+                                contingencyFactors.forEach(lfFactor -> {
+                                    lfFactor.setSensitivityValuePredefinedResult(null);
+                                    lfFactor.setFunctionPredefinedResult(null);
+                                });
+
+                                lfContingency.apply(lfParameters.getBalanceType());
+
+                                Map<LfBus, Double> postContingencySlackParticipationByBus;
+                                Set<LfBus> slackConnectedComponent;
+                                if (lfContingency.getDisabledBuses().isEmpty()) {
+                                    // contingency not breaking connectivity
+                                    LOGGER.debug("Contingency '{}' without loss of connectivity", lfContingency.getId());
+                                    slackConnectedComponent = new HashSet<>(lfNetwork.getBuses());
+
+                                    // Sensitivity values 0 and function reference NaN in case of a sensitivity on a disabled branch
+                                    contingencyFactors.stream()
+                                            .filter(lfFactor -> lfFactor.getFunctionElement() instanceof LfBranch)
+                                            .filter(lfFactor -> lfContingency.getDisabledBranches().contains(lfFactor.getFunctionElement()))
+                                            .forEach(lfFactor -> {
+                                                lfFactor.setSensitivityValuePredefinedResult(0d);
+                                                lfFactor.setFunctionPredefinedResult(Double.NaN);
+                                            });
+
+                                    // Sensitivity values 0 in case of a sensitivity from the transformer phase of a disabled transformer
+                                    contingencyFactors.stream()
+                                            .filter(lfFactor -> lfFactor.getVariableType().equals(SensitivityVariableType.TRANSFORMER_PHASE))
+                                            .filter(lfFactor -> lfContingency.getDisabledBranches().contains(lfNetwork.getBranchById(lfFactor.getVariableId())))
+                                            .forEach(lfFactor -> lfFactor.setSensitivityValuePredefinedResult(0d));
+                                } else {
+                                    // contingency breaking connectivity
+                                    LOGGER.debug("Contingency {} with loss of connectivity", lfContingency.getId());
+                                    // we check if factors are still in the main component
+                                    slackConnectedComponent = new HashSet<>(lfNetwork.getBuses()).stream().filter(Predicate.not(lfContingency.getDisabledBuses()::contains)).collect(Collectors.toSet());
+                                    setPredefinedResults(contingencyFactors, lfContingency.getDisabledBuses(), lfContingency.getDisabledBranches());
+                                    // we recompute GLSK weights if needed
+                                    rescaleGlsk(factorGroups, lfContingency.getDisabledBuses());
+                                }
+
+                                // compute the participation for each injection factor (+1 on the injection and then -participation factor on all
+                                // buses that contain elements participating to slack distribution)
+                                if (lfParameters.isDistributedSlack()) {
+                                    postContingencySlackParticipationByBus = getParticipatingElements(slackConnectedComponent, lfParameters.getBalanceType(), lfParametersExt).stream().collect(Collectors.toMap(
+                                            ParticipatingElement::getLfBus, element -> -element.getFactor(), Double::sum));
+                                } else {
+                                    postContingencySlackParticipationByBus = Collections.singletonMap(lfNetwork.getSlackBus(), -1d);
+                                }
+                                calculatePostContingencySensitivityValues(contingencyFactors, lfContingency, lfNetwork, context, factorGroups, postContingencySlackParticipationByBus,
+                                        lfParameters, lfParametersExt, lfContingency.getIndex(), resultWriter, Boolean.TRUE.equals(hasBusTargetVoltage.getRight()));
+
+                                networkState.restore();
+                            }, () -> {
+                                    // it means that the contingency has no impact.
+                                    // we need to force the state vector to be re-initialized from base case network state
+                                    NewtonRaphson.initStateVector(lfNetwork, context.getEquationSystem(), context.getParameters().getVoltageInitializer());
+
+                                    calculateSensitivityValues(validFactorHolder.getFactorsForContingency(contingency.getContingency().getId()), factorGroups, factorsStates, contingency.getIndex(), resultWriter);
+                                    // write contingency status
+                                    resultWriter.writeContingencyStatus(contingency.getIndex(), SensitivityAnalysisResult.Status.NO_IMPACT);
+                                });
+                });
             }
-
-            // we make the assumption that we ran a loadflow before, and thus this jacobian is the right one
-
-            // otherwise, defining the rhs matrix will result in integer overflow
-            if (factorGroups.getList().size() >= Integer.MAX_VALUE / (context.getEquationSystem().getIndex().getSortedEquationsToSolve().size() * Double.BYTES)) {
-                throw new PowsyblException("Too many factors!");
-            }
-
-            // initialize right hand side from valid factors
-            DenseMatrix factorsStates = initFactorsRhs(context.getEquationSystem(), factorGroups, slackParticipationByBus); // this is the rhs for the moment
-
-            // solve system
-            context.getJacobianMatrix().solveTransposed(factorsStates);
-
-            // calculate sensitivity values
-            setFunctionReferences(validLfFactors);
-            calculateSensitivityValues(validFactorHolder.getFactorsForBaseNetwork(), factorGroups, factorsStates, -1, resultWriter);
-
-            NetworkState networkState = NetworkState.save(lfNetwork);
-
-            // we always restart from base case voltages for contingency simulation
-            context.getParameters().setVoltageInitializer(new PreviousValueVoltageInitializer());
-
-            contingencies.forEach(contingency -> {
-                LOGGER.info("Simulate contingency '{}'", contingency.getContingency().getId());
-                contingency.toLfContingency(lfNetwork)
-                        .ifPresentOrElse(lfContingency -> {
-                            List<LfSensitivityFactor<AcVariableType, AcEquationType>> contingencyFactors = validFactorHolder.getFactorsForContingency(lfContingency.getId());
-                            contingencyFactors.forEach(lfFactor -> {
-                                lfFactor.setSensitivityValuePredefinedResult(null);
-                                lfFactor.setFunctionPredefinedResult(null);
-                            });
-
-                            lfContingency.apply(lfParameters.getBalanceType());
-
-                            Map<LfBus, Double> postContingencySlackParticipationByBus;
-                            Set<LfBus> slackConnectedComponent;
-                            if (lfContingency.getDisabledBuses().isEmpty()) {
-                                // contingency not breaking connectivity
-                                LOGGER.debug("Contingency '{}' without loss of connectivity", lfContingency.getId());
-                                slackConnectedComponent = new HashSet<>(lfNetwork.getBuses());
-
-                                // Sensitivity values 0 and function reference NaN in case of a sensitivity on a disabled branch
-                                contingencyFactors.stream()
-                                        .filter(lfFactor -> lfFactor.getFunctionElement() instanceof LfBranch)
-                                        .filter(lfFactor -> lfContingency.getDisabledBranches().contains(lfFactor.getFunctionElement()))
-                                        .forEach(lfFactor -> {
-                                            lfFactor.setSensitivityValuePredefinedResult(0d);
-                                            lfFactor.setFunctionPredefinedResult(Double.NaN);
-                                        });
-
-                                // Sensitivity values 0 in case of a sensitivity from the transformer phase of a disabled transformer
-                                contingencyFactors.stream()
-                                        .filter(lfFactor -> lfFactor.getVariableType().equals(SensitivityVariableType.TRANSFORMER_PHASE))
-                                        .filter(lfFactor -> lfContingency.getDisabledBranches().contains(lfNetwork.getBranchById(lfFactor.getVariableId())))
-                                        .forEach(lfFactor -> lfFactor.setSensitivityValuePredefinedResult(0d));
-                            } else {
-                                // contingency breaking connectivity
-                                LOGGER.debug("Contingency {} with loss of connectivity", lfContingency.getId());
-                                // we check if factors are still in the main component
-                                slackConnectedComponent = new HashSet<>(lfNetwork.getBuses()).stream().filter(Predicate.not(lfContingency.getDisabledBuses()::contains)).collect(Collectors.toSet());
-                                setPredefinedResults(contingencyFactors, lfContingency.getDisabledBuses(), lfContingency.getDisabledBranches());
-                                // we recompute GLSK weights if needed
-                                rescaleGlsk(factorGroups, lfContingency.getDisabledBuses());
-                            }
-
-                            // compute the participation for each injection factor (+1 on the injection and then -participation factor on all
-                            // buses that contain elements participating to slack distribution)
-                            if (lfParameters.isDistributedSlack()) {
-                                postContingencySlackParticipationByBus = getParticipatingElements(slackConnectedComponent, lfParameters.getBalanceType(), lfParametersExt).stream().collect(Collectors.toMap(
-                                        ParticipatingElement::getLfBus, element -> -element.getFactor(), Double::sum));
-                            } else {
-                                postContingencySlackParticipationByBus = Collections.singletonMap(lfNetwork.getSlackBus(), -1d);
-                            }
-                            calculatePostContingencySensitivityValues(contingencyFactors, lfContingency, lfNetwork, context, factorGroups, postContingencySlackParticipationByBus,
-                                    lfParameters, lfParametersExt, lfContingency.getIndex(), resultWriter, Boolean.TRUE.equals(hasBusTargetVoltage.getRight()));
-
-                            networkState.restore();
-                        }, () -> {
-                                // it means that the contingency has no impact.
-                                // we need to force the state vector to be re-initialized from base case network state
-                                NewtonRaphson.initStateVector(lfNetwork, context.getEquationSystem(), context.getParameters().getVoltageInitializer());
-
-                                calculateSensitivityValues(validFactorHolder.getFactorsForContingency(contingency.getContingency().getId()), factorGroups, factorsStates, contingency.getIndex(), resultWriter);
-                                // write contingency status
-                                resultWriter.writeContingencyStatus(contingency.getIndex(), SensitivityAnalysisResult.Status.NO_IMPACT);
-                            });
-            });
         }
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
@@ -235,7 +235,7 @@ public class AcSensitivityAnalysis extends AbstractSensitivityAnalysis<AcVariabl
 
         // create networks including all necessary switches
         try (LfNetworkList lfNetworks = Networks.load(network, lfNetworkParameters, allSwitchesToOpen, Collections.emptySet(), reporter)) {
-            LfNetwork lfNetwork = lfNetworks.getList().get(0);
+            LfNetwork lfNetwork = lfNetworks.getLargest().orElseThrow(() -> new PowsyblException("Empty network"));
             checkContingencies(lfNetwork, contingencies);
             checkLoadFlowParameters(lfParameters);
 

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -857,7 +857,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
                 .setMaxPlausibleTargetVoltage(lfParametersExt.getMaxPlausibleTargetVoltage());
         // create networks including all necessary switches
         try (LfNetworkList lfNetworks = Networks.load(network, lfNetworkParameters, allSwitchesToOpen, Collections.emptySet(), reporter)) {
-            LfNetwork lfNetwork = lfNetworks.getList().get(0);
+            LfNetwork lfNetwork = lfNetworks.getLargest().orElseThrow(() -> new PowsyblException("Empty network"));
             checkContingencies(lfNetwork, contingencies);
             checkLoadFlowParameters(lfParameters);
 

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -29,6 +29,7 @@ import com.powsybl.openloadflow.equations.JacobianMatrix;
 import com.powsybl.openloadflow.graph.GraphConnectivity;
 import com.powsybl.openloadflow.graph.GraphConnectivityFactory;
 import com.powsybl.openloadflow.network.*;
+import com.powsybl.openloadflow.network.impl.LfNetworkList;
 import com.powsybl.openloadflow.network.impl.Networks;
 import com.powsybl.openloadflow.network.impl.PropagatedContingency;
 import com.powsybl.openloadflow.network.util.ParticipatingElement;
@@ -855,112 +856,113 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
                 .setMinPlausibleTargetVoltage(lfParametersExt.getMinPlausibleTargetVoltage())
                 .setMaxPlausibleTargetVoltage(lfParametersExt.getMaxPlausibleTargetVoltage());
         // create networks including all necessary switches
-        List<LfNetwork> lfNetworks = Networks.load(network, lfNetworkParameters, allSwitchesToOpen, Collections.emptySet(), reporter);
-        LfNetwork lfNetwork = lfNetworks.get(0);
-        checkContingencies(lfNetwork, contingencies);
-        checkLoadFlowParameters(lfParameters);
+        try (LfNetworkList lfNetworks = Networks.load(network, lfNetworkParameters, allSwitchesToOpen, Collections.emptySet(), reporter)) {
+            LfNetwork lfNetwork = lfNetworks.getList().get(0);
+            checkContingencies(lfNetwork, contingencies);
+            checkLoadFlowParameters(lfParameters);
 
-        Map<String, SensitivityVariableSet> variableSetsById = variableSets.stream().collect(Collectors.toMap(SensitivityVariableSet::getId, Function.identity()));
-        SensitivityFactorHolder<DcVariableType, DcEquationType> allFactorHolder = readAndCheckFactors(network, variableSetsById, factorReader, lfNetwork, breakers);
-        List<LfSensitivityFactor<DcVariableType, DcEquationType>> allLfFactors = allFactorHolder.getAllFactors();
+            Map<String, SensitivityVariableSet> variableSetsById = variableSets.stream().collect(Collectors.toMap(SensitivityVariableSet::getId, Function.identity()));
+            SensitivityFactorHolder<DcVariableType, DcEquationType> allFactorHolder = readAndCheckFactors(network, variableSetsById, factorReader, lfNetwork, breakers);
+            List<LfSensitivityFactor<DcVariableType, DcEquationType>> allLfFactors = allFactorHolder.getAllFactors();
 
-        allLfFactors.stream()
-                .filter(lfFactor -> (lfFactor.getFunctionType() != SensitivityFunctionType.BRANCH_ACTIVE_POWER
-                    && lfFactor.getFunctionType() != SensitivityFunctionType.BRANCH_ACTIVE_POWER_1
-                    && lfFactor.getFunctionType() != SensitivityFunctionType.BRANCH_ACTIVE_POWER_2)
-                    || (lfFactor.getVariableType() != SensitivityVariableType.INJECTION_ACTIVE_POWER
-                    && lfFactor.getVariableType() != SensitivityVariableType.TRANSFORMER_PHASE
-                    && lfFactor.getVariableType() != SensitivityVariableType.HVDC_LINE_ACTIVE_POWER))
-                .findFirst()
-                .ifPresent(ignored -> {
-                    throw new PowsyblException("Only variables of type TRANSFORMER_PHASE, INJECTION_ACTIVE_POWER and HVDC_LINE_ACTIVE_POWER, and functions of type BRANCH_ACTIVE_POWER_1 and BRANCH_ACTIVE_POWER_2 are yet supported in DC");
-                });
+            allLfFactors.stream()
+                    .filter(lfFactor -> (lfFactor.getFunctionType() != SensitivityFunctionType.BRANCH_ACTIVE_POWER
+                            && lfFactor.getFunctionType() != SensitivityFunctionType.BRANCH_ACTIVE_POWER_1
+                            && lfFactor.getFunctionType() != SensitivityFunctionType.BRANCH_ACTIVE_POWER_2)
+                            || (lfFactor.getVariableType() != SensitivityVariableType.INJECTION_ACTIVE_POWER
+                            && lfFactor.getVariableType() != SensitivityVariableType.TRANSFORMER_PHASE
+                            && lfFactor.getVariableType() != SensitivityVariableType.HVDC_LINE_ACTIVE_POWER))
+                    .findFirst()
+                    .ifPresent(ignored -> {
+                        throw new PowsyblException("Only variables of type TRANSFORMER_PHASE, INJECTION_ACTIVE_POWER and HVDC_LINE_ACTIVE_POWER, and functions of type BRANCH_ACTIVE_POWER_1 and BRANCH_ACTIVE_POWER_2 are yet supported in DC");
+                    });
 
-        LOGGER.info("Running DC sensitivity analysis with {} factors and {} contingencies", allLfFactors.size(), contingencies.size());
+            LOGGER.info("Running DC sensitivity analysis with {} factors and {} contingencies", allLfFactors.size(), contingencies.size());
 
-        var dcLoadFlowParameters = createDcLoadFlowParameters(lfNetworkParameters, matrixFactory, lfParameters);
+            var dcLoadFlowParameters = createDcLoadFlowParameters(lfNetworkParameters, matrixFactory, lfParameters);
 
-        // create DC equation system for sensitivity analysis
-        EquationSystem<DcVariableType, DcEquationType> equationSystem = DcEquationSystem.create(lfNetwork, dcLoadFlowParameters.getEquationSystemCreationParameters());
+            // create DC equation system for sensitivity analysis
+            EquationSystem<DcVariableType, DcEquationType> equationSystem = DcEquationSystem.create(lfNetwork, dcLoadFlowParameters.getEquationSystemCreationParameters());
 
-        // next we only work with valid factors
-        var validFactorHolder = writeInvalidFactors(allFactorHolder, resultWriter);
-        var validLfFactors = validFactorHolder.getAllFactors();
-        LOGGER.info("{}/{} factors are valid", validLfFactors.size(), allLfFactors.size());
+            // next we only work with valid factors
+            var validFactorHolder = writeInvalidFactors(allFactorHolder, resultWriter);
+            var validLfFactors = validFactorHolder.getAllFactors();
+            LOGGER.info("{}/{} factors are valid", validLfFactors.size(), allLfFactors.size());
 
-        // index factors by variable group to compute the minimal number of states
-        SensitivityFactorGroupList<DcVariableType, DcEquationType> factorGroups = createFactorGroups(validLfFactors.stream().filter(factor -> factor.getStatus() == LfSensitivityFactor.Status.VALID).collect(Collectors.toList()));
+            // index factors by variable group to compute the minimal number of states
+            SensitivityFactorGroupList<DcVariableType, DcEquationType> factorGroups = createFactorGroups(validLfFactors.stream().filter(factor -> factor.getStatus() == LfSensitivityFactor.Status.VALID).collect(Collectors.toList()));
 
-        // compute the participation for each injection factor (+1 on the injection and then -participation factor on all
-        // buses that contain elements participating to slack distribution)
-        List<ParticipatingElement> participatingElements = lfParameters.isDistributedSlack()
-                ? getParticipatingElements(lfNetwork.getBuses(), lfParameters.getBalanceType(), lfParametersExt)
-                : Collections.emptyList();
+            // compute the participation for each injection factor (+1 on the injection and then -participation factor on all
+            // buses that contain elements participating to slack distribution)
+            List<ParticipatingElement> participatingElements = lfParameters.isDistributedSlack()
+                    ? getParticipatingElements(lfNetwork.getBuses(), lfParameters.getBalanceType(), lfParametersExt)
+                    : Collections.emptyList();
 
-        // index contingency elements by branch id
-        Map<String, ComputedContingencyElement> contingencyElementByBranch = createContingencyElementsIndexByBranchId(contingencies, lfNetwork, equationSystem);
+            // index contingency elements by branch id
+            Map<String, ComputedContingencyElement> contingencyElementByBranch = createContingencyElementsIndexByBranchId(contingencies, lfNetwork, equationSystem);
 
-        // create jacobian matrix either using calculated voltages from pre-contingency network or nominal voltages
-        VoltageInitializer voltageInitializer = lfParameters.getVoltageInitMode() == LoadFlowParameters.VoltageInitMode.PREVIOUS_VALUES
-                ? new PreviousValueVoltageInitializer()
-                : new UniformValueVoltageInitializer();
+            // create jacobian matrix either using calculated voltages from pre-contingency network or nominal voltages
+            VoltageInitializer voltageInitializer = lfParameters.getVoltageInitMode() == LoadFlowParameters.VoltageInitMode.PREVIOUS_VALUES
+                    ? new PreviousValueVoltageInitializer()
+                    : new UniformValueVoltageInitializer();
 
-        try (JacobianMatrix<DcVariableType, DcEquationType> j = createJacobianMatrix(lfNetwork, equationSystem, voltageInitializer)) {
+            try (JacobianMatrix<DcVariableType, DcEquationType> j = createJacobianMatrix(lfNetwork, equationSystem, voltageInitializer)) {
 
-            // run DC load on pre-contingency network
-            DenseMatrix flowStates = calculateActivePowerFlows(lfNetwork, dcLoadFlowParameters, equationSystem, j, validLfFactors, participatingElements, Collections.emptyList(), Collections.emptyList(), reporter);
+                // run DC load on pre-contingency network
+                DenseMatrix flowStates = calculateActivePowerFlows(lfNetwork, dcLoadFlowParameters, equationSystem, j, validLfFactors, participatingElements, Collections.emptyList(), Collections.emptyList(), reporter);
 
-            // compute the pre-contingency sensitivity values
-            DenseMatrix factorsStates = calculateFactorStates(lfNetwork, equationSystem, factorGroups, j, participatingElements);
+                // compute the pre-contingency sensitivity values
+                DenseMatrix factorsStates = calculateFactorStates(lfNetwork, equationSystem, factorGroups, j, participatingElements);
 
-            // calculate sensitivity values for pre-contingency network
-            calculateSensitivityValues(validFactorHolder.getFactorsForBaseNetwork(), factorsStates, null, flowStates,
-                    Collections.emptyList(), null, resultWriter);
+                // calculate sensitivity values for pre-contingency network
+                calculateSensitivityValues(validFactorHolder.getFactorsForBaseNetwork(), factorsStates, null, flowStates,
+                        Collections.emptyList(), null, resultWriter);
 
-            // compute states with +1 -1 to model the contingencies
-            DenseMatrix contingenciesStates = calculateContingenciesStates(lfNetwork, equationSystem, contingencyElementByBranch, j);
+                // compute states with +1 -1 to model the contingencies
+                DenseMatrix contingenciesStates = calculateContingenciesStates(lfNetwork, equationSystem, contingencyElementByBranch, j);
 
-            // connectivity analysis by contingency
-            // we have to compute sensitivities and reference functions in a different way depending on either or not the contingency breaks connectivity
-            // so, we will index contingencies by a list of branch that may break connectivity
-            // for example, if in the network, loosing line L1 breaks connectivity, and loosing L2 and L3 together breaks connectivity,
-            // the index would be: {L1, L2, L3}
-            // a contingency involving a phase tap changer loss has to be processed separately
-            List<PropagatedContingency> nonBreakingConnectivityContingencies = new ArrayList<>();
-            Map<Set<ComputedContingencyElement>, List<PropagatedContingency>> contingenciesByGroupOfElementsPotentiallyBreakingConnectivity = new LinkedHashMap<>();
+                // connectivity analysis by contingency
+                // we have to compute sensitivities and reference functions in a different way depending on either or not the contingency breaks connectivity
+                // so, we will index contingencies by a list of branch that may break connectivity
+                // for example, if in the network, loosing line L1 breaks connectivity, and loosing L2 and L3 together breaks connectivity,
+                // the index would be: {L1, L2, L3}
+                // a contingency involving a phase tap changer loss has to be processed separately
+                List<PropagatedContingency> nonBreakingConnectivityContingencies = new ArrayList<>();
+                Map<Set<ComputedContingencyElement>, List<PropagatedContingency>> contingenciesByGroupOfElementsPotentiallyBreakingConnectivity = new LinkedHashMap<>();
 
-            // this first method based on sensitivity criteria is able to detect some contingencies that do not break
-            // connectivity and other contingencies that potentially break connectivity
-            detectPotentialConnectivityBreak(lfNetwork, contingenciesStates, contingencies, contingencyElementByBranch, equationSystem,
-                    nonBreakingConnectivityContingencies, contingenciesByGroupOfElementsPotentiallyBreakingConnectivity);
-            LOGGER.info("After sensitivity based connectivity analysis, {} contingencies do not break connectivity, {} contingencies potentially break connectivity",
-                    nonBreakingConnectivityContingencies.size(), contingenciesByGroupOfElementsPotentiallyBreakingConnectivity.values().stream().mapToInt(List::size).count());
+                // this first method based on sensitivity criteria is able to detect some contingencies that do not break
+                // connectivity and other contingencies that potentially break connectivity
+                detectPotentialConnectivityBreak(lfNetwork, contingenciesStates, contingencies, contingencyElementByBranch, equationSystem,
+                        nonBreakingConnectivityContingencies, contingenciesByGroupOfElementsPotentiallyBreakingConnectivity);
+                LOGGER.info("After sensitivity based connectivity analysis, {} contingencies do not break connectivity, {} contingencies potentially break connectivity",
+                        nonBreakingConnectivityContingencies.size(), contingenciesByGroupOfElementsPotentiallyBreakingConnectivity.values().stream().mapToInt(List::size).count());
 
-            // this second method process all contingencies that potentially break connectivity and using graph algorithms
-            // find remaining contingencies that do not break connectivity
-            List<ConnectivityAnalysisResult> connectivityAnalysisResults
-                    = computeConnectivityData(lfNetwork, validFactorHolder, contingenciesByGroupOfElementsPotentiallyBreakingConnectivity, nonBreakingConnectivityContingencies, resultWriter);
-            LOGGER.info("After graph based connectivity analysis, {} contingencies do not break connectivity, {} contingencies break connectivity",
-                    nonBreakingConnectivityContingencies.size(), connectivityAnalysisResults.stream().mapToInt(results -> results.getContingencies().size()).count());
+                // this second method process all contingencies that potentially break connectivity and using graph algorithms
+                // find remaining contingencies that do not break connectivity
+                List<ConnectivityAnalysisResult> connectivityAnalysisResults
+                        = computeConnectivityData(lfNetwork, validFactorHolder, contingenciesByGroupOfElementsPotentiallyBreakingConnectivity, nonBreakingConnectivityContingencies, resultWriter);
+                LOGGER.info("After graph based connectivity analysis, {} contingencies do not break connectivity, {} contingencies break connectivity",
+                        nonBreakingConnectivityContingencies.size(), connectivityAnalysisResults.stream().mapToInt(results -> results.getContingencies().size()).count());
 
-            LOGGER.info("Processing contingencies with no connectivity break");
+                LOGGER.info("Processing contingencies with no connectivity break");
 
-            // process contingencies with no connectivity break
-            calculateSensitivityValuesForContingencyList(lfNetwork, lfParametersExt, dcLoadFlowParameters, equationSystem, validFactorHolder, factorGroups,
-                    j, factorsStates, contingenciesStates, flowStates, nonBreakingConnectivityContingencies, contingencyElementByBranch,
-                    Collections.emptySet(), participatingElements, Collections.emptySet(), resultWriter, reporter);
+                // process contingencies with no connectivity break
+                calculateSensitivityValuesForContingencyList(lfNetwork, lfParametersExt, dcLoadFlowParameters, equationSystem, validFactorHolder, factorGroups,
+                        j, factorsStates, contingenciesStates, flowStates, nonBreakingConnectivityContingencies, contingencyElementByBranch,
+                        Collections.emptySet(), participatingElements, Collections.emptySet(), resultWriter, reporter);
 
-            LOGGER.info("Processing contingencies with connectivity break");
+                LOGGER.info("Processing contingencies with connectivity break");
 
-            // process contingencies with connectivity break
-            for (ConnectivityAnalysisResult connectivityAnalysisResult : connectivityAnalysisResults) {
-                processContingenciesBreakingConnectivity(connectivityAnalysisResult, lfNetwork, lfParameters, lfParametersExt,
-                        dcLoadFlowParameters, equationSystem, validFactorHolder, factorGroups, participatingElements,
-                        contingencyElementByBranch, j, flowStates, factorsStates, contingenciesStates, resultWriter, reporter);
+                // process contingencies with connectivity break
+                for (ConnectivityAnalysisResult connectivityAnalysisResult : connectivityAnalysisResults) {
+                    processContingenciesBreakingConnectivity(connectivityAnalysisResult, lfNetwork, lfParameters, lfParametersExt,
+                            dcLoadFlowParameters, equationSystem, validFactorHolder, factorGroups, participatingElements,
+                            contingencyElementByBranch, j, flowStates, factorsStates, contingenciesStates, resultWriter, reporter);
+                }
             }
-        }
 
-        stopwatch.stop();
-        LOGGER.info("DC sensitivity analysis done in {} ms", stopwatch.elapsed(TimeUnit.MILLISECONDS));
+            stopwatch.stop();
+            LOGGER.info("DC sensitivity analysis done in {} ms", stopwatch.elapsed(TimeUnit.MILLISECONDS));
+        }
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/LfActionTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/LfActionTest.java
@@ -62,7 +62,7 @@ class LfActionTest extends AbstractConverterTest {
         AcLoadFlowParameters acParameters = OpenLoadFlowParameters.createAcParameters(network,
                 new LoadFlowParameters(), new OpenLoadFlowParameters(), matrixFactory, new NaiveGraphConnectivityFactory<>(LfBus::getNum), Reporter.NO_OP, true, false);
         try (LfNetworkList lfNetworks = Networks.load(network, acParameters.getNetworkParameters(), Set.of(network.getSwitch("C")), Collections.emptySet(), Reporter.NO_OP)) {
-            LfNetwork lfNetwork = lfNetworks.getList().get(0);
+            LfNetwork lfNetwork = lfNetworks.getLargest().orElseThrow();
             LfAction lfAction = new LfAction(switchAction, lfNetwork);
             String loadId = "LOAD";
             Contingency contingency = new Contingency(loadId, new LoadContingency("LD"));

--- a/src/test/java/com/powsybl/openloadflow/sa/LfActionTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/LfActionTest.java
@@ -21,6 +21,7 @@ import com.powsybl.openloadflow.network.LfAction;
 import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.network.LfNetwork;
 import com.powsybl.openloadflow.network.NodeBreakerNetworkFactory;
+import com.powsybl.openloadflow.network.impl.LfNetworkList;
 import com.powsybl.openloadflow.network.impl.Networks;
 import com.powsybl.openloadflow.network.impl.PropagatedContingency;
 import com.powsybl.security.action.SwitchAction;
@@ -60,21 +61,22 @@ class LfActionTest extends AbstractConverterTest {
         var matrixFactory = new DenseMatrixFactory();
         AcLoadFlowParameters acParameters = OpenLoadFlowParameters.createAcParameters(network,
                 new LoadFlowParameters(), new OpenLoadFlowParameters(), matrixFactory, new NaiveGraphConnectivityFactory<>(LfBus::getNum), Reporter.NO_OP, true, false);
-        List<LfNetwork> lfNetworks = Networks.load(network, acParameters.getNetworkParameters(), Set.of(network.getSwitch("C")), Collections.emptySet(), Reporter.NO_OP);
-        LfNetwork lfNetwork = lfNetworks.get(0);
-        LfAction lfAction = new LfAction(switchAction, lfNetwork);
-        String loadId = "LOAD";
-        Contingency contingency = new Contingency(loadId, new LoadContingency("LD"));
-        PropagatedContingency propagatedContingency = PropagatedContingency.createList(network,
-                Collections.singletonList(contingency), new HashSet<>(), false, false, false, true).get(0);
-        propagatedContingency.toLfContingency(lfNetwork).ifPresent(lfContingency -> {
-            LfAction.apply(List.of(lfAction), lfNetwork, lfContingency);
-            assertTrue(lfNetwork.getBranchById("C").isDisabled());
-            assertEquals("C", lfAction.getDisabledBranch().getId());
-            assertNull(lfAction.getEnabledBranch());
-        });
+        try (LfNetworkList lfNetworks = Networks.load(network, acParameters.getNetworkParameters(), Set.of(network.getSwitch("C")), Collections.emptySet(), Reporter.NO_OP)) {
+            LfNetwork lfNetwork = lfNetworks.getList().get(0);
+            LfAction lfAction = new LfAction(switchAction, lfNetwork);
+            String loadId = "LOAD";
+            Contingency contingency = new Contingency(loadId, new LoadContingency("LD"));
+            PropagatedContingency propagatedContingency = PropagatedContingency.createList(network,
+                    Collections.singletonList(contingency), new HashSet<>(), false, false, false, true).get(0);
+            propagatedContingency.toLfContingency(lfNetwork).ifPresent(lfContingency -> {
+                LfAction.apply(List.of(lfAction), lfNetwork, lfContingency);
+                assertTrue(lfNetwork.getBranchById("C").isDisabled());
+                assertEquals("C", lfAction.getDisabledBranch().getId());
+                assertNull(lfAction.getEnabledBranch());
+            });
 
-        SwitchAction switchAction2 = new SwitchAction("switchAction", "S", true);
-        assertThrows(PowsyblException.class, () -> new LfAction(switchAction2, lfNetwork), "Branch S not found in the network");
+            SwitchAction switchAction2 = new SwitchAction("switchAction", "S", true);
+            assertThrows(PowsyblException.class, () -> new LfAction(switchAction2, lfNetwork), "Branch S not found in the network");
+        }
     }
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When we create a LF network from an IIDM network in bus/breaker topo, we create it from a temporary variant. The variant is removed just after and created LF network still wraps IIDM objects from removed variants (especially calculated bus which are no more part of the IIDM network). The only reason for we didn't seen any bug is that we don't update the IIDM network at the end. 


**What is the new behavior (if this is a feature change)?**
IIDM temporary variant is removed at the end of the calculation when we don't need it anymore.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
