### PR TITLE
[WIP] Fix calculated p load in security analysis

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -309,6 +309,7 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
         if (newLoadTargetP != this.loadTargetP) {
             double oldLoadTargetP = this.loadTargetP;
             this.loadTargetP = newLoadTargetP;
+            lfAggregatedLoads.invalidate();
             for (LfNetworkListener listener : network.getListeners()) {
                 listener.onLoadActivePowerTargetChange(this, oldLoadTargetP, newLoadTargetP);
             }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfAggregatedLoadsImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfAggregatedLoadsImpl.java
@@ -41,6 +41,10 @@ class LfAggregatedLoadsImpl extends AbstractPropertyBag implements LfAggregatedL
         return loads.stream().map(Identifiable::getId).collect(Collectors.toList());
     }
 
+    void invalidate() {
+        initialized = false;
+    }
+
     void add(Load load) {
         loads.add(load);
         initialized = false;

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -1178,9 +1178,9 @@ class OpenSecurityAnalysisTest {
 
         // post-contingency tests
         PostContingencyResult l4ContingencyResult = getPostContingencyResult(result, "l4");
-        assertEquals(80.003, l4ContingencyResult.getNetworkResult().getBranchResult("l24").getP1(), LoadFlowAssert.DELTA_POWER);
-        assertEquals(-40.002, l4ContingencyResult.getNetworkResult().getBranchResult("l14").getP2(), LoadFlowAssert.DELTA_POWER);
-        assertEquals(99.997, l4ContingencyResult.getNetworkResult().getBranchResult("l34").getP2(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(83.053, l4ContingencyResult.getNetworkResult().getBranchResult("l24").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(-41.526, l4ContingencyResult.getNetworkResult().getBranchResult("l14").getP2(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(97.455, l4ContingencyResult.getNetworkResult().getBranchResult("l34").getP2(), LoadFlowAssert.DELTA_POWER);
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
No fully sure of the diagnostic: but I think that in a security analysis with a contingency load, distribution p factor for load update are not recalculated taking into account the missing load.


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
