### PR TITLE
Remove updateAllowedDirection method duplication

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/IncrementalContextData.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/IncrementalContextData.java
@@ -30,17 +30,13 @@ class IncrementalContextData {
 
         private AllowedDirection allowedDirection = AllowedDirection.BOTH;
 
-        MutableInt getDirectionChangeCount() {
-            return directionChangeCount;
-        }
-
         AllowedDirection getAllowedDirection() {
             return allowedDirection;
         }
 
         void updateAllowedDirection(Direction direction) {
             if (directionChangeCount.getValue() <= maxDirectionChange) {
-                if (!allowedDirection.equals(direction.getAllowedDirection())) {
+                if (allowedDirection != direction.getAllowedDirection()) {
                     // both vs increase or decrease
                     // increase vs decrease
                     // decrease vs increase

--- a/src/main/java/com/powsybl/openloadflow/ac/IncrementalContextData.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/IncrementalContextData.java
@@ -7,11 +7,11 @@
 package com.powsybl.openloadflow.ac;
 
 import com.powsybl.openloadflow.network.AllowedDirection;
+import com.powsybl.openloadflow.network.Direction;
 import org.apache.commons.lang3.mutable.MutableInt;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -19,6 +19,12 @@ import java.util.Objects;
 class IncrementalContextData {
 
     static final class ControllerContext {
+
+        private final int maxDirectionChange;
+
+        ControllerContext(int maxDirectionChange) {
+            this.maxDirectionChange = maxDirectionChange;
+        }
 
         private final MutableInt directionChangeCount = new MutableInt();
 
@@ -32,8 +38,16 @@ class IncrementalContextData {
             return allowedDirection;
         }
 
-        void setAllowedDirection(AllowedDirection allowedDirection) {
-            this.allowedDirection = Objects.requireNonNull(allowedDirection);
+        void updateAllowedDirection(Direction direction) {
+            if (directionChangeCount.getValue() <= maxDirectionChange) {
+                if (!allowedDirection.equals(direction.getAllowedDirection())) {
+                    // both vs increase or decrease
+                    // increase vs decrease
+                    // decrease vs increase
+                    directionChangeCount.increment();
+                }
+                allowedDirection = direction.getAllowedDirection();
+            }
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/ac/IncrementalShuntVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/IncrementalShuntVoltageControlOuterLoop.java
@@ -54,19 +54,8 @@ public class IncrementalShuntVoltageControlOuterLoop implements OuterLoop {
         for (LfShunt shunt : getControllerShunts(context.getNetwork())) {
             shunt.getVoltageControl().ifPresent(voltageControl -> shunt.setVoltageControlEnabled(false));
             for (LfShunt.Controller lfShuntController : shunt.getControllers()) {
-                contextData.getControllersContexts().put(lfShuntController.getId(), new IncrementalContextData.ControllerContext());
+                contextData.getControllersContexts().put(lfShuntController.getId(), new IncrementalContextData.ControllerContext(MAX_DIRECTION_CHANGE));
             }
-        }
-    }
-
-    private static void updateAllowedDirection(IncrementalContextData.ControllerContext controllerContext, Direction direction) {
-        if (controllerContext.getDirectionChangeCount().getValue() <= MAX_DIRECTION_CHANGE) {
-            if (!controllerContext.getAllowedDirection().equals(direction.getAllowedDirection())) {
-                // both vs increase or decrease
-                // increase vs decrease or decrease vs increase
-                controllerContext.getDirectionChangeCount().increment();
-            }
-            controllerContext.setAllowedDirection(direction.getAllowedDirection());
         }
     }
 
@@ -141,7 +130,7 @@ public class IncrementalShuntVoltageControlOuterLoop implements OuterLoop {
                             double deltaB = remainingDiffV / sensitivity;
                             Direction direction = controller.updateSectionB(deltaB, 1, controllerContext.getAllowedDirection()).orElse(null);
                             if (direction != null) {
-                                updateAllowedDirection(controllerContext, direction);
+                                controllerContext.updateAllowedDirection(direction);
                                 remainingDiffV -= (controller.getB() - previousB) * sensitivity;
                                 hasChanged = true;
                                 status.setValue(OuterLoopStatus.UNSTABLE);

--- a/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/IncrementalTransformerVoltageControlOuterLoop.java
@@ -62,19 +62,7 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
         // done into the equation system
         for (LfBranch branch : getControllerBranches(context.getNetwork())) {
             branch.getVoltageControl().ifPresent(voltageControl -> branch.setVoltageControlEnabled(false));
-            contextData.getControllersContexts().put(branch.getId(), new IncrementalContextData.ControllerContext());
-        }
-    }
-
-    private static void updateAllowedDirection(IncrementalContextData.ControllerContext controllerContext, Direction direction) {
-        if (controllerContext.getDirectionChangeCount().getValue() <= MAX_DIRECTION_CHANGE) {
-            if (!controllerContext.getAllowedDirection().equals(direction.getAllowedDirection())) {
-                // both vs increase or decrease
-                // increase vs decrease
-                // decrease vs increase
-                controllerContext.getDirectionChangeCount().increment();
-            }
-            controllerContext.setAllowedDirection(direction.getAllowedDirection());
+            contextData.getControllersContexts().put(branch.getId(), new IncrementalContextData.ControllerContext(MAX_DIRECTION_CHANGE));
         }
     }
 
@@ -132,7 +120,7 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
         int previousTapPosition = piModel.getTapPosition();
         double deltaR1 = diffV / sensitivity;
         return piModel.updateTapPositionToReachNewR1(deltaR1, maxTapShift, controllerContext.getAllowedDirection()).map(direction -> {
-            updateAllowedDirection(controllerContext, direction);
+            controllerContext.updateAllowedDirection(direction);
             Range<Integer> tapPositionRange = piModel.getTapPositionRange();
             LOGGER.debug("Controller branch '{}' change tap from {} to {} (full range: {})", controllerBranch.getId(),
                     previousTapPosition, piModel.getTapPosition(), tapPositionRange);
@@ -168,7 +156,7 @@ public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTrans
                     double previousR1 = piModel.getR1();
                     double deltaR1 = remainingDiffV.doubleValue() / sensitivity;
                     piModel.updateTapPositionToReachNewR1(deltaR1, 1, controllerContext.getAllowedDirection()).ifPresent(direction -> {
-                        updateAllowedDirection(controllerContext, direction);
+                        controllerContext.updateAllowedDirection(direction);
                         remainingDiffV.add(-(piModel.getR1() - previousR1) * sensitivity);
                         hasChanged.setValue(true);
                         adjusted.setValue(true);


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Technical debt


**What is the current behavior?** *(You can also link to an open issue here)*
updateAllowedDirection is duplicated is transformer et shunt outer loop.


**What is the new behavior (if this is a feature change)?**
updateAllowedDirection has been moved to incremental context.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
