### PR TITLE
Avoid useless peruniting/de-peruniting

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -201,9 +201,9 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
 
     void addLoad(Load load, LfNetworkParameters parameters) {
         double p0 = load.getP0();
-        loadTargetP += p0;
-        initialLoadTargetP += p0;
-        loadTargetQ += load.getQ0();
+        loadTargetP += p0 / PerUnit.SB;
+        initialLoadTargetP += p0 / PerUnit.SB;
+        loadTargetQ += load.getQ0() / PerUnit.SB;
         if (p0 < 0) {
             ensurePowerFactorConstantByLoad = true;
         }
@@ -214,16 +214,16 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
         // note that LCC converter station are out of the slack distribution.
         lccCsRefs.add(Ref.create(lccCs, parameters.isCacheEnabled()));
         double targetP = HvdcConverterStations.getConverterStationTargetP(lccCs, parameters.isBreakers());
-        loadTargetP += targetP;
-        initialLoadTargetP += targetP;
-        loadTargetQ += HvdcConverterStations.getLccConverterStationLoadTargetQ(lccCs, parameters.isBreakers());
+        loadTargetP += targetP / PerUnit.SB;
+        initialLoadTargetP += targetP / PerUnit.SB;
+        loadTargetQ += HvdcConverterStations.getLccConverterStationLoadTargetQ(lccCs, parameters.isBreakers()) / PerUnit.SB;
     }
 
     protected void add(LfGenerator generator) {
         generators.add(generator);
         generator.setBus(this);
         if (generator.getGeneratorControlType() != LfGenerator.GeneratorControlType.VOLTAGE && !Double.isNaN(generator.getTargetQ())) {
-            generationTargetQ += generator.getTargetQ() * PerUnit.SB;
+            generationTargetQ += generator.getTargetQ();
         }
     }
 
@@ -288,56 +288,53 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
 
     @Override
     public double getGenerationTargetQ() {
-        return generationTargetQ / PerUnit.SB;
+        return generationTargetQ;
     }
 
     @Override
     public void setGenerationTargetQ(double generationTargetQ) {
-        double newGenerationTargetQ = generationTargetQ * PerUnit.SB;
-        if (newGenerationTargetQ != this.generationTargetQ) {
+        if (generationTargetQ != this.generationTargetQ) {
             double oldGenerationTargetQ = this.generationTargetQ;
-            this.generationTargetQ = newGenerationTargetQ;
+            this.generationTargetQ = generationTargetQ;
             for (LfNetworkListener listener : network.getListeners()) {
-                listener.onGenerationReactivePowerTargetChange(this, oldGenerationTargetQ, newGenerationTargetQ);
+                listener.onGenerationReactivePowerTargetChange(this, oldGenerationTargetQ, generationTargetQ);
             }
         }
     }
 
     @Override
     public double getLoadTargetP() {
-        return loadTargetP / PerUnit.SB;
+        return loadTargetP;
     }
 
     @Override
     public double getInitialLoadTargetP() {
-        return initialLoadTargetP / PerUnit.SB;
+        return initialLoadTargetP;
     }
 
     @Override
     public void setLoadTargetP(double loadTargetP) {
-        double newLoadTargetP = loadTargetP * PerUnit.SB;
-        if (newLoadTargetP != this.loadTargetP) {
+        if (loadTargetP != this.loadTargetP) {
             double oldLoadTargetP = this.loadTargetP;
-            this.loadTargetP = newLoadTargetP;
+            this.loadTargetP = loadTargetP;
             for (LfNetworkListener listener : network.getListeners()) {
-                listener.onLoadActivePowerTargetChange(this, oldLoadTargetP, newLoadTargetP);
+                listener.onLoadActivePowerTargetChange(this, oldLoadTargetP, loadTargetP);
             }
         }
     }
 
     @Override
     public double getLoadTargetQ() {
-        return loadTargetQ / PerUnit.SB;
+        return loadTargetQ;
     }
 
     @Override
     public void setLoadTargetQ(double loadTargetQ) {
-        double newLoadTargetQ = loadTargetQ * PerUnit.SB;
-        if (newLoadTargetQ != this.loadTargetQ) {
+        if (loadTargetQ != this.loadTargetQ) {
             double oldLoadTargetQ = this.loadTargetQ;
-            this.loadTargetQ = newLoadTargetQ;
+            this.loadTargetQ = loadTargetQ;
             for (LfNetworkListener listener : network.getListeners()) {
-                listener.onLoadReactivePowerTargetChange(this, oldLoadTargetQ, newLoadTargetQ);
+                listener.onLoadReactivePowerTargetChange(this, oldLoadTargetQ, loadTargetQ);
             }
         }
     }
@@ -480,7 +477,7 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     @Override
     public void updateState(LfNetworkStateUpdateParameters parameters) {
         // update generator reactive power
-        updateGeneratorsState(generatorVoltageControlEnabled ? q.eval() * PerUnit.SB + loadTargetQ : generationTargetQ, parameters.isReactiveLimits());
+        updateGeneratorsState((generatorVoltageControlEnabled ? (q.eval() + loadTargetQ) : generationTargetQ) * PerUnit.SB, parameters.isReactiveLimits());
 
         // update load power
         lfAggregatedLoads.updateState(getLoadTargetP() - getInitialLoadTargetP(), parameters.isLoadPowerFactorConstant());

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
@@ -78,23 +78,22 @@ public abstract class AbstractLfGenerator extends AbstractPropertyBag implements
 
     @Override
     public double getInitialTargetP() {
-        return initialTargetP / PerUnit.SB;
+        return initialTargetP;
     }
 
     @Override
     public double getTargetP() {
-        return targetP / PerUnit.SB;
+        return targetP;
     }
 
     @Override
     public void setTargetP(double targetP) {
-        double newTargetP = targetP * PerUnit.SB;
-        if (newTargetP != this.targetP) {
+        if (targetP != this.targetP) {
             double oldTargetP = this.targetP;
-            this.targetP = newTargetP;
+            this.targetP = targetP;
             bus.invalidateGenerationTargetP();
             for (LfNetworkListener listener : bus.getNetwork().getListeners()) {
-                listener.onGenerationActivePowerTargetChange(this, oldTargetP, newTargetP);
+                listener.onGenerationActivePowerTargetChange(this, oldTargetP, targetP);
             }
         }
     }
@@ -129,14 +128,14 @@ public abstract class AbstractLfGenerator extends AbstractPropertyBag implements
     @Override
     public double getMinQ() {
         return getReactiveLimits()
-                .map(limits -> limits.getMinQ(targetP) / PerUnit.SB)
+                .map(limits -> limits.getMinQ(targetP * PerUnit.SB) / PerUnit.SB)
                 .orElse(-Double.MAX_VALUE);
     }
 
     @Override
     public double getMaxQ() {
         return getReactiveLimits()
-                .map(limits -> limits.getMaxQ(targetP) / PerUnit.SB)
+                .map(limits -> limits.getMaxQ(targetP * PerUnit.SB) / PerUnit.SB)
                 .orElse(Double.MAX_VALUE);
     }
 
@@ -158,7 +157,7 @@ public abstract class AbstractLfGenerator extends AbstractPropertyBag implements
                             }
                         }
                     } else if (rangeMode == ReactiveRangeMode.TARGET_P) {
-                        rangeQ = reactiveLimits.getMaxQ(targetP) - reactiveLimits.getMinQ(targetP);
+                        rangeQ = reactiveLimits.getMaxQ(targetP * PerUnit.SB) - reactiveLimits.getMinQ(targetP * PerUnit.SB);
                     } else {
                         throw new PowsyblException("Unsupported reactive range mode: " + rangeMode);
                     }
@@ -180,12 +179,12 @@ public abstract class AbstractLfGenerator extends AbstractPropertyBag implements
 
     @Override
     public double getCalculatedQ() {
-        return calculatedQ / PerUnit.SB;
+        return calculatedQ;
     }
 
     @Override
     public void setCalculatedQ(double calculatedQ) {
-        this.calculatedQ = calculatedQ * PerUnit.SB;
+        this.calculatedQ = calculatedQ;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBatteryImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBatteryImpl.java
@@ -30,7 +30,7 @@ public final class LfBatteryImpl extends AbstractLfGenerator {
     private double participationFactor;
 
     private LfBatteryImpl(Battery battery, LfNetwork network, LfNetworkParameters parameters, LfNetworkLoadingReport report) {
-        super(network, battery.getTargetP());
+        super(network, battery.getTargetP() / PerUnit.SB);
         this.batteryRef = Ref.create(battery, parameters.isCacheEnabled());
         participating = true;
         droop = DEFAULT_DROOP;
@@ -113,7 +113,7 @@ public final class LfBatteryImpl extends AbstractLfGenerator {
     public void updateState() {
         var battery = getBattery();
         battery.getTerminal()
-                .setP(-targetP)
+                .setP(-targetP * PerUnit.SB)
                 .setQ(-battery.getTargetQ());
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBus.java
@@ -10,6 +10,7 @@ import com.powsybl.iidm.network.DanglingLine;
 import com.powsybl.openloadflow.network.LfNetwork;
 import com.powsybl.openloadflow.network.LfNetworkParameters;
 import com.powsybl.openloadflow.network.LfNetworkStateUpdateParameters;
+import com.powsybl.openloadflow.util.PerUnit;
 
 import java.util.List;
 
@@ -26,8 +27,8 @@ public class LfDanglingLineBus extends AbstractLfBus {
         super(network, Networks.getPropertyV(danglingLine), Math.toRadians(Networks.getPropertyAngle(danglingLine)), false);
         this.danglingLineRef = Ref.create(danglingLine, parameters.isCacheEnabled());
         nominalV = danglingLine.getTerminal().getVoltageLevel().getNominalV();
-        loadTargetP += danglingLine.getP0();
-        loadTargetQ += danglingLine.getQ0();
+        loadTargetP += danglingLine.getP0() / PerUnit.SB;
+        loadTargetQ += danglingLine.getQ0() / PerUnit.SB;
         DanglingLine.Generation generation = danglingLine.getGeneration();
         if (generation != null) {
             add(LfDanglingLineGenerator.create(danglingLine, network, getId(), parameters, report));

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineGenerator.java
@@ -25,7 +25,7 @@ public final class LfDanglingLineGenerator extends AbstractLfGenerator {
 
     private LfDanglingLineGenerator(DanglingLine danglingLine, LfNetwork network, String controlledLfBusId, LfNetworkParameters parameters,
                                     LfNetworkLoadingReport report) {
-        super(network, danglingLine.getGeneration().getTargetP());
+        super(network, danglingLine.getGeneration().getTargetP() / PerUnit.SB);
         this.danglingLineRef = Ref.create(danglingLine, parameters.isCacheEnabled());
 
         // local control only

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
@@ -33,7 +33,7 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
     private double participationFactor;
 
     private LfGeneratorImpl(Generator generator, LfNetwork network, LfNetworkParameters parameters, LfNetworkLoadingReport report) {
-        super(network, generator.getTargetP());
+        super(network, generator.getTargetP() / PerUnit.SB);
         this.generatorRef = Ref.create(generator, parameters.isCacheEnabled());
         participating = true;
         droop = DEFAULT_DROOP;
@@ -142,7 +142,7 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
     public void updateState() {
         var generator = getGenerator();
         generator.getTerminal()
-                .setP(-targetP)
-                .setQ(Double.isNaN(calculatedQ) ? -generator.getTargetQ() : -calculatedQ);
+                .setP(-targetP * PerUnit.SB)
+                .setQ(Double.isNaN(calculatedQ) ? -generator.getTargetQ() : -calculatedQ * PerUnit.SB);
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfStaticVarCompensatorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfStaticVarCompensatorImpl.java
@@ -108,7 +108,7 @@ public final class LfStaticVarCompensatorImpl extends AbstractLfGenerator implem
             }
         }
         if (svc.getRegulationMode() == StaticVarCompensator.RegulationMode.REACTIVE_POWER) {
-            targetQ = -svc.getReactivePowerSetpoint();
+            targetQ = -svc.getReactivePowerSetpoint() / PerUnit.SB;
         }
     }
 
@@ -133,7 +133,7 @@ public final class LfStaticVarCompensatorImpl extends AbstractLfGenerator implem
 
     @Override
     public double getTargetQ() {
-        return targetQ / PerUnit.SB;
+        return targetQ;
     }
 
     @Override
@@ -155,7 +155,7 @@ public final class LfStaticVarCompensatorImpl extends AbstractLfGenerator implem
     public void updateState() {
         double vSquare = bus.getV() * bus.getV() * nominalV * nominalV;
         double newTargetQ = Double.isNaN(targetQ) ? 0 : -targetQ;
-        double q = Double.isNaN(calculatedQ) ? newTargetQ : -calculatedQ;
+        double q = (Double.isNaN(calculatedQ) ? newTargetQ : -calculatedQ) * PerUnit.SB;
         getSvc().getTerminal()
                 .setP(0)
                 .setQ(q - b0 * vSquare);

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfVscConverterStationImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfVscConverterStationImpl.java
@@ -29,7 +29,7 @@ public class LfVscConverterStationImpl extends AbstractLfGenerator implements Lf
     private LfHvdc hvdc; // set only when AC emulation is activated
 
     public LfVscConverterStationImpl(VscConverterStation station, LfNetwork network, LfNetworkParameters parameters, LfNetworkLoadingReport report) {
-        super(network, HvdcConverterStations.getConverterStationTargetP(station, parameters.isBreakers()));
+        super(network, HvdcConverterStations.getConverterStationTargetP(station, parameters.isBreakers()) / PerUnit.SB);
         this.stationRef = Ref.create(station, parameters.isCacheEnabled());
         this.lossFactor = station.getLossFactor();
 
@@ -94,9 +94,9 @@ public class LfVscConverterStationImpl extends AbstractLfGenerator implements Lf
     public void updateState() {
         var station = getStation();
         station.getTerminal()
-                .setQ(Double.isNaN(calculatedQ) ? -station.getReactivePowerSetpoint() : -calculatedQ);
+                .setQ(Double.isNaN(calculatedQ) ? -station.getReactivePowerSetpoint() : -calculatedQ * PerUnit.SB);
         if (hvdc == null) { // because when AC emulation is activated, update of p is done in LFHvdcImpl
-            station.getTerminal().setP(-targetP);
+            station.getTerminal().setP(-targetP * PerUnit.SB);
         }
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Unnecessary power per uniting is responsible for loss of precision and uncontrolled network notifications when saving/restorating state. 


**What is the new behavior (if this is a feature change)?**
We do not anymore perunit/de-perunit when setting of getting active/reactive power in the LF data model.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
