### PR TITLE
Zero impedance branch management refactoring

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
@@ -126,7 +126,7 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
                                                 parameters.isDistributedSlack() && (parameters.getBalanceType() == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD || parameters.getBalanceType() == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD) && parametersExt.isLoadPowerFactorConstant(), parameters.isDc());
 
                 // zero or low impedance branch flows computation
-                computeZeroImpedanceFlows(result.getNetwork(), parameters.isDc(), parametersExt.getLowImpedanceThreshold());
+                computeZeroImpedanceFlows(result.getNetwork());
             }
 
             LoadFlowResult.ComponentResult.Status status;
@@ -158,11 +158,11 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
         return new LoadFlowResultImpl(ok, Collections.emptyMap(), null, componentResults);
     }
 
-    private void computeZeroImpedanceFlows(LfNetwork network, boolean dc, double lowImpedanceThreshold) {
-        Graph<LfBus, LfBranch> zeroImpedanceSubGraph = network.createZeroImpedanceSubGraph(dc, lowImpedanceThreshold);
+    private void computeZeroImpedanceFlows(LfNetwork network) {
+        Graph<LfBus, LfBranch> zeroImpedanceSubGraph = network.createZeroImpedanceSubGraph();
         if (!zeroImpedanceSubGraph.vertexSet().isEmpty()) {
             SpanningTreeAlgorithm.SpanningTree<LfBranch> spanningTree = new KruskalMinimumSpanningTree<>(zeroImpedanceSubGraph).getSpanningTree();
-            new ZeroImpedanceFlows(zeroImpedanceSubGraph, spanningTree).compute(dc, lowImpedanceThreshold);
+            new ZeroImpedanceFlows(zeroImpedanceSubGraph, spanningTree).compute();
         }
     }
 
@@ -196,7 +196,7 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
                     false, true);
 
             // zero or low impedance branch flows computation
-            computeZeroImpedanceFlows(result.getNetwork(), true, networkParameters.getLowImpedanceThreshold());
+            computeZeroImpedanceFlows(result.getNetwork());
         }
 
         return new LoadFlowResultImpl.ComponentResultImpl(

--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
@@ -30,7 +30,6 @@ import com.powsybl.openloadflow.graph.GraphConnectivityFactory;
 import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.network.LfNetwork;
-import com.powsybl.openloadflow.network.LfNetworkParameters;
 import com.powsybl.openloadflow.network.impl.LfNetworkLoaderImpl;
 import com.powsybl.openloadflow.network.impl.Networks;
 import com.powsybl.openloadflow.network.util.ZeroImpedanceFlows;
@@ -176,13 +175,12 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
 
         Networks.resetState(network);
 
-        List<LoadFlowResult.ComponentResult> componentsResult = results.stream().map(r -> processResult(network, r, parameters, dcParameters.getNetworkParameters())).collect(Collectors.toList());
+        List<LoadFlowResult.ComponentResult> componentsResult = results.stream().map(r -> processResult(network, r, parameters)).collect(Collectors.toList());
         boolean ok = results.stream().anyMatch(DcLoadFlowResult::isSucceeded);
         return new LoadFlowResultImpl(ok, Collections.emptyMap(), null, componentsResult);
     }
 
-    private LoadFlowResult.ComponentResult processResult(Network network, DcLoadFlowResult result, LoadFlowParameters parameters,
-                                                         LfNetworkParameters networkParameters) {
+    private LoadFlowResult.ComponentResult processResult(Network network, DcLoadFlowResult result, LoadFlowParameters parameters) {
         if (result.isSucceeded() && parameters.isWriteSlackBus()) {
             SlackTerminal.reset(network);
         }

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystem.java
@@ -248,7 +248,7 @@ public final class AcEquationSystem {
         List<EquationTerm<AcVariableType, AcEquationType>> terms = new ArrayList<>();
         for (LfBranch branch : controllerBus.getBranches()) {
             EquationTerm<AcVariableType, AcEquationType> q;
-            if (branch.isZeroImpedanceBranch()) {
+            if (branch.isZeroImpedance()) {
                 if (!branch.isSpanningTreeEdge()) {
                     continue;
                 }
@@ -740,7 +740,7 @@ public final class AcEquationSystem {
                                               EquationSystem<AcVariableType, AcEquationType> equationSystem,
                                               AcEquationSystemCreationParameters creationParameters) {
         // create zero and non zero impedance branch equations
-        if (branch.isZeroImpedanceBranch()) {
+        if (branch.isZeroImpedance()) {
             if (branch.isSpanningTreeEdge()) {
                 createNonImpedantBranch(branch, branch.getBus1(), branch.getBus2(), equationSystem);
             }

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
@@ -15,8 +15,8 @@ import com.powsybl.openloadflow.network.*;
  */
 public class AcEquationSystemUpdater extends AbstractEquationSystemUpdater<AcVariableType, AcEquationType> {
 
-    public AcEquationSystemUpdater(EquationSystem<AcVariableType, AcEquationType> equationSystem, double lowImpedanceThreshold) {
-        super(equationSystem, lowImpedanceThreshold);
+    public AcEquationSystemUpdater(EquationSystem<AcVariableType, AcEquationType> equationSystem) {
+        super(equationSystem);
     }
 
     @Override
@@ -61,7 +61,7 @@ public class AcEquationSystemUpdater extends AbstractEquationSystemUpdater<AcVar
 
     @Override
     public void onDisableChange(LfElement element, boolean disabled) {
-        updateElementEquations(element, !disabled, false);
+        updateElementEquations(element, !disabled);
         switch (element.getType()) {
             case BUS:
                 LfBus bus = (LfBus) element;

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcLoadFlowContext.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcLoadFlowContext.java
@@ -35,8 +35,7 @@ public class AcLoadFlowContext extends AbstractLoadFlowContext<AcVariableType, A
     @Override
     public EquationSystem<AcVariableType, AcEquationType> getEquationSystem() {
         if (equationSystem == null) {
-            equationSystem = AcEquationSystem.create(network, parameters.getEquationSystemCreationParameters(),
-                    parameters.getNetworkParameters().getLowImpedanceThreshold());
+            equationSystem = AcEquationSystem.create(network, parameters.getEquationSystemCreationParameters());
         }
         return equationSystem;
     }

--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowContext.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowContext.java
@@ -29,7 +29,7 @@ public class DcLoadFlowContext extends AbstractLoadFlowContext<DcVariableType, D
     @Override
     public EquationSystem<DcVariableType, DcEquationType> getEquationSystem() {
         if (equationSystem == null) {
-            equationSystem = DcEquationSystem.create(network, parameters.getEquationSystemCreationParameters(), parameters.getNetworkParameters().getLowImpedanceThreshold(), true);
+            equationSystem = DcEquationSystem.create(network, parameters.getEquationSystemCreationParameters(), true);
         }
         return equationSystem;
     }

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationSystem.java
@@ -109,7 +109,7 @@ public final class DcEquationSystem {
             LfBus bus1 = branch.getBus1();
             LfBus bus2 = branch.getBus2();
             if (branch.isZeroImpedanceBranch()) {
-                if (bus1 != null && bus2 != null && branch.isSpanningTreeEdge()) {
+                if (branch.isSpanningTreeEdge()) {
                     createNonImpedantBranch(equationSystem, branch, bus1, bus2);
                 }
             } else {

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationSystem.java
@@ -108,7 +108,7 @@ public final class DcEquationSystem {
         for (LfBranch branch : network.getBranches()) {
             LfBus bus1 = branch.getBus1();
             LfBus bus2 = branch.getBus2();
-            if (branch.isZeroImpedanceBranch()) {
+            if (branch.isZeroImpedance()) {
                 if (branch.isSpanningTreeEdge()) {
                     createNonImpedantBranch(equationSystem, branch, bus1, bus2);
                 }

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationSystem.java
@@ -13,13 +13,6 @@ import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.network.LfNetwork;
 import com.powsybl.openloadflow.util.EvaluableConstants;
-import org.jgrapht.Graph;
-import org.jgrapht.alg.interfaces.SpanningTreeAlgorithm;
-import org.jgrapht.alg.spanning.KruskalMinimumSpanningTree;
-import org.jgrapht.graph.Pseudograph;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -111,48 +104,31 @@ public final class DcEquationSystem {
     }
 
     private static void createBranches(LfNetwork network, EquationSystem<DcVariableType, DcEquationType> equationSystem,
-                                       DcEquationSystemCreationParameters creationParameters,
-                                       double lowImpedanceThreshold) {
-        List<LfBranch> nonImpedantBranches = new ArrayList<>();
+                                       DcEquationSystemCreationParameters creationParameters) {
         for (LfBranch branch : network.getBranches()) {
             LfBus bus1 = branch.getBus1();
             LfBus bus2 = branch.getBus2();
-            if (branch.isZeroImpedanceBranch(true, lowImpedanceThreshold)) {
-                if (bus1 != null && bus2 != null) {
-                    nonImpedantBranches.add(branch);
+            if (branch.isZeroImpedanceBranch()) {
+                if (bus1 != null && bus2 != null && branch.isSpanningTreeEdge()) {
+                    createNonImpedantBranch(equationSystem, branch, bus1, bus2);
                 }
             } else {
                 createImpedantBranch(equationSystem, creationParameters, branch, bus1, bus2);
             }
         }
-
-        // create non impedant equations only on minimum spanning forest calculated from non impedant subgraph
-        if (!nonImpedantBranches.isEmpty()) {
-            Graph<LfBus, LfBranch> nonImpedantSubGraph = new Pseudograph<>(LfBranch.class);
-            for (LfBranch branch : nonImpedantBranches) {
-                nonImpedantSubGraph.addVertex(branch.getBus1());
-                nonImpedantSubGraph.addVertex(branch.getBus2());
-                nonImpedantSubGraph.addEdge(branch.getBus1(), branch.getBus2(), branch);
-            }
-
-            SpanningTreeAlgorithm.SpanningTree<LfBranch> spanningTree = new KruskalMinimumSpanningTree<>(nonImpedantSubGraph).getSpanningTree();
-            for (LfBranch branch : spanningTree.getEdges()) {
-                createNonImpedantBranch(equationSystem, branch, branch.getBus1(), branch.getBus2());
-            }
-        }
     }
 
     public static EquationSystem<DcVariableType, DcEquationType> create(LfNetwork network, DcEquationSystemCreationParameters creationParameters,
-                                                                        double lowImpedanceThreshold, boolean withListener) {
+                                                                        boolean withListener) {
         EquationSystem<DcVariableType, DcEquationType> equationSystem = new EquationSystem<>(creationParameters.isIndexTerms());
 
         createBuses(network, equationSystem);
-        createBranches(network, equationSystem, creationParameters, lowImpedanceThreshold);
+        createBranches(network, equationSystem, creationParameters);
 
         EquationSystemPostProcessor.findAll().forEach(pp -> pp.onCreate(equationSystem));
 
         if (withListener) {
-            network.addListener(new DcEquationSystemUpdater(equationSystem, lowImpedanceThreshold));
+            network.addListener(new DcEquationSystemUpdater(equationSystem));
         }
 
         return equationSystem;

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationSystemUpdater.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationSystemUpdater.java
@@ -15,8 +15,8 @@ import com.powsybl.openloadflow.network.*;
  */
 public class DcEquationSystemUpdater extends AbstractEquationSystemUpdater<DcVariableType, DcEquationType> {
 
-    public DcEquationSystemUpdater(EquationSystem<DcVariableType, DcEquationType> equationSystem, double lowImpedanceThreshold) {
-        super(equationSystem, lowImpedanceThreshold);
+    public DcEquationSystemUpdater(EquationSystem<DcVariableType, DcEquationType> equationSystem) {
+        super(equationSystem);
     }
 
     @Override
@@ -33,7 +33,7 @@ public class DcEquationSystemUpdater extends AbstractEquationSystemUpdater<DcVar
 
     @Override
     public void onDisableChange(LfElement element, boolean disabled) {
-        updateElementEquations(element, !disabled, true);
+        updateElementEquations(element, !disabled);
         switch (element.getType()) {
             case BUS:
                 LfBus bus = (LfBus) element;

--- a/src/main/java/com/powsybl/openloadflow/lf/AbstractEquationSystemUpdater.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/AbstractEquationSystemUpdater.java
@@ -35,7 +35,7 @@ public abstract class AbstractEquationSystemUpdater<V extends Enum<V> & Quantity
     protected abstract void updateNonImpedantBranchEquations(LfBranch branch, boolean enable);
 
     protected void updateElementEquations(LfElement element, boolean enable) {
-        if (element instanceof LfBranch && ((LfBranch) element).isZeroImpedanceBranchWithEquation()) {
+        if (element instanceof LfBranch && ((LfBranch) element).isZeroImpedance() && ((LfBranch) element).isSpanningTreeEdge()) {
             updateNonImpedantBranchEquations((LfBranch) element, enable);
         } else {
             // update all equations related to the element

--- a/src/main/java/com/powsybl/openloadflow/lf/AbstractEquationSystemUpdater.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/AbstractEquationSystemUpdater.java
@@ -22,11 +22,8 @@ public abstract class AbstractEquationSystemUpdater<V extends Enum<V> & Quantity
 
     protected final EquationSystem<V, E> equationSystem;
 
-    protected final double lowImpedanceThreshold;
-
-    protected AbstractEquationSystemUpdater(EquationSystem<V, E> equationSystem, double lowImpedanceThreshold) {
+    protected AbstractEquationSystemUpdater(EquationSystem<V, E> equationSystem) {
         this.equationSystem = equationSystem;
-        this.lowImpedanceThreshold = lowImpedanceThreshold;
     }
 
     protected static void checkSlackBus(LfBus bus, boolean disabled) {
@@ -37,13 +34,8 @@ public abstract class AbstractEquationSystemUpdater<V extends Enum<V> & Quantity
 
     protected abstract void updateNonImpedantBranchEquations(LfBranch branch, boolean enable);
 
-    protected boolean isNonImpedantBranchWithEquation(LfBranch branch, boolean dc) {
-        return branch.isZeroImpedanceBranch(dc, lowImpedanceThreshold)
-                && branch.isSpanningTreeEdge();
-    }
-
-    protected void updateElementEquations(LfElement element, boolean enable, boolean dc) {
-        if (element instanceof LfBranch && isNonImpedantBranchWithEquation((LfBranch) element, dc)) {
+    protected void updateElementEquations(LfElement element, boolean enable) {
+        if (element instanceof LfBranch && ((LfBranch) element).isZeroImpedanceBranchWithEquation()) {
             updateNonImpedantBranchEquations((LfBranch) element, enable);
         } else {
             // update all equations related to the element

--- a/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
@@ -139,13 +139,11 @@ public interface LfBranch extends LfElement {
 
     double computeApparentPower2();
 
-    boolean isZeroImpedanceBranch();
+    boolean isZeroImpedance();
 
     void setSpanningTreeEdge(boolean spanningTreeEdge);
 
     boolean isSpanningTreeEdge();
-
-    boolean isZeroImpedanceBranchWithEquation();
 
     Evaluable getA1();
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
@@ -139,11 +139,13 @@ public interface LfBranch extends LfElement {
 
     double computeApparentPower2();
 
-    boolean isZeroImpedanceBranch(boolean dc, double lowImpedanceThreshold);
+    boolean isZeroImpedanceBranch();
 
     void setSpanningTreeEdge(boolean spanningTreeEdge);
 
     boolean isSpanningTreeEdge();
+
+    boolean isZeroImpedanceBranchWithEquation();
 
     Evaluable getA1();
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -517,8 +517,8 @@ public class LfNetwork extends AbstractPropertyBag implements PropertyBag {
      * The graph is intentionally not cached as a parameter so far, to avoid the complexity of invalidating it if changes occur
      * @return the zero-impedance subgraph
      */
-    public Graph<LfBus, LfBranch> createZeroImpedanceSubGraph(boolean dc, double lowImpedanceThreshold) {
-        return createSubGraph(branch -> branch.isZeroImpedanceBranch(dc, lowImpedanceThreshold)
+    public Graph<LfBus, LfBranch> createZeroImpedanceSubGraph() {
+        return createSubGraph(branch -> branch.isZeroImpedanceBranch()
                 && branch.getBus1() != null && branch.getBus2() != null);
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -518,7 +518,7 @@ public class LfNetwork extends AbstractPropertyBag implements PropertyBag {
      * @return the zero-impedance subgraph
      */
     public Graph<LfBus, LfBranch> createZeroImpedanceSubGraph() {
-        return createSubGraph(branch -> branch.isZeroImpedanceBranch()
+        return createSubGraph(branch -> branch.isZeroImpedance()
                 && branch.getBus1() != null && branch.getBus2() != null);
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractImpedantLfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractImpedantLfBranch.java
@@ -32,8 +32,8 @@ public abstract class AbstractImpedantLfBranch extends AbstractLfBranch {
 
     protected Evaluable i2 = NAN;
 
-    protected AbstractImpedantLfBranch(LfNetwork network, LfBus bus1, LfBus bus2, PiModel piModel) {
-        super(network, bus1, bus2, piModel);
+    protected AbstractImpedantLfBranch(LfNetwork network, LfBus bus1, LfBus bus2, PiModel piModel, boolean dc, double lowImpedanceThreshold) {
+        super(network, bus1, bus2, piModel, dc, lowImpedanceThreshold);
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
@@ -49,7 +49,7 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
 
     private ReactivePowerControl reactivePowerControl;
 
-    protected boolean zeroImpedanceBranch;
+    protected boolean zeroImpedance;
 
     protected AbstractLfBranch(LfNetwork network, LfBus bus1, LfBus bus2, PiModel piModel, boolean dc, double lowImpedanceThreshold) {
         super(network);
@@ -57,11 +57,7 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
         this.bus2 = bus2;
         this.piModel = Objects.requireNonNull(piModel);
         this.piModel.setBranch(this);
-        if (dc) {
-            zeroImpedanceBranch = FastMath.abs(piModel.getX()) < lowImpedanceThreshold;
-        } else {
-            zeroImpedanceBranch = piModel.getZ() < lowImpedanceThreshold;
-        }
+        zeroImpedance = isZeroImpedanceBranch(piModel, dc, lowImpedanceThreshold);
     }
 
     protected static List<LfLimit> createSortedLimitsList(LoadingLimits loadingLimits, LfBus bus) {
@@ -251,8 +247,8 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
     }
 
     @Override
-    public boolean isZeroImpedanceBranch() {
-        return this.zeroImpedanceBranch;
+    public boolean isZeroImpedance() {
+        return this.zeroImpedance;
     }
 
     @Override
@@ -263,11 +259,6 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
     @Override
     public boolean isSpanningTreeEdge() {
         return this.spanningTreeEdge;
-    }
-
-    @Override
-    public boolean isZeroImpedanceBranchWithEquation() {
-        return this.zeroImpedanceBranch && this.spanningTreeEdge;
     }
 
     @Override
@@ -299,6 +290,14 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
         if (piModel.setMinZ(lowImpedanceThreshold, dc)) {
             LOGGER.trace("Branch {} has a low impedance, set to min {}", getId(), lowImpedanceThreshold);
         }
-        this.zeroImpedanceBranch = false;
+        this.zeroImpedance = false;
+    }
+
+    public static boolean isZeroImpedanceBranch(PiModel piModel, boolean dc, double lowImpedanceThreshold) {
+        if (dc) {
+            return FastMath.abs(piModel.getX()) < lowImpedanceThreshold;
+        } else {
+            return piModel.getZ() < lowImpedanceThreshold;
+        }
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
@@ -23,12 +23,12 @@ public class LfBranchImpl extends AbstractImpedantLfBranch {
 
     private final Ref<Branch<?>> branchRef;
 
-    protected LfBranchImpl(LfNetwork network, LfBus bus1, LfBus bus2, PiModel piModel, Branch<?> branch) {
-        super(network, bus1, bus2, piModel);
+    protected LfBranchImpl(LfNetwork network, LfBus bus1, LfBus bus2, PiModel piModel, Branch<?> branch, boolean dc, double lowImpedanceThreshold) {
+        super(network, bus1, bus2, piModel, dc, lowImpedanceThreshold);
         this.branchRef = new Ref<>(branch);
     }
 
-    private static LfBranchImpl createLine(Line line, LfNetwork network, LfBus bus1, LfBus bus2, double zb) {
+    private static LfBranchImpl createLine(Line line, LfNetwork network, LfBus bus1, LfBus bus2, double zb, boolean dc, double lowImpedanceThreshold) {
         PiModel piModel = new SimplePiModel()
                 .setR1(1 / Transformers.getRatioPerUnitBase(line))
                 .setR(line.getR() / zb)
@@ -38,10 +38,11 @@ public class LfBranchImpl extends AbstractImpedantLfBranch {
                 .setB1(line.getB1() * zb)
                 .setB2(line.getB2() * zb);
 
-        return new LfBranchImpl(network, bus1, bus2, piModel, line);
+        return new LfBranchImpl(network, bus1, bus2, piModel, line, dc, lowImpedanceThreshold);
     }
 
-    private static LfBranchImpl createTransformer(TwoWindingsTransformer twt, LfNetwork network, LfBus bus1, LfBus bus2, double zb, boolean twtSplitShuntAdmittance) {
+    private static LfBranchImpl createTransformer(TwoWindingsTransformer twt, LfNetwork network, LfBus bus1, LfBus bus2, double zb,
+                                                  boolean twtSplitShuntAdmittance, boolean dc, double lowImpedanceThreshold) {
         PiModel piModel = null;
 
         double baseRatio = Transformers.getRatioPerUnitBase(twt);
@@ -85,18 +86,19 @@ public class LfBranchImpl extends AbstractImpedantLfBranch {
             piModel = Transformers.createPiModel(tapCharacteristics, zb, baseRatio, twtSplitShuntAdmittance);
         }
 
-        return new LfBranchImpl(network, bus1, bus2, piModel, twt);
+        return new LfBranchImpl(network, bus1, bus2, piModel, twt, dc, lowImpedanceThreshold);
     }
 
-    public static LfBranchImpl create(Branch<?> branch, LfNetwork network, LfBus bus1, LfBus bus2, boolean twtSplitShuntAdmittance) {
+    public static LfBranchImpl create(Branch<?> branch, LfNetwork network, LfBus bus1, LfBus bus2, boolean twtSplitShuntAdmittance,
+                                      boolean dc, double lowImpedanceThreshold) {
         Objects.requireNonNull(branch);
         double nominalV2 = branch.getTerminal2().getVoltageLevel().getNominalV();
         double zb = nominalV2 * nominalV2 / PerUnit.SB;
         if (branch instanceof Line) {
-            return createLine((Line) branch, network, bus1, bus2, zb);
+            return createLine((Line) branch, network, bus1, bus2, zb, dc, lowImpedanceThreshold);
         } else if (branch instanceof TwoWindingsTransformer) {
             TwoWindingsTransformer twt = (TwoWindingsTransformer) branch;
-            return createTransformer(twt, network, bus1, bus2, zb, twtSplitShuntAdmittance);
+            return createTransformer(twt, network, bus1, bus2, zb, twtSplitShuntAdmittance, dc, lowImpedanceThreshold);
         } else {
             throw new PowsyblException("Unsupported type of branch for flow equations of branch: " + branch.getId());
         }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
@@ -26,12 +26,14 @@ public class LfDanglingLineBranch extends AbstractImpedantLfBranch {
 
     private final Ref<DanglingLine> danglingLineRef;
 
-    protected LfDanglingLineBranch(LfNetwork network, LfBus bus1, LfBus bus2, PiModel piModel, DanglingLine danglingLine) {
-        super(network, bus1, bus2, piModel);
+    protected LfDanglingLineBranch(LfNetwork network, LfBus bus1, LfBus bus2, PiModel piModel, DanglingLine danglingLine,
+                                   boolean dc, double lowImpedanceThreshold) {
+        super(network, bus1, bus2, piModel, dc, lowImpedanceThreshold);
         this.danglingLineRef = new Ref<>(danglingLine);
     }
 
-    public static LfDanglingLineBranch create(DanglingLine danglingLine, LfNetwork network, LfBus bus1, LfBus bus2) {
+    public static LfDanglingLineBranch create(DanglingLine danglingLine, LfNetwork network, LfBus bus1, LfBus bus2,
+                                              boolean dc, double lowImpedanceThreshold) {
         Objects.requireNonNull(danglingLine);
         Objects.requireNonNull(bus1);
         Objects.requireNonNull(bus2);
@@ -44,7 +46,7 @@ public class LfDanglingLineBranch extends AbstractImpedantLfBranch {
                 .setG2(danglingLine.getG() / 2 * zb)
                 .setB1(danglingLine.getB() / 2 * zb)
                 .setB2(danglingLine.getB() / 2 * zb);
-        return new LfDanglingLineBranch(network, bus1, bus2, piModel, danglingLine);
+        return new LfDanglingLineBranch(network, bus1, bus2, piModel, danglingLine, dc, lowImpedanceThreshold);
     }
 
     private DanglingLine getDanglingLine() {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
@@ -23,8 +23,9 @@ public class LfLegBranch extends AbstractImpedantLfBranch {
 
     private final Ref<ThreeWindingsTransformer.Leg> legRef;
 
-    protected LfLegBranch(LfNetwork network, LfBus bus1, LfBus bus0, PiModel piModel, ThreeWindingsTransformer twt, ThreeWindingsTransformer.Leg leg) {
-        super(network, bus1, bus0, piModel);
+    protected LfLegBranch(LfNetwork network, LfBus bus1, LfBus bus0, PiModel piModel, ThreeWindingsTransformer twt, ThreeWindingsTransformer.Leg leg,
+                          boolean dc, double lowImpedanceThreshold) {
+        super(network, bus1, bus0, piModel, dc, lowImpedanceThreshold);
         this.twtRef = new Ref<>(twt);
         this.legRef = new Ref<>(leg);
     }
@@ -38,7 +39,7 @@ public class LfLegBranch extends AbstractImpedantLfBranch {
     }
 
     public static LfLegBranch create(LfNetwork network, LfBus bus1, LfBus bus0, ThreeWindingsTransformer twt, ThreeWindingsTransformer.Leg leg,
-                                     boolean twtSplitShuntAdmittance) {
+                                     boolean twtSplitShuntAdmittance, boolean dc, double lowImpedanceThreshold) {
         Objects.requireNonNull(bus0);
         Objects.requireNonNull(twt);
         Objects.requireNonNull(leg);
@@ -87,7 +88,7 @@ public class LfLegBranch extends AbstractImpedantLfBranch {
             piModel = Transformers.createPiModel(tapCharacteristics, zb, baseRatio, twtSplitShuntAdmittance);
         }
 
-        return new LfLegBranch(network, bus1, bus0, piModel, twt, leg);
+        return new LfLegBranch(network, bus1, bus0, piModel, twt, leg, dc, lowImpedanceThreshold);
     }
 
     private int getLegNum() {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -322,7 +322,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
             LOGGER.trace("Discard branch '{}' because connected to same bus at both ends", lfBranch.getId());
             report.branchesDiscardedBecauseConnectedToSameBusAtBothEnds++;
         } else {
-            if (lfBranch.isZeroImpedanceBranch()) {
+            if (lfBranch.isZeroImpedance()) {
                 LOGGER.trace("Branch {} is non impedant", lfBranch.getId());
                 report.nonImpedantBranches++;
             }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -316,13 +316,13 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         return lfBus;
     }
 
-    private static void addBranch(LfNetwork lfNetwork, LfBranch lfBranch, LfNetworkLoadingReport report, boolean dc, double lowImpedanceThreshold) {
+    private static void addBranch(LfNetwork lfNetwork, LfBranch lfBranch, LfNetworkLoadingReport report) {
         boolean connectedToSameBus = lfBranch.getBus1() == lfBranch.getBus2();
         if (connectedToSameBus) {
             LOGGER.trace("Discard branch '{}' because connected to same bus at both ends", lfBranch.getId());
             report.branchesDiscardedBecauseConnectedToSameBusAtBothEnds++;
         } else {
-            if (lfBranch.isZeroImpedanceBranch(dc, lowImpedanceThreshold)) {
+            if (lfBranch.isZeroImpedanceBranch()) {
                 LOGGER.trace("Branch {} is non impedant", lfBranch.getId());
                 report.nonImpedantBranches++;
             }
@@ -335,8 +335,9 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         for (Branch<?> branch : loadingContext.branchSet) {
             LfBus lfBus1 = getLfBus(branch.getTerminal1(), lfNetwork, parameters.isBreakers());
             LfBus lfBus2 = getLfBus(branch.getTerminal2(), lfNetwork, parameters.isBreakers());
-            LfBranchImpl lfBranch = LfBranchImpl.create(branch, lfNetwork, lfBus1, lfBus2, parameters.isTwtSplitShuntAdmittance());
-            addBranch(lfNetwork, lfBranch, report, parameters.isDc(), parameters.getLowImpedanceThreshold());
+            LfBranchImpl lfBranch = LfBranchImpl.create(branch, lfNetwork, lfBus1, lfBus2, parameters.isTwtSplitShuntAdmittance(),
+                    parameters.isDc(), parameters.getLowImpedanceThreshold());
+            addBranch(lfNetwork, lfBranch, report);
             postProcessors.forEach(pp -> pp.onBranchAdded(branch, lfBranch));
         }
 
@@ -346,8 +347,8 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
             lfNetwork.addBus(lfBus2);
             lfBuses.add(lfBus2);
             LfBus lfBus1 = getLfBus(danglingLine.getTerminal(), lfNetwork, parameters.isBreakers());
-            LfBranch lfBranch = LfDanglingLineBranch.create(danglingLine, lfNetwork, lfBus1, lfBus2);
-            addBranch(lfNetwork, lfBranch, report, parameters.isDc(), parameters.getLowImpedanceThreshold());
+            LfBranch lfBranch = LfDanglingLineBranch.create(danglingLine, lfNetwork, lfBus1, lfBus2, parameters.isDc(), parameters.getLowImpedanceThreshold());
+            addBranch(lfNetwork, lfBranch, report);
             postProcessors.forEach(pp -> {
                 pp.onBusAdded(danglingLine, lfBus2);
                 pp.onBranchAdded(danglingLine, lfBranch);
@@ -360,12 +361,12 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
             LfBus lfBus1 = getLfBus(t3wt.getLeg1().getTerminal(), lfNetwork, parameters.isBreakers());
             LfBus lfBus2 = getLfBus(t3wt.getLeg2().getTerminal(), lfNetwork, parameters.isBreakers());
             LfBus lfBus3 = getLfBus(t3wt.getLeg3().getTerminal(), lfNetwork, parameters.isBreakers());
-            LfLegBranch lfBranch1 = LfLegBranch.create(lfNetwork, lfBus1, lfBus0, t3wt, t3wt.getLeg1(), parameters.isTwtSplitShuntAdmittance());
-            LfLegBranch lfBranch2 = LfLegBranch.create(lfNetwork, lfBus2, lfBus0, t3wt, t3wt.getLeg2(), parameters.isTwtSplitShuntAdmittance());
-            LfLegBranch lfBranch3 = LfLegBranch.create(lfNetwork, lfBus3, lfBus0, t3wt, t3wt.getLeg3(), parameters.isTwtSplitShuntAdmittance());
-            addBranch(lfNetwork, lfBranch1, report, parameters.isDc(), parameters.getLowImpedanceThreshold());
-            addBranch(lfNetwork, lfBranch2, report, parameters.isDc(), parameters.getLowImpedanceThreshold());
-            addBranch(lfNetwork, lfBranch3, report, parameters.isDc(), parameters.getLowImpedanceThreshold());
+            LfLegBranch lfBranch1 = LfLegBranch.create(lfNetwork, lfBus1, lfBus0, t3wt, t3wt.getLeg1(), parameters.isTwtSplitShuntAdmittance(), parameters.isDc(), parameters.getLowImpedanceThreshold());
+            LfLegBranch lfBranch2 = LfLegBranch.create(lfNetwork, lfBus2, lfBus0, t3wt, t3wt.getLeg2(), parameters.isTwtSplitShuntAdmittance(), parameters.isDc(), parameters.getLowImpedanceThreshold());
+            LfLegBranch lfBranch3 = LfLegBranch.create(lfNetwork, lfBus3, lfBus0, t3wt, t3wt.getLeg3(), parameters.isTwtSplitShuntAdmittance(), parameters.isDc(), parameters.getLowImpedanceThreshold());
+            addBranch(lfNetwork, lfBranch1, report);
+            addBranch(lfNetwork, lfBranch2, report);
+            addBranch(lfNetwork, lfBranch3, report);
             postProcessors.forEach(pp -> {
                 pp.onBusAdded(t3wt, lfBus0);
                 pp.onBranchAdded(t3wt, lfBranch1);
@@ -440,19 +441,18 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
                 Bus bus2 = vl.getBusBreakerView().getBus2(sw.getId());
                 LfBus lfBus1 = lfNetwork.getBusById(bus1.getId());
                 LfBus lfBus2 = lfNetwork.getBusById(bus2.getId());
-                LfSwitch lfSwitch = new LfSwitch(lfNetwork, lfBus1, lfBus2, sw);
-                addBranch(lfNetwork, lfSwitch, report, dc, lowImpedanceThreshold);
+                LfSwitch lfSwitch = new LfSwitch(lfNetwork, lfBus1, lfBus2, sw, dc, lowImpedanceThreshold);
+                addBranch(lfNetwork, lfSwitch, report);
                 postProcessors.forEach(pp -> pp.onBranchAdded(sw, lfSwitch));
             }
         }
     }
 
-    private static void fixAllVoltageControls(LfNetwork lfNetwork, boolean minImpedance, boolean transformerVoltageControl,
-                                              boolean dc, double lowImpedanceThreshold) {
+    private static void fixAllVoltageControls(LfNetwork lfNetwork, boolean minImpedance, boolean transformerVoltageControl) {
         // If min impedance is set, there is no zero-impedance branch
         if (!minImpedance) {
             // Merge the discrete voltage control in each zero impedance connected set
-            List<Set<LfBus>> connectedSets = new ConnectivityInspector<>(lfNetwork.createZeroImpedanceSubGraph(dc, lowImpedanceThreshold)).connectedSets();
+            List<Set<LfBus>> connectedSets = new ConnectivityInspector<>(lfNetwork.createZeroImpedanceSubGraph()).connectedSets();
             connectedSets.forEach(connectedSet -> mergeVoltageControls(connectedSet, transformerVoltageControl));
         }
     }
@@ -751,13 +751,12 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
 
         if (!parameters.isDc()) {
             // Fixing voltage controls need to be done after creating switches, as the zero-impedance graph is changed with switches
-            fixAllVoltageControls(lfNetwork, parameters.isMinImpedance(), parameters.isTransformerVoltageControl(),
-                    parameters.isDc(), parameters.getLowImpedanceThreshold());
+            fixAllVoltageControls(lfNetwork, parameters.isMinImpedance(), parameters.isTransformerVoltageControl());
         }
 
         if (!parameters.isMinImpedance()) {
             // create zero impedance equations only on minimum spanning forest calculated from zero impedance sub graph
-            Graph<LfBus, LfBranch> zeroImpedanceSubGraph = lfNetwork.createZeroImpedanceSubGraph(parameters.isDc(), parameters.getLowImpedanceThreshold());
+            Graph<LfBus, LfBranch> zeroImpedanceSubGraph = lfNetwork.createZeroImpedanceSubGraph();
             if (!zeroImpedanceSubGraph.vertexSet().isEmpty()) {
                 SpanningTreeAlgorithm.SpanningTree<LfBranch> spanningTree = new KruskalMinimumSpanningTree<>(zeroImpedanceSubGraph).getSpanningTree();
                 for (LfBranch branch : spanningTree.getEdges()) {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfSwitch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfSwitch.java
@@ -27,8 +27,8 @@ public class LfSwitch extends AbstractLfBranch {
 
     private final Ref<Switch> switchRef;
 
-    public LfSwitch(LfNetwork network, LfBus bus1, LfBus bus2, Switch aSwitch) {
-        super(network, bus1, bus2, new SimplePiModel());
+    public LfSwitch(LfNetwork network, LfBus bus1, LfBus bus2, Switch aSwitch, boolean dc, double lowImpedanceThreshold) {
+        super(network, bus1, bus2, new SimplePiModel(), dc, lowImpedanceThreshold);
         this.switchRef = new Ref<>(aSwitch);
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/util/ZeroImpedanceFlows.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ZeroImpedanceFlows.java
@@ -132,7 +132,7 @@ public class ZeroImpedanceFlows {
 
             // only lines with impedance
             List<LfBranch> adjacentBranchesWithImpedance = bus.getBranches().stream()
-                .filter(branch -> !branch.isZeroImpedanceBranch()).collect(Collectors.toList());
+                .filter(branch -> !branch.isZeroImpedance()).collect(Collectors.toList());
 
             adjacentBranchesWithImpedance.forEach(branch -> {
                 PQ branchFlow = getBranchFlow(branch, bus);

--- a/src/main/java/com/powsybl/openloadflow/network/util/ZeroImpedanceFlows.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ZeroImpedanceFlows.java
@@ -35,7 +35,7 @@ public class ZeroImpedanceFlows {
         this.tree = spanningTree;
     }
 
-    public void compute(boolean dc, double lowImpedanceThreshold) {
+    public void compute() {
         Set<LfBus> processed = new HashSet<>();
 
         graph.vertexSet().forEach(lfBus -> {
@@ -43,7 +43,7 @@ public class ZeroImpedanceFlows {
                 return;
             }
             TreeByLevels treeByLevels = new TreeByLevels(graph, tree, lfBus);
-            treeByLevels.updateFlows(dc, lowImpedanceThreshold);
+            treeByLevels.updateFlows();
             processed.addAll(treeByLevels.getProcessedLfBuses());
         });
 
@@ -104,7 +104,7 @@ public class ZeroImpedanceFlows {
             return branch.getBus1().equals(bus) ? branch.getBus2() : branch.getBus1();
         }
 
-        private void updateFlows(boolean dc, double lowImpedanceThreshold) {
+        private void updateFlows() {
             Map<LfBus, PQ> descendantZeroImpedanceFlow = new HashMap<>();
 
             // traverse the tree from leaves to root
@@ -112,7 +112,7 @@ public class ZeroImpedanceFlows {
             int level = levels.size() - 1;
             while (level >= 1) {
                 levels.get(level).forEach(bus -> {
-                    PQ balance = balanceWithImpedance(bus, dc, lowImpedanceThreshold);
+                    PQ balance = balanceWithImpedance(bus);
                     PQ z0flow = getDescendantZeroImpedanceFlow(descendantZeroImpedanceFlow, bus);
                     PQ branchFlow = balance.add(z0flow);
 
@@ -124,7 +124,7 @@ public class ZeroImpedanceFlows {
             }
         }
 
-        private PQ balanceWithImpedance(LfBus bus, boolean dc, double lowImpedanceThreshold) {
+        private PQ balanceWithImpedance(LfBus bus) {
             // balance considering injections and flow from lines with impedance
 
             // take care of the sign
@@ -132,7 +132,7 @@ public class ZeroImpedanceFlows {
 
             // only lines with impedance
             List<LfBranch> adjacentBranchesWithImpedance = bus.getBranches().stream()
-                .filter(branch -> !branch.isZeroImpedanceBranch(dc, lowImpedanceThreshold)).collect(Collectors.toList());
+                .filter(branch -> !branch.isZeroImpedanceBranch()).collect(Collectors.toList());
 
             adjacentBranchesWithImpedance.forEach(branch -> {
                 PQ branchFlow = getBranchFlow(branch, bus);

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -832,8 +832,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
             var dcLoadFlowParameters = createDcLoadFlowParameters(lfNetworkParameters, matrixFactory, lfParameters);
 
             // create DC equation system for sensitivity analysis
-            EquationSystem<DcVariableType, DcEquationType> equationSystem = DcEquationSystem.create(lfNetwork, dcLoadFlowParameters.getEquationSystemCreationParameters(),
-                    dcLoadFlowParameters.getNetworkParameters().getLowImpedanceThreshold(), false);
+            EquationSystem<DcVariableType, DcEquationType> equationSystem = DcEquationSystem.create(lfNetwork, dcLoadFlowParameters.getEquationSystemCreationParameters(), false);
 
             // next we only work with valid factors
             var validFactorHolder = writeInvalidFactors(allFactorHolder, resultWriter);

--- a/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowMatrixTest.java
+++ b/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowMatrixTest.java
@@ -21,7 +21,6 @@ import com.powsybl.openloadflow.equations.JacobianMatrix;
 import com.powsybl.openloadflow.network.FirstSlackBusSelector;
 import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.network.LfNetwork;
-import com.powsybl.openloadflow.network.LfNetworkParameters;
 import com.powsybl.openloadflow.network.impl.Networks;
 import com.powsybl.openloadflow.network.util.UniformValueVoltageInitializer;
 import org.junit.jupiter.api.Test;
@@ -60,7 +59,7 @@ class DcLoadFlowMatrixTest {
         LfNetwork mainNetwork = lfNetworks.get(0);
 
         DcEquationSystemCreationParameters creationParameters = new DcEquationSystemCreationParameters(true, false, false, true);
-        EquationSystem<DcVariableType, DcEquationType> equationSystem = DcEquationSystem.create(mainNetwork, creationParameters, LfNetworkParameters.LOW_IMPEDANCE_THRESHOLD_DEFAULT_VALUE, false);
+        EquationSystem<DcVariableType, DcEquationType> equationSystem = DcEquationSystem.create(mainNetwork, creationParameters, false);
 
         for (LfBus b : mainNetwork.getBuses()) {
             equationSystem.createEquation(b.getNum(), DcEquationType.BUS_TARGET_P);
@@ -110,7 +109,7 @@ class DcLoadFlowMatrixTest {
         lfNetworks = Networks.load(network, new FirstSlackBusSelector());
         mainNetwork = lfNetworks.get(0);
 
-        equationSystem = DcEquationSystem.create(mainNetwork, creationParameters, LfNetworkParameters.LOW_IMPEDANCE_THRESHOLD_DEFAULT_VALUE, false);
+        equationSystem = DcEquationSystem.create(mainNetwork, creationParameters, false);
 
         try (var j = new JacobianMatrix<>(equationSystem, matrixFactory)) {
             try (DcTargetVector targets = new DcTargetVector(mainNetwork, equationSystem)) {

--- a/src/test/java/com/powsybl/openloadflow/equations/EquationSystemTest.java
+++ b/src/test/java/com/powsybl/openloadflow/equations/EquationSystemTest.java
@@ -173,7 +173,7 @@ class EquationSystemTest {
         List<LfNetwork> lfNetworks = Networks.load(EurostagTutorialExample1Factory.create(), new FirstSlackBusSelector());
         LfNetwork network = lfNetworks.get(0);
 
-        EquationSystem<DcVariableType, DcEquationType> equationSystem = DcEquationSystem.create(network, new DcEquationSystemCreationParameters(true, false, false, true), LfNetworkParameters.LOW_IMPEDANCE_THRESHOLD_DEFAULT_VALUE, false);
+        EquationSystem<DcVariableType, DcEquationType> equationSystem = DcEquationSystem.create(network, new DcEquationSystemCreationParameters(true, false, false, true), false);
         String ref = String.join(System.lineSeparator(),
                 "bus_target_φ0 = φ0",
                 "bus_target_p1 = dc_p_2(φ0, φ1) + dc_p_1(φ1, φ2) + dc_p_1(φ1, φ2)",


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <anne.tilloy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

The status of zero impedance branch is defined once, when the LfNetwork is created, in a AC context or in a DC context. So:
- if during the simulation the tap position changes, it does not change this status. Which is not so bad indeed because we don't change the branch equation from an impedant branch equation to a zero impedance one or inversely.
- In case of an initialisation relying on DC loadflow, the zero impedance status is defined in an AC context.    

**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
