### PR TITLE
added test for lines with different nominal voltages at both ends

### DIFF
--- a/src/test/java/com/powsybl/openloadflow/ac/LinesWithDifferentNominalVoltagesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/LinesWithDifferentNominalVoltagesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * Copyright (c) 2022, Coreso SA (https://www.coreso.eu/) and TSCNET Services GmbH (https://www.tscnet.eu/)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/src/test/java/com/powsybl/openloadflow/ac/LinesWithDifferentNominalVoltagesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/LinesWithDifferentNominalVoltagesTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.ac;
+
+import com.powsybl.iidm.network.Branch;
+import com.powsybl.iidm.network.Bus;
+import com.powsybl.iidm.network.Line;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.loadflow.LoadFlow;
+import com.powsybl.loadflow.LoadFlowParameters;
+import com.powsybl.loadflow.LoadFlowResult;
+import com.powsybl.math.matrix.DenseMatrixFactory;
+import com.powsybl.openloadflow.OpenLoadFlowParameters;
+import com.powsybl.openloadflow.OpenLoadFlowProvider;
+import com.powsybl.openloadflow.network.LinesWithDifferentNominalVoltagesNetworkFactory;
+import com.powsybl.openloadflow.network.SlackBusSelectionMode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.powsybl.openloadflow.util.LoadFlowAssert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @see LinesWithDifferentNominalVoltagesNetworkFactory
+ *
+ * @author Damien Jeandemange <damien.jeandemange at artelys.com>
+ */
+class LinesWithDifferentNominalVoltagesTest {
+
+    private Network network;
+    private LoadFlow.Runner loadFlowRunner;
+    private LoadFlowParameters parameters;
+
+    private Bus b225g;
+    private Bus b225l;
+    private Bus b220A;
+    private Bus b230A;
+    private Bus b220B;
+    private Bus b230B;
+    private Line l225to225;
+    private Line l225to230;
+    private Line l225to220;
+    private Line l230to225;
+    private Line l220to225;
+
+    @BeforeEach
+    void setUp() {
+        network = LinesWithDifferentNominalVoltagesNetworkFactory.create();
+
+        b225g = network.getBusBreakerView().getBus("b225g");
+        b225l = network.getBusBreakerView().getBus("b225l");
+        b220A = network.getBusBreakerView().getBus("b220A");
+        b230A = network.getBusBreakerView().getBus("b230A");
+        b220B = network.getBusBreakerView().getBus("b220B");
+        b230B = network.getBusBreakerView().getBus("b230B");
+        l225to225 = network.getLine("l225-225");
+        l225to230 = network.getLine("l225-230");
+        l225to220 = network.getLine("l225-220");
+        l230to225 = network.getLine("l230-225");
+        l220to225 = network.getLine("l220-225");
+
+        loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
+        parameters = new LoadFlowParameters().setDistributedSlack(true);
+        OpenLoadFlowParameters.create(parameters)
+                .setSlackBusSelectionMode(SlackBusSelectionMode.LARGEST_GENERATOR)
+                .setAddRatioToLinesWithDifferentNominalVoltageAtBothEnds(true);
+    }
+
+    @Test
+    void test() {
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertEquals(1, result.getComponentResults().size());
+
+        // slack bus
+        assertVoltageEquals(225.0, b225g);
+        assertAngleEquals(0.0, b225g);
+
+        // load buses
+        List.of(b225l, b220A, b230A, b220B, b230B).forEach(bus -> {
+            assertVoltageEquals(218.294, bus);
+            assertAngleEquals(-3.4606395, bus);
+        });
+
+        // line flows, load side
+        List.of(
+            l225to225.getTerminal(Branch.Side.TWO),
+            l225to220.getTerminal(Branch.Side.TWO),
+            l225to230.getTerminal(Branch.Side.TWO),
+            l220to225.getTerminal(Branch.Side.ONE),
+            l230to225.getTerminal(Branch.Side.ONE)).forEach(terminal -> {
+                assertActivePowerEquals(-100, terminal);
+                assertReactivePowerEquals(-40, terminal);
+            });
+
+        // line flows, generator side
+        List.of(
+            l225to225.getTerminal(Branch.Side.ONE),
+            l225to220.getTerminal(Branch.Side.ONE),
+            l225to230.getTerminal(Branch.Side.ONE),
+            l220to225.getTerminal(Branch.Side.TWO),
+            l230to225.getTerminal(Branch.Side.TWO)).forEach(terminal -> {
+                assertActivePowerEquals(103.444104, terminal);
+                assertReactivePowerEquals(45.4712006, terminal);
+            });
+    }
+
+}

--- a/src/test/java/com/powsybl/openloadflow/network/LinesWithDifferentNominalVoltagesNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/LinesWithDifferentNominalVoltagesNetworkFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * Copyright (c) 2022, Coreso SA (https://www.coreso.eu/) and TSCNET Services GmbH (https://www.tscnet.eu/)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/src/test/java/com/powsybl/openloadflow/network/LinesWithDifferentNominalVoltagesNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/LinesWithDifferentNominalVoltagesNetworkFactory.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.network;
+
+import com.powsybl.iidm.network.Bus;
+import com.powsybl.iidm.network.EnergySource;
+import com.powsybl.iidm.network.Generator;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.extensions.ActivePowerControlAdder;
+
+/**
+ * <p>test network with lines connecting buses with different nominal voltages
+ * , all other parameters identical (r, x, gsh, bsh, ...)</p>
+ * <p>all lines should solve to the exact same solution</p>
+ *
+ * <pre>
+ *
+ *           225kV Bus     side1    side2      225kV Bus
+ *      g1----[b225g]--------(l225-225)---------[b225l]---->l225 Load
+ *   Generator   |
+ *               |         side1    side2      220kV Bus
+ *               ------------(l225-220)---------[b220A]---->l220A Load
+ *               |
+ *               |         side1    side2      230kV Bus
+ *               ------------(l225-230)---------[b230A]---->l230A Load
+ *               |
+ *               |         side2    side1      220kV Bus
+ *               ------------(l220-225)---------[b220B]---->l220B Load
+ *               |
+ *               |         side2    side1      230kV Bus
+ *               ------------(l230-225)---------[b230B]---->l230B Load
+ *
+ * </pre>
+ *
+ * @author Damien Jeandemange <damien.jeandemange at artelys.com>
+ */
+public class LinesWithDifferentNominalVoltagesNetworkFactory extends AbstractLoadFlowNetworkFactory {
+
+    public static Network create() {
+        Network network = Network.create("lines-different-nominal-voltage", "code");
+        Bus b225g = createBus(network, "b225g", 225);
+        Bus b225l = createBus(network, "b225l", 225);
+        Bus b220A = createBus(network, "b220A", 220);
+        Bus b230A = createBus(network, "b230A", 230);
+        Bus b220B = createBus(network, "b220B", 220);
+        Bus b230B = createBus(network, "b230B", 230);
+        Generator g1 = b225g.getVoltageLevel()
+                .newGenerator()
+                .setId("g1")
+                .setBus("b225g")
+                .setConnectableBus("b225g")
+                .setEnergySource(EnergySource.THERMAL)
+                .setMinP(0)
+                .setMaxP(600)
+                .setTargetP(500)
+                .setTargetV(225)
+                .setVoltageRegulatorOn(true)
+                .add();
+        g1.newExtension(ActivePowerControlAdder.class)
+                .withParticipate(true)
+                .withDroop(4)
+                .add();
+        // loads
+        final double pLoad = 100;
+        final double qLoad = 40;
+        createLoad(b225l, "l225", pLoad, qLoad);
+        createLoad(b220A, "l220A", pLoad, qLoad);
+        createLoad(b230A, "l230A", pLoad, qLoad);
+        createLoad(b220B, "l220B", pLoad, qLoad);
+        createLoad(b230B, "l230B", pLoad, qLoad);
+        // lines
+        final double r = 2.0;
+        final double x = 30.0;
+        final double halfGsh = 3e-5;
+        final double halfBsh = 2e-5;
+        createLine(network, b225g, b225l, "l225-225", x);
+        createLine(network, b225g, b220A, "l225-220", x);
+        createLine(network, b225g, b230A, "l225-230", x);
+        createLine(network, b220B, b225g, "l220-225", x);
+        createLine(network, b230B, b225g, "l230-225", x);
+        network.getLines().forEach(l -> l.setR(r).setB1(halfBsh).setG1(halfGsh).setB2(halfBsh).setG2(halfGsh));
+        return network;
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Damien Jeandemange <damien.jeandemange@artelys.com>

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
No change, only test added about lines whose terminals are of different nominal voltage.
This test confirms the option `addRatioToLinesWithDifferentNominalVoltageAtBothEnds` should always be enabled to get correct results in AC NR loadflow.


**What is the current behavior?**
good behavior :)


**What is the new behavior (if this is a feature change)?**
unchanged good behavior :)
