### PR TITLE
DcValueVoltageInitializer fails in presence of resistive only branches

### DIFF
--- a/src/test/java/com/powsybl/openloadflow/ac/DcValueVoltageInitializerTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DcValueVoltageInitializerTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2022, Coreso SA (https://www.coreso.eu/) and TSCNET Services GmbH (https://www.tscnet.eu/)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.ac;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.loadflow.LoadFlowParameters;
+import com.powsybl.math.matrix.DenseMatrixFactory;
+import com.powsybl.math.matrix.MatrixFactory;
+import com.powsybl.openloadflow.dc.DcValueVoltageInitializer;
+import com.powsybl.openloadflow.network.*;
+import com.powsybl.openloadflow.network.impl.LfNetworkLoaderImpl;
+import com.powsybl.openloadflow.network.util.VoltageInitializer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * @author Damien Jeandemange <damien.jeandemange at artelys.com>
+ */
+class DcValueVoltageInitializerTest {
+
+    private Network network;
+    private SlackBusSelector slackBusSelector;
+    private MatrixFactory matrixFactory;
+    private LfNetworkParameters lfNetworkParameters;
+
+    private static void assertBusVoltage(LfNetwork network, VoltageInitializer initializer, String busId, double angleRef) {
+        LfBus bus = network.getBusById(busId);
+        assertNotNull(bus);
+        double v = initializer.getMagnitude(bus);
+        double angle = initializer.getAngle(bus);
+        assertEquals(1.0, v, 1E-6d);
+        assertEquals(angleRef, angle, 1E-2d);
+    }
+
+    @BeforeEach
+    void setUp() {
+        network = FourBusNetworkFactory.create();
+        slackBusSelector = new FirstSlackBusSelector();
+        matrixFactory = new DenseMatrixFactory();
+        lfNetworkParameters = new LfNetworkParameters().setSlackBusSelector(slackBusSelector);
+    }
+
+    @Test
+    void testFourBusNetwork() {
+        LfNetwork lfNetwork = LfNetwork.load(network, new LfNetworkLoaderImpl(), slackBusSelector).get(0);
+        VoltageInitializer initializer = new DcValueVoltageInitializer(lfNetworkParameters,
+                false,
+                LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX,
+                true,
+                matrixFactory);
+        initializer.prepare(lfNetwork);
+        assertBusVoltage(lfNetwork, initializer, "b1_vl_0", 0.0);
+        assertBusVoltage(lfNetwork, initializer, "b2_vl_0", -1.432394);
+        assertBusVoltage(lfNetwork, initializer, "b3_vl_0", -8.594367);
+        assertBusVoltage(lfNetwork, initializer, "b4_vl_0", -1.432394);
+    }
+
+    @Test
+    void testFourBusNetworkZeroImpedanceBranch() {
+        // Line l12 with zero impedance
+        network.getLine("l12").setR(0).setX(0);
+        LfNetwork lfNetwork = LfNetwork.load(network, new LfNetworkLoaderImpl(), slackBusSelector).get(0);
+        VoltageInitializer initializer = new DcValueVoltageInitializer(lfNetworkParameters,
+                false,
+                LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX,
+                true,
+                matrixFactory);
+        initializer.prepare(lfNetwork);
+        assertBusVoltage(lfNetwork, initializer, "b1_vl_0", 0.0);
+        assertBusVoltage(lfNetwork, initializer, "b2_vl_0", 0.0);
+        assertBusVoltage(lfNetwork, initializer, "b3_vl_0", -8.021409);
+        assertBusVoltage(lfNetwork, initializer, "b4_vl_0", -1.145915);
+    }
+
+    @Test
+    void testFourBusNetworkResistiveOnlyBranch() {
+        // Line l12 only resistive
+        network.getLine("l12").setR(0.1).setX(0);
+        LfNetwork lfNetwork = LfNetwork.load(network, new LfNetworkLoaderImpl(), slackBusSelector).get(0);
+        VoltageInitializer initializer = new DcValueVoltageInitializer(lfNetworkParameters,
+                false,
+                LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX,
+                true,
+                matrixFactory);
+        initializer.prepare(lfNetwork);
+        assertBusVoltage(lfNetwork, initializer, "b1_vl_0", 0.0);
+        assertBusVoltage(lfNetwork, initializer, "b2_vl_0", 0.0);
+        assertBusVoltage(lfNetwork, initializer, "b3_vl_0", -8.021409);
+        assertBusVoltage(lfNetwork, initializer, "b4_vl_0", -1.145915);
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Damien Jeandemange <damien.jeandemange@artelys.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Exception thrown by DcValueVoltageInitializer if the newtwork contains a resistive only branch.


**What is the new behavior (if this is a feature change)?**
TBD


**Does this PR introduce a breaking change or deprecate an API?**
No

**Other information**:

```
java.lang.IllegalArgumentException: Branch 'l12' has reactance equal to zero

	at com.powsybl.openloadflow.dc.equations.AbstractClosedBranchDcFlowEquationTerm.<init>(AbstractClosedBranchDcFlowEquationTerm.java:42)
	at com.powsybl.openloadflow.dc.equations.ClosedBranchSide1DcFlowEquationTerm.<init>(ClosedBranchSide1DcFlowEquationTerm.java:24)
	at com.powsybl.openloadflow.dc.equations.ClosedBranchSide1DcFlowEquationTerm.create(ClosedBranchSide1DcFlowEquationTerm.java:33)
	at com.powsybl.openloadflow.dc.equations.DcEquationSystem.createImpedantBranch(DcEquationSystem.java:75)
	at com.powsybl.openloadflow.dc.equations.DcEquationSystem.createBranches(DcEquationSystem.java:116)
	at com.powsybl.openloadflow.dc.equations.DcEquationSystem.create(DcEquationSystem.java:126)
	at com.powsybl.openloadflow.dc.DcLoadFlowContext.getEquationSystem(DcLoadFlowContext.java:32)
	at com.powsybl.openloadflow.dc.DcLoadFlowEngine.run(DcLoadFlowEngine.java:65)
	at com.powsybl.openloadflow.dc.DcValueVoltageInitializer.prepare(DcValueVoltageInitializer.java:58)
	at com.powsybl.openloadflow.ac.DcValueVoltageInitializerTest.testFourBusNetworkResistiveOnlyBranch(DcValueVoltageInitializerTest.java:92)
``