### PR TITLE
Fix contingency on line disconnected at one side

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/PropagatedContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/PropagatedContingency.java
@@ -293,8 +293,10 @@ public class PropagatedContingency {
         for (LfBus bus : buses) {
             bus.getBranches().stream().filter(b -> !b.isConnectedAtBothSides()).forEach(branches::add);
         }
-
-        branchIdsToOpen.stream().map(network::getBranchById).filter(b -> !b.isConnectedAtBothSides()).forEach(branches::add);
+        branchIdsToOpen.stream().map(network::getBranchById)
+                .filter(Objects::nonNull)
+                .filter(b -> !b.isConnectedAtBothSides())
+                .forEach(branches::add);
 
         // reset connectivity to discard triggered branches
         connectivity.undoTemporaryChanges();

--- a/src/main/java/com/powsybl/openloadflow/network/impl/PropagatedContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/PropagatedContingency.java
@@ -277,10 +277,14 @@ public class PropagatedContingency {
         // update connectivity with triggered branches of this network
         GraphConnectivity<LfBus, LfBranch> connectivity = network.getConnectivity();
         connectivity.startTemporaryChanges();
-        branchIdsToOpen.stream()
+
+        List<LfBranch> branchesToOpen = branchIdsToOpen.stream()
                 .map(network::getBranchById)
                 .filter(Objects::nonNull) // could be in another component
-                .filter(b -> b.getBus1() != null && b.getBus2() != null)
+                .collect(Collectors.toList());
+
+        branchesToOpen.stream()
+                .filter(LfBranch::isConnectedAtBothSides)
                 .forEach(connectivity::removeEdge);
 
         // add to contingency description buses and branches that won't be part of the main connected
@@ -290,8 +294,7 @@ public class PropagatedContingency {
         Set<LfBranch> branches = new HashSet<>(connectivity.getEdgesRemovedFromMainComponent());
 
         // we should manage branches open at one side
-        branchIdsToOpen.stream().map(network::getBranchById)
-                .filter(Objects::nonNull)
+        branchesToOpen.stream()
                 .filter(b -> !b.isConnectedAtBothSides())
                 .forEach(branches::add);
         for (LfBus bus : buses) {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/PropagatedContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/PropagatedContingency.java
@@ -289,14 +289,14 @@ public class PropagatedContingency {
         Set<LfBus> buses = connectivity.getVerticesRemovedFromMainComponent();
         Set<LfBranch> branches = new HashSet<>(connectivity.getEdgesRemovedFromMainComponent());
 
-        // we should manage branches open at one side.
-        for (LfBus bus : buses) {
-            bus.getBranches().stream().filter(b -> !b.isConnectedAtBothSides()).forEach(branches::add);
-        }
+        // we should manage branches open at one side
         branchIdsToOpen.stream().map(network::getBranchById)
                 .filter(Objects::nonNull)
                 .filter(b -> !b.isConnectedAtBothSides())
                 .forEach(branches::add);
+        for (LfBus bus : buses) {
+            bus.getBranches().stream().filter(b -> !b.isConnectedAtBothSides()).forEach(branches::add);
+        }
 
         // reset connectivity to discard triggered branches
         connectivity.undoTemporaryChanges();

--- a/src/main/java/com/powsybl/openloadflow/network/impl/PropagatedContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/PropagatedContingency.java
@@ -294,6 +294,8 @@ public class PropagatedContingency {
             bus.getBranches().stream().filter(b -> !b.isConnectedAtBothSides()).forEach(branches::add);
         }
 
+        branchIdsToOpen.stream().map(network::getBranchById).filter(b -> !b.isConnectedAtBothSides()).forEach(branches::add);
+
         // reset connectivity to discard triggered branches
         connectivity.undoTemporaryChanges();
 

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -2576,4 +2576,14 @@ class OpenSecurityAnalysisTest {
         assertEquals(-35.294, operatorStrategyResult2.getNetworkResult().getBranchResult("l14").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(-58.824, operatorStrategyResult2.getNetworkResult().getBranchResult("l34").getP1(), LoadFlowAssert.DELTA_POWER);
     }
+
+    @Test
+    void testLineDisconnectedOnOneSideContingency() {
+        Network network = DistributedSlackNetworkFactory.create();
+        network.getBranch("l24").getTerminal1().disconnect();
+
+        SecurityAnalysisResult result = runSecurityAnalysis(network, List.of(new Contingency("l24", new BranchContingency("l24"))), Collections.emptyList());
+
+        assertEquals(1, result.getPostContingencyResults().size());
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -2581,9 +2581,13 @@ class OpenSecurityAnalysisTest {
     void testLineDisconnectedOnOneSideContingency() {
         Network network = DistributedSlackNetworkFactory.create();
         network.getBranch("l24").getTerminal1().disconnect();
-
-        SecurityAnalysisResult result = runSecurityAnalysis(network, List.of(new Contingency("l24", new BranchContingency("l24"))), Collections.emptyList());
-
+        List<StateMonitor> monitors = createAllBranchesMonitors(network);
+        SecurityAnalysisResult result = runSecurityAnalysis(network, List.of(new Contingency("l24", new BranchContingency("l24"))), monitors);
+        PostContingencyResult postContingencyResult = getPostContingencyResult(result, "l24");
+        assertEquals(200.000, postContingencyResult.getNetworkResult().getBranchResult("l14").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(140.141, postContingencyResult.getNetworkResult().getBranchResult("l14").getQ1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(300.000, postContingencyResult.getNetworkResult().getBranchResult("l34").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(260.005, postContingencyResult.getNetworkResult().getBranchResult("l34").getQ1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(1, result.getPostContingencyResults().size());
     }
 }


### PR DESCRIPTION
Fix contingencies on line disconnected on one side not appearing in post contingency results.

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
