### PR TITLE
Add network update state parameters

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
@@ -30,6 +30,7 @@ import com.powsybl.openloadflow.graph.GraphConnectivityFactory;
 import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.network.LfNetwork;
+import com.powsybl.openloadflow.network.LfNetworkStateUpdateParameters;
 import com.powsybl.openloadflow.network.impl.LfNetworkLoaderImpl;
 import com.powsybl.openloadflow.network.impl.Networks;
 import com.powsybl.openloadflow.network.util.ZeroImpedanceFlows;
@@ -117,12 +118,13 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
         for (AcLoadFlowResult result : results) {
             // update network state
             if (result.getNewtonRaphsonStatus() == NewtonRaphsonStatus.CONVERGED) {
-                result.getNetwork().updateState(!parameters.isNoGeneratorReactiveLimits(),
-                                                parameters.isWriteSlackBus(),
-                                                parameters.isPhaseShifterRegulationOn(),
-                                                parameters.isTransformerVoltageControlOn(),
-                                                parameters.isDistributedSlack() && parameters.getBalanceType() == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD,
-                                                parameters.isDistributedSlack() && (parameters.getBalanceType() == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD || parameters.getBalanceType() == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD) && parametersExt.isLoadPowerFactorConstant(), parameters.isDc());
+                var updateParameters = new LfNetworkStateUpdateParameters(!parameters.isNoGeneratorReactiveLimits(),
+                                                                          parameters.isWriteSlackBus(),
+                                                                          parameters.isPhaseShifterRegulationOn(),
+                                                                          parameters.isTransformerVoltageControlOn(),
+                                                                          parameters.isDistributedSlack() && (parameters.getBalanceType() == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD || parameters.getBalanceType() == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD) && parametersExt.isLoadPowerFactorConstant(),
+                                                                          parameters.isDc());
+                result.getNetwork().updateState(updateParameters);
 
                 // zero or low impedance branch flows computation
                 computeZeroImpedanceFlows(result.getNetwork());
@@ -186,12 +188,13 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
         }
 
         if (result.isSucceeded()) {
-            result.getNetwork().updateState(false,
-                    parameters.isWriteSlackBus(),
-                    parameters.isPhaseShifterRegulationOn(),
-                    parameters.isTransformerVoltageControlOn(),
-                    parameters.isDistributedSlack() && parameters.getBalanceType() == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD,
-                    false, true);
+            var updateParameters = new LfNetworkStateUpdateParameters(false,
+                                                                      parameters.isWriteSlackBus(),
+                                                                      parameters.isPhaseShifterRegulationOn(),
+                                                                      parameters.isTransformerVoltageControlOn(),
+                                                                      false,
+                                                                      true);
+            result.getNetwork().updateState(updateParameters);
 
             // zero or low impedance branch flows computation
             computeZeroImpedanceFlows(result.getNetwork());

--- a/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
@@ -105,7 +105,7 @@ public interface LfBranch extends LfElement {
 
     Optional<DiscretePhaseControl> getDiscretePhaseControl();
 
-    void updateState(boolean phaseShifterRegulationOn, boolean isTransformerVoltageControlOn, boolean dc);
+    void updateState(LfNetworkStateUpdateParameters parameters);
 
     void updateFlows(double p1, double q1, double p2, double q2);
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBus.java
@@ -125,7 +125,7 @@ public interface LfBus extends LfElement {
 
     void addHvdc(LfHvdc hvdc);
 
-    void updateState(boolean reactiveLimits, boolean writeSlackBus, boolean distributedOnConformLoad, boolean loadPowerFactorConstant);
+    void updateState(LfNetworkStateUpdateParameters parameters);
 
     Optional<TransformerVoltageControl> getTransformerVoltageControl();
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -231,24 +231,22 @@ public class LfNetwork extends AbstractPropertyBag implements PropertyBag {
         return hvdcsById.get(id);
     }
 
-    public void updateState(boolean reactiveLimits, boolean writeSlackBus, boolean phaseShifterRegulationOn,
-                            boolean transformerVoltageControlOn, boolean distributedOnConformLoad, boolean loadPowerFactorConstant,
-                            boolean dc) {
+    public void updateState(LfNetworkStateUpdateParameters parameters) {
         Stopwatch stopwatch = Stopwatch.createStarted();
 
         for (LfHvdc hvdc : hvdcs) {
             hvdc.updateState();
         }
         for (LfBus bus : busesById.values()) {
-            bus.updateState(reactiveLimits, writeSlackBus, distributedOnConformLoad, loadPowerFactorConstant);
+            bus.updateState(parameters);
             for (LfGenerator generator : bus.getGenerators()) {
                 generator.updateState();
             }
-            bus.getShunt().ifPresent(shunt -> shunt.updateState(dc));
-            bus.getControllerShunt().ifPresent(shunt -> shunt.updateState(dc));
+            bus.getShunt().ifPresent(shunt -> shunt.updateState(parameters));
+            bus.getControllerShunt().ifPresent(shunt -> shunt.updateState(parameters));
         }
         for (LfBranch branch : branches) {
-            branch.updateState(phaseShifterRegulationOn, transformerVoltageControlOn, dc);
+            branch.updateState(parameters);
         }
 
         stopwatch.stop();

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetworkStateUpdateParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetworkStateUpdateParameters.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.network;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class LfNetworkStateUpdateParameters {
+
+    private final boolean reactiveLimits;
+
+    private final boolean writeSlackBus;
+
+    private final boolean phaseShifterRegulationOn;
+
+    private final boolean transformerVoltageControlOn;
+
+    private final boolean loadPowerFactorConstant;
+
+    private final boolean dc;
+
+    public LfNetworkStateUpdateParameters(boolean reactiveLimits, boolean writeSlackBus, boolean phaseShifterRegulationOn,
+                                          boolean transformerVoltageControlOn, boolean loadPowerFactorConstant, boolean dc) {
+        this.reactiveLimits = reactiveLimits;
+        this.writeSlackBus = writeSlackBus;
+        this.phaseShifterRegulationOn = phaseShifterRegulationOn;
+        this.transformerVoltageControlOn = transformerVoltageControlOn;
+        this.loadPowerFactorConstant = loadPowerFactorConstant;
+        this.dc = dc;
+    }
+
+    public boolean isReactiveLimits() {
+        return reactiveLimits;
+    }
+
+    public boolean isWriteSlackBus() {
+        return writeSlackBus;
+    }
+
+    public boolean isPhaseShifterRegulationOn() {
+        return phaseShifterRegulationOn;
+    }
+
+    public boolean isTransformerVoltageControlOn() {
+        return transformerVoltageControlOn;
+    }
+
+    public boolean isLoadPowerFactorConstant() {
+        return loadPowerFactorConstant;
+    }
+
+    public boolean isDc() {
+        return dc;
+    }
+}

--- a/src/main/java/com/powsybl/openloadflow/network/LfShunt.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfShunt.java
@@ -23,7 +23,7 @@ public interface LfShunt extends LfElement {
 
     void setG(double g);
 
-    void updateState(boolean dc);
+    void updateState(LfNetworkStateUpdateParameters parameters);
 
     boolean hasVoltageControlCapability();
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfStandbyAutomatonShunt.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfStandbyAutomatonShunt.java
@@ -108,7 +108,7 @@ public final class LfStandbyAutomatonShunt extends AbstractElement implements Lf
     }
 
     @Override
-    public void updateState(boolean dc) {
+    public void updateState(LfNetworkStateUpdateParameters parameters) {
         // nothing to do
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -475,12 +475,12 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     }
 
     @Override
-    public void updateState(boolean reactiveLimits, boolean writeSlackBus, boolean distributedOnConformLoad, boolean loadPowerFactorConstant) {
+    public void updateState(LfNetworkStateUpdateParameters parameters) {
         // update generator reactive power
-        updateGeneratorsState(voltageControlEnabled ? q.eval() * PerUnit.SB + loadTargetQ : generationTargetQ, reactiveLimits);
+        updateGeneratorsState(voltageControlEnabled ? q.eval() * PerUnit.SB + loadTargetQ : generationTargetQ, parameters.isReactiveLimits());
 
         // update load power
-        lfAggregatedLoads.updateState(getLoadTargetP() - getInitialLoadTargetP(), loadPowerFactorConstant);
+        lfAggregatedLoads.updateState(getLoadTargetP() - getInitialLoadTargetP(), parameters.isLoadPowerFactorConstant());
 
         // update lcc converter station power
         for (Ref<LccConverterStation> lccCsRef : lccCsRefs) {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
@@ -175,19 +175,19 @@ public class LfBranchImpl extends AbstractImpedantLfBranch {
     }
 
     @Override
-    public void updateState(boolean phaseShifterRegulationOn, boolean isTransformerVoltageControlOn, boolean dc) {
+    public void updateState(LfNetworkStateUpdateParameters parameters) {
         var branch = getBranch();
 
         updateFlows(p1.eval(), q1.eval(), p2.eval(), q2.eval());
 
-        if (phaseShifterRegulationOn && isPhaseController()) {
+        if (parameters.isPhaseShifterRegulationOn() && isPhaseController()) {
             // it means there is a regulating phase tap changer located on that branch
             updateTapPosition(((TwoWindingsTransformer) branch).getPhaseTapChanger());
             // check if the target value deadband is respected
             checkTargetDeadband(discretePhaseControl.getControlledSide() == DiscretePhaseControl.ControlledSide.ONE ? p1.eval() : p2.eval());
         }
 
-        if (isTransformerVoltageControlOn && isVoltageController()) { // it means there is a regulating ratio tap changer
+        if (parameters.isTransformerVoltageControlOn() && isVoltageController()) { // it means there is a regulating ratio tap changer
             TwoWindingsTransformer twt = (TwoWindingsTransformer) branch;
             RatioTapChanger rtc = twt.getRatioTapChanger();
             double baseRatio = Transformers.getRatioPerUnitBase(twt);

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
@@ -9,6 +9,7 @@ package com.powsybl.openloadflow.network.impl;
 import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.extensions.SlackTerminal;
 import com.powsybl.openloadflow.network.LfNetwork;
+import com.powsybl.openloadflow.network.LfNetworkStateUpdateParameters;
 import com.powsybl.security.results.BusResult;
 
 import java.util.List;
@@ -84,16 +85,16 @@ public class LfBusImpl extends AbstractLfBus {
     }
 
     @Override
-    public void updateState(boolean reactiveLimits, boolean writeSlackBus, boolean distributedOnConformLoad, boolean loadPowerFactorConstant) {
+    public void updateState(LfNetworkStateUpdateParameters parameters) {
         var bus = getBus();
         bus.setV(v).setAngle(angle);
 
         // update slack bus
-        if (slack && writeSlackBus) {
+        if (slack && parameters.isWriteSlackBus()) {
             SlackTerminal.attach(bus);
         }
 
-        super.updateState(reactiveLimits, writeSlackBus, distributedOnConformLoad, loadPowerFactorConstant);
+        super.updateState(parameters);
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
@@ -9,10 +9,7 @@ package com.powsybl.openloadflow.network.impl;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.DanglingLine;
 import com.powsybl.iidm.network.LimitType;
-import com.powsybl.openloadflow.network.LfBus;
-import com.powsybl.openloadflow.network.LfNetwork;
-import com.powsybl.openloadflow.network.PiModel;
-import com.powsybl.openloadflow.network.SimplePiModel;
+import com.powsybl.openloadflow.network.*;
 import com.powsybl.openloadflow.util.PerUnit;
 import com.powsybl.security.results.BranchResult;
 
@@ -90,7 +87,7 @@ public class LfDanglingLineBranch extends AbstractImpedantLfBranch {
     }
 
     @Override
-    public void updateState(boolean phaseShifterRegulationOn, boolean isTransformerVoltageControlOn, boolean dc) {
+    public void updateState(LfNetworkStateUpdateParameters parameters) {
         updateFlows(p1.eval(), q1.eval(), Double.NaN, Double.NaN);
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBus.java
@@ -9,6 +9,7 @@ package com.powsybl.openloadflow.network.impl;
 import com.powsybl.iidm.network.DanglingLine;
 import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.network.LfNetwork;
+import com.powsybl.openloadflow.network.LfNetworkStateUpdateParameters;
 
 import java.util.List;
 
@@ -68,11 +69,11 @@ public class LfDanglingLineBus extends AbstractLfBus {
     }
 
     @Override
-    public void updateState(boolean reactiveLimits, boolean writeSlackBus, boolean distributedOnConformLoad, boolean loadPowerFactorConstant) {
+    public void updateState(LfNetworkStateUpdateParameters parameters) {
         var danglingLine = getDanglingLine();
         Networks.setPropertyV(danglingLine, v);
         Networks.setPropertyAngle(danglingLine, angle);
 
-        super.updateState(reactiveLimits, writeSlackBus, false, false);
+        super.updateState(parameters);
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
@@ -157,23 +157,23 @@ public class LfLegBranch extends AbstractImpedantLfBranch {
     }
 
     @Override
-    public void updateState(boolean phaseShifterRegulationOn, boolean isTransformerVoltageControlOn, boolean dc) {
+    public void updateState(LfNetworkStateUpdateParameters parameters) {
         var twt = getTwt();
         var leg = getLeg();
 
         updateFlows(p1.eval(), q1.eval(), Double.NaN, Double.NaN);
 
-        if (phaseShifterRegulationOn && isPhaseController()) {
+        if (parameters.isPhaseShifterRegulationOn() && isPhaseController()) {
             // it means there is a regulating phase tap changer located on that leg
             updateTapPosition(leg.getPhaseTapChanger());
         }
 
-        if (phaseShifterRegulationOn && isPhaseControlled() && discretePhaseControl.getControlledSide() == DiscretePhaseControl.ControlledSide.ONE) {
+        if (parameters.isPhaseShifterRegulationOn() && isPhaseControlled() && discretePhaseControl.getControlledSide() == DiscretePhaseControl.ControlledSide.ONE) {
             // check if the target value deadband is respected
             checkTargetDeadband(p1.eval());
         }
 
-        if (isTransformerVoltageControlOn && isVoltageController()) { // it means there is a regulating ratio tap changer
+        if (parameters.isTransformerVoltageControlOn() && isVoltageController()) { // it means there is a regulating ratio tap changer
             RatioTapChanger rtc = leg.getRatioTapChanger();
             double baseRatio = Transformers.getRatioPerUnitBase(leg, twt);
             double rho = getPiModel().getR1() * leg.getRatedU() / twt.getRatedU0() * baseRatio;

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfShuntImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfShuntImpl.java
@@ -244,8 +244,8 @@ public class LfShuntImpl extends AbstractElement implements LfShunt {
     }
 
     @Override
-    public void updateState(boolean dc) {
-        if (dc) {
+    public void updateState(LfNetworkStateUpdateParameters parameters) {
+        if (parameters.isDc()) {
             for (var scRef : shuntCompensatorsRefs) {
                 var sc = scRef.get();
                 sc.getTerminal().setP(0);

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfStarBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfStarBus.java
@@ -8,6 +8,7 @@ package com.powsybl.openloadflow.network.impl;
 
 import com.powsybl.iidm.network.ThreeWindingsTransformer;
 import com.powsybl.openloadflow.network.LfNetwork;
+import com.powsybl.openloadflow.network.LfNetworkStateUpdateParameters;
 
 import java.util.List;
 
@@ -60,11 +61,11 @@ public class LfStarBus extends AbstractLfBus {
     }
 
     @Override
-    public void updateState(boolean reactiveLimits, boolean writeSlackBus, boolean distributedOnConformLoad, boolean loadPowerFactorConstant) {
+    public void updateState(LfNetworkStateUpdateParameters parameters) {
         var t3wt = getT3wt();
         Networks.setPropertyV(t3wt, v);
         Networks.setPropertyAngle(t3wt, angle);
 
-        super.updateState(reactiveLimits, writeSlackBus, false, false);
+        super.updateState(parameters);
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfSwitch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfSwitch.java
@@ -11,6 +11,7 @@ import com.powsybl.iidm.network.LimitType;
 import com.powsybl.iidm.network.Switch;
 import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.network.LfNetwork;
+import com.powsybl.openloadflow.network.LfNetworkStateUpdateParameters;
 import com.powsybl.openloadflow.network.SimplePiModel;
 import com.powsybl.openloadflow.util.Evaluable;
 import com.powsybl.security.results.BranchResult;
@@ -126,7 +127,7 @@ public class LfSwitch extends AbstractLfBranch {
     }
 
     @Override
-    public void updateState(boolean phaseShifterRegulationOn, boolean isTransformerVoltageControlOn, boolean dc) {
+    public void updateState(LfNetworkStateUpdateParameters parameters) {
         // nothing to do
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/NonImpedantBranchWithBreakerIssueTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/NonImpedantBranchWithBreakerIssueTest.java
@@ -16,6 +16,7 @@ import com.powsybl.openloadflow.ac.outerloop.AcLoadFlowParameters;
 import com.powsybl.openloadflow.ac.outerloop.AcloadFlowEngine;
 import com.powsybl.openloadflow.network.LfNetwork;
 import com.powsybl.openloadflow.network.LfNetworkParameters;
+import com.powsybl.openloadflow.network.LfNetworkStateUpdateParameters;
 import com.powsybl.openloadflow.network.NodeBreakerNetworkFactory;
 import com.powsybl.openloadflow.network.impl.Networks;
 import com.powsybl.openloadflow.network.util.UniformValueVoltageInitializer;
@@ -47,7 +48,7 @@ class NonImpedantBranchWithBreakerIssueTest {
             new AcloadFlowEngine(context)
                     .run();
         }
-        lfNetwork.updateState(false, false, false, false, false, false, false);
+        lfNetwork.updateState(new LfNetworkStateUpdateParameters(false, false, false, false, false, false));
         for (Bus bus : network.getBusView().getBuses()) {
             assertEquals(400, bus.getV(), 0);
             assertEquals(0, bus.getAngle(), 0);
@@ -70,7 +71,7 @@ class NonImpedantBranchWithBreakerIssueTest {
             new AcloadFlowEngine(context)
                     .run();
         }
-        lfNetwork.updateState(false, false, false, false, false, false, false);
+        lfNetwork.updateState(new LfNetworkStateUpdateParameters(false, false, false, false, false, false));
         assertEquals(-100, network.getGenerator("G1").getTerminal().getQ(), 0);
         assertEquals(-100, network.getGenerator("G2").getTerminal().getQ(), 0);
     }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
Network update methods have too many parameters.


**What is the new behavior (if this is a feature change)?**
An additionnel object `LfNetworkStateUpdateParameters` has been added to simplify method signature.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
