### PR TITLE
Refactor PV -> PQ switch counter

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/BusState.java
+++ b/src/main/java/com/powsybl/openloadflow/network/BusState.java
@@ -51,7 +51,6 @@ public class BusState extends BusDcState {
         element.setLoadTargetQ(loadTargetQ);
         element.setGenerationTargetQ(generationTargetQ);
         element.setVoltageControlEnabled(voltageControlEnabled);
-        element.setVoltageControlSwitchOffCount(0);
         if (shuntVoltageControlEnabled != null) {
             element.getControllerShunt().orElseThrow().setVoltageControlEnabled(shuntVoltageControlEnabled);
         }

--- a/src/main/java/com/powsybl/openloadflow/network/LfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBus.java
@@ -36,15 +36,6 @@ public interface LfBus extends LfElement {
 
     void removeGeneratorSlopes();
 
-    /**
-     * Get the number of time, voltage control status has be set from true to false.
-     *
-     * @return the number of time, voltage control status has be set from true to false
-     */
-    int getVoltageControlSwitchOffCount();
-
-    void setVoltageControlSwitchOffCount(int voltageControlSwitchOffCount);
-
     void setVoltageControlEnabled(boolean voltageControlEnabled);
 
     Optional<VoltageControl> getVoltageControl();

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -41,8 +41,6 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
 
     protected boolean voltageControlEnabled = false;
 
-    protected int voltageControlSwitchOffCount = 0;
-
     protected double loadTargetP = 0;
 
     protected double initialLoadTargetP = 0;
@@ -179,24 +177,11 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     @Override
     public void setVoltageControlEnabled(boolean voltageControlEnabled) {
         if (this.voltageControlEnabled != voltageControlEnabled) {
-            if (this.voltageControlEnabled) {
-                voltageControlSwitchOffCount++;
-            }
             this.voltageControlEnabled = voltageControlEnabled;
             for (LfNetworkListener listener : network.getListeners()) {
                 listener.onVoltageControlChange(this, voltageControlEnabled);
             }
         }
-    }
-
-    @Override
-    public int getVoltageControlSwitchOffCount() {
-        return voltageControlSwitchOffCount;
-    }
-
-    @Override
-    public void setVoltageControlSwitchOffCount(int voltageControlSwitchOffCount) {
-        this.voltageControlSwitchOffCount = voltageControlSwitchOffCount;
     }
 
     void addLoad(Load load) {


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
switch PV -> PQ counter of reactive limit outer loop is driven by LfBus.setVoltageControlEnabled calls. This is quite dangerous because there is many other reason that could lead to switch of voltage control that PV -> PQ switch (like validation checks).


**What is the new behavior (if this is a feature change)?**
PV -> PQ counter is now managed directly in reactive limits outer loop context. 


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
