### PR TITLE
Move bus getters to Networks utility class

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -39,8 +39,6 @@ public class LfNetwork extends AbstractPropertyBag implements PropertyBag {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LfNetwork.class);
 
-    private static final double TARGET_VOLTAGE_EPSILON = Math.pow(10, -6);
-
     private final int numCC;
 
     private final int numSC;

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -240,10 +240,6 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         }
     }
 
-    private static Bus getBus(Terminal terminal, boolean breakers) {
-        return breakers ? terminal.getBusBreakerView().getBus() : terminal.getBusView().getBus();
-    }
-
     private static LfBusImpl createBus(Bus bus, LfNetworkParameters parameters, LfNetwork lfNetwork, LoadingContext loadingContext,
                                        LfNetworkLoadingReport report, List<LfNetworkLoaderPostProcessor> postProcessors) {
         LfBusImpl lfBus = LfBusImpl.create(bus, lfNetwork, parameters.isDistributedOnConformLoad(), participateToSlackDistribution(parameters, bus), parameters.isBreakers());
@@ -738,7 +734,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
     }
 
     private static LfBus getLfBus(Terminal terminal, LfNetwork lfNetwork, boolean breakers) {
-        Bus bus = getBus(terminal, breakers);
+        Bus bus = Networks.getBus(terminal, breakers);
         return bus != null ? lfNetwork.getBusById(bus.getId()) : null;
     }
 
@@ -851,8 +847,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         Stopwatch stopwatch = Stopwatch.createStarted();
 
         Map<Pair<Integer, Integer>, List<Bus>> busesByCc = new TreeMap<>();
-        Iterable<Bus> buses = parameters.isBreakers() ? network.getBusBreakerView().getBuses()
-                                                      : network.getBusView().getBuses();
+        Iterable<Bus> buses = Networks.getBuses(network, parameters.isBreakers());
         for (Bus bus : buses) {
             Component cc = bus.getConnectedComponent();
             Component sc = bus.getSynchronousComponent();

--- a/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
@@ -167,4 +167,14 @@ public final class Networks {
             return new LfNetworkList(lfNetworks, new LfNetworkList.VariantCleaner(network, workingVariantId, tmpVariantId));
         }
     }
+
+    public static Iterable<Bus> getBuses(Network network, boolean breaker) {
+        return breaker ? network.getBusBreakerView().getBuses()
+                       : network.getBusView().getBuses();
+    }
+
+    public static Bus getBus(Terminal terminal, boolean breakers) {
+        return breakers ? terminal.getBusBreakerView().getBus()
+                        : terminal.getBusView().getBus();
+    }
 }

--- a/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
@@ -20,9 +20,13 @@ import com.powsybl.openloadflow.equations.EquationSystem;
 import com.powsybl.openloadflow.equations.EquationTerm;
 import com.powsybl.openloadflow.equations.Quantity;
 import com.powsybl.openloadflow.graph.GraphConnectivityFactory;
-import com.powsybl.openloadflow.network.*;
+import com.powsybl.openloadflow.network.LfBranch;
+import com.powsybl.openloadflow.network.LfBus;
+import com.powsybl.openloadflow.network.LfElement;
+import com.powsybl.openloadflow.network.LfNetwork;
 import com.powsybl.openloadflow.network.impl.HvdcConverterStations;
 import com.powsybl.openloadflow.network.impl.LfDanglingLineBus;
+import com.powsybl.openloadflow.network.impl.Networks;
 import com.powsybl.openloadflow.network.impl.PropagatedContingency;
 import com.powsybl.openloadflow.network.util.ActivePowerDistribution;
 import com.powsybl.openloadflow.network.util.ParticipatingElement;
@@ -867,15 +871,7 @@ public abstract class AbstractSensitivityAnalysis<V extends Enum<V> & Quantity, 
 
     private static void checkBus(Network network, String busId, Map<String, Bus> busCache, boolean breakers) {
         if (busCache.isEmpty()) {
-            if (breakers) {
-                network.getBusBreakerView()
-                        .getBusStream()
-                        .forEach(bus -> busCache.put(bus.getId(), bus));
-            } else {
-                network.getBusView()
-                        .getBusStream()
-                        .forEach(bus -> busCache.put(bus.getId(), bus));
-            }
+            Networks.getBuses(network, breakers).forEach(bus -> busCache.put(bus.getId(), bus));
         }
         Bus bus = busCache.get(busId);
         if (bus == null) {


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactoring


**What is the new behavior (if this is a feature change)?**
Some utility methods regarding bus access have been moved to `Networks`.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
