### PR TITLE
Only use branches connected at both sides in most meshed slack bus

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
+++ b/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
@@ -29,6 +29,10 @@ public class MostMeshedSlackBusSelector implements SlackBusSelector {
         this.maxNominalVoltagePercentile = maxNominalVoltagePercentile;
     }
 
+    private static int getBranchCountConnectedAtBothSides(LfBus bus) {
+        return (int) bus.getBranches().stream().filter(LfBranch::isConnectedAtBothSides).count();
+    }
+
     @Override
     public SelectedSlackBus select(List<LfBus> buses, int limit) {
         double[] nominalVoltages = buses.stream()
@@ -41,7 +45,7 @@ public class MostMeshedSlackBusSelector implements SlackBusSelector {
         // select non-fictitious and most meshed bus among buses with the highest nominal voltage
         List<LfBus> slackBuses = buses.stream()
             .filter(bus -> !bus.isFictitious() && bus.getNominalV() == maxNominalV)
-            .sorted(Comparator.comparingInt((LfBus bus) -> bus.getBranches().size())
+            .sorted(Comparator.comparingInt(MostMeshedSlackBusSelector::getBranchCountConnectedAtBothSides)
                     .thenComparing(Comparator.comparing(LfBus::getId).reversed()).reversed())
             .limit(limit)
             .collect(Collectors.toList());

--- a/src/test/java/com/powsybl/openloadflow/ac/NonImpedantBranchDisablingTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/NonImpedantBranchDisablingTest.java
@@ -73,8 +73,8 @@ class NonImpedantBranchDisablingTest {
         network.getLine("L2").setR(0.0).setX(0.0);
         network.getLine("L1").getTerminal1().disconnect();
         LoadFlow.run(network);
-        assertEquals(600.0, network.getLine("L2").getTerminal1().getP(), LoadFlowAssert.DELTA_POWER);
-        assertEquals(-600.0, network.getLine("L2").getTerminal2().getP(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(600.018, network.getLine("L2").getTerminal1().getP(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(-600.018, network.getLine("L2").getTerminal2().getP(), LoadFlowAssert.DELTA_POWER);
         assertEquals(Double.NaN, network.getLine("L1").getTerminal1().getP(), LoadFlowAssert.DELTA_POWER);
 
         network.getLine("L1").getTerminal1().connect();


### PR DESCRIPTION

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
In most meshed slack bus selection, we take into account branches connected at one side.


**What is the new behavior (if this is a feature change)?**
We only use branches connected at both sides (so the ones that can really flow active power).


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
