### PR TITLE
Refactor voltage control equations

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
@@ -60,7 +60,7 @@ public class AcEquationSystemCreator {
         createShuntEquations(bus, equationSystem);
 
         // voltage control equations
-        createGeneratorControlEquations(bus, equationSystem);
+        createGeneratorVoltageControlEquations(bus, equationSystem);
 
         createTransformerVoltageControlEquations(bus, equationSystem);
 
@@ -73,15 +73,15 @@ public class AcEquationSystemCreator {
         }
     }
 
-    private void createGeneratorControlEquations(LfBus bus,
-                                                 EquationSystem<AcVariableType, AcEquationType> equationSystem) {
+    private void createGeneratorVoltageControlEquations(LfBus bus,
+                                                        EquationSystem<AcVariableType, AcEquationType> equationSystem) {
         bus.getGeneratorVoltageControl()
                 .ifPresent(voltageControl -> {
                     if (bus.isGeneratorVoltageControlled()) {
                         if (voltageControl.isLocalControl()) {
                             createLocalVoltageControlEquation(bus, equationSystem);
                         } else {
-                            createRemoteVoltageControlEquations(voltageControl, equationSystem);
+                            createGeneratorRemoteVoltageControlEquations(voltageControl, equationSystem);
                         }
                         updateGeneratorVoltageControl(voltageControl, equationSystem);
                     }
@@ -149,8 +149,8 @@ public class AcEquationSystemCreator {
         bus.getSvcShunt().ifPresent(shunt -> createShuntEquation(shunt, bus, equationSystem, false));
     }
 
-    private void createRemoteVoltageControlEquations(GeneratorVoltageControl voltageControl,
-                                                     EquationSystem<AcVariableType, AcEquationType> equationSystem) {
+    private void createGeneratorRemoteVoltageControlEquations(GeneratorVoltageControl voltageControl,
+                                                              EquationSystem<AcVariableType, AcEquationType> equationSystem) {
         for (LfBus controllerBus : voltageControl.getControllerElements()) {
             equationSystem.createEquation(controllerBus, AcEquationType.BUS_TARGET_Q);
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
@@ -57,9 +57,10 @@ public class AcEquationSystemCreator {
                 .setActive(false);
         bus.setCalculatedV(vTerm);
 
-        createGeneratorControlEquations(bus, equationSystem);
-
         createShuntEquations(bus, equationSystem);
+
+        // voltage control equations
+        createGeneratorControlEquations(bus, equationSystem);
 
         createTransformerVoltageControlEquations(bus, equationSystem);
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationType.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationType.java
@@ -16,7 +16,6 @@ public enum AcEquationType implements Quantity {
     BUS_TARGET_P("bus_target_p", ElementType.BUS), // bus active power target
     BUS_TARGET_Q("bus_target_q", ElementType.BUS), // bus reactive power target
     BUS_TARGET_V("bus_target_v", ElementType.BUS), // bus voltage magnitude control
-    BUS_TARGET_V_WITH_SLOPE("bus_target_v_slope", ElementType.BUS), // V - slop * Q like bus voltage magnitude control
     BUS_TARGET_PHI("bus_target_\u03C6", ElementType.BUS), // slack bus voltage angle target
     SHUNT_TARGET_B("shunt_target_b", ElementType.SHUNT_COMPENSATOR), // shunt susceptance
     BRANCH_TARGET_P("branch_target_p", ElementType.BRANCH), // phase shifter active flow control

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/PerEquationTypeStoppingCriteria.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/PerEquationTypeStoppingCriteria.java
@@ -68,7 +68,6 @@ public class PerEquationTypeStoppingCriteria implements NewtonRaphsonStoppingCri
                     }
                     break;
                 case BUS_TARGET_V:
-                case BUS_TARGET_V_WITH_SLOPE:
                 case ZERO_V:
                     if (Math.abs(fx[idx]) >= maxVoltageMismatch) {
                         return false;

--- a/src/main/java/com/powsybl/openloadflow/network/GeneratorVoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/GeneratorVoltageControl.java
@@ -25,6 +25,11 @@ public class GeneratorVoltageControl extends VoltageControl<LfBus> {
     }
 
     @Override
+    public boolean isControllerEnabled(LfBus controllerElement) {
+        return controllerElement.isGeneratorVoltageControlEnabled();
+    }
+
+    @Override
     public void setTargetValue(double targetValue) {
         if (targetValue != this.targetValue) {
             this.targetValue = targetValue;

--- a/src/main/java/com/powsybl/openloadflow/network/ShuntVoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/ShuntVoltageControl.java
@@ -15,4 +15,9 @@ public class ShuntVoltageControl extends DiscreteVoltageControl<LfShunt> {
     public ShuntVoltageControl(LfBus controlledBus, double targetValue, Double targetDeadband) {
         super(controlledBus, targetValue, targetDeadband);
     }
+
+    @Override
+    public boolean isControllerEnabled(LfShunt controllerElement) {
+        return controllerElement.isVoltageControlEnabled();
+    }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/TransformerVoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/TransformerVoltageControl.java
@@ -15,4 +15,9 @@ public class TransformerVoltageControl extends DiscreteVoltageControl<LfBranch> 
     public TransformerVoltageControl(LfBus controlledBus, double targetValue, Double targetDeadband) {
         super(controlledBus, targetValue, targetDeadband);
     }
+
+    @Override
+    public boolean isControllerEnabled(LfBranch controllerElement) {
+        return controllerElement.isVoltageControlEnabled();
+    }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/VoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/VoltageControl.java
@@ -35,4 +35,8 @@ public class VoltageControl<T extends LfElement> extends Control {
     public void addControllerElement(T controllerElement) {
         controllerElements.add(Objects.requireNonNull(controllerElement));
     }
+
+    public boolean isControllerEnabled(T controllerElement) {
+        throw new IllegalStateException();
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactor/Simplify


**What is the new behavior (if this is a feature change)?**
 - BUS_TARGET_V_WITH_SLOPE is removed and replaced by BUS_TARGET_V to be consistent with other voltage control.
 - In AC equation system, BUS_TARGET_V is first and always created so that we don't need to create it in each voltage control and create missing at the end.
 - In AC equation system, code is shared for the 3 voltage control update (code was duplicated and also buggy for transformer).


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
