### PR TITLE
Fix no impact load contingency when simulated with a switch contingency

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/PowerShift.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PowerShift.java
@@ -47,4 +47,12 @@ public class PowerShift {
         variableActive += other.getVariableActive();
         reactive += other.getReactive();
     }
+
+    @Override
+    public String toString() {
+        return "PowerShift("
+                + active + ", "
+                + variableActive + ", "
+                + reactive + ")";
+    }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/PropagatedContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/PropagatedContingency.java
@@ -105,8 +105,7 @@ public class PropagatedContingency {
                               load.getQ0() / PerUnit.SB); // ensurePowerFactorConstant is not supported.
     }
 
-    public static List<PropagatedContingency> createList(Network network, List<Contingency> contingencies, Set<Switch> allSwitchesToOpen, Set<Switch> allSwitchesToClose,
-                                                         boolean contingencyPropagation, boolean shuntCompensatorVoltageControlOn, boolean slackDistributionOnConformLoad, boolean hvdcAcEmulation) {
+    public static List<PropagatedContingency> createList(Network network, List<Contingency> contingencies, Set<Switch> allSwitchesToOpen, boolean contingencyPropagation) {
         List<PropagatedContingency> propagatedContingencies = new ArrayList<>();
         for (int index = 0; index < contingencies.size(); index++) {
             Contingency contingency = contingencies.get(index);
@@ -115,7 +114,13 @@ public class PropagatedContingency {
             propagatedContingencies.add(propagatedContingency);
             allSwitchesToOpen.addAll(propagatedContingency.switchesToOpen);
         }
-        boolean breakers = !(allSwitchesToOpen.isEmpty() && allSwitchesToClose.isEmpty());
+        return propagatedContingencies;
+    }
+
+    public static List<PropagatedContingency> completeList(List<PropagatedContingency> propagatedContingencies, boolean shuntCompensatorVoltageControlOn,
+                                                           boolean slackDistributionOnConformLoad, boolean hvdcAcEmulation, boolean breakers) {
+        // complete definition of contingencies after network loading
+        // in order to have the good busId.
         for (PropagatedContingency propagatedContingency : propagatedContingencies) {
             propagatedContingency.complete(shuntCompensatorVoltageControlOn, slackDistributionOnConformLoad, hvdcAcEmulation, breakers);
         }
@@ -142,7 +147,7 @@ public class PropagatedContingency {
     }
 
     private void complete(boolean shuntCompensatorVoltageControlOn, boolean slackDistributionOnConformLoad,
-                                 boolean hvdcAcEmulation, boolean breakers) {
+                         boolean hvdcAcEmulation, boolean breakers) {
         for (Switch sw : switchesToOpen) {
             branchIdsToOpen.add(sw.getId());
         }

--- a/src/main/java/com/powsybl/openloadflow/sa/AcSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AcSecurityAnalysis.java
@@ -85,9 +85,7 @@ public class AcSecurityAnalysis extends AbstractSecurityAnalysis<AcVariableType,
         List<Contingency> contingencies = contingenciesProvider.getContingencies(network);
         // try to find all switches impacted by at least one contingency and for each contingency the branches impacted
         List<PropagatedContingency> propagatedContingencies = PropagatedContingency.createList(network, contingencies, allSwitchesToOpen,
-                allSwitchesToClose, securityAnalysisParametersExt.isContingencyPropagation(), lfParameters.isShuntCompensatorVoltageControlOn(),
-                lfParameters.getBalanceType() == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD,
-                lfParameters.isHvdcAcEmulation());
+                securityAnalysisParametersExt.isContingencyPropagation());
 
         boolean breakers = !(allSwitchesToOpen.isEmpty() && allSwitchesToClose.isEmpty());
         AcLoadFlowParameters acParameters = OpenLoadFlowParameters.createAcParameters(network, lfParameters, lfParametersExt, matrixFactory, connectivityFactory, breakers, false);
@@ -98,6 +96,10 @@ public class AcSecurityAnalysis extends AbstractSecurityAnalysis<AcVariableType,
 
         // create networks including all necessary switches
         try (LfNetworkList lfNetworks = Networks.load(network, acParameters.getNetworkParameters(), allSwitchesToOpen, allSwitchesToClose, saReporter)) {
+
+            // complete definition of contingencies after network loading
+            PropagatedContingency.completeList(propagatedContingencies, lfParameters.isShuntCompensatorVoltageControlOn(),
+                    lfParameters.getBalanceType() == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD, lfParameters.isHvdcAcEmulation(), breakers);
 
             // run simulation on largest network
             SecurityAnalysisResult result = lfNetworks.getLargest().filter(LfNetwork::isValid)

--- a/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
@@ -221,6 +221,11 @@ public class AcSensitivityAnalysis extends AbstractSensitivityAnalysis<AcVariabl
         // create networks including all necessary switches
         try (LfNetworkList lfNetworks = Networks.load(network, lfNetworkParameters, allSwitchesToOpen, Collections.emptySet(), reporter)) {
             LfNetwork lfNetwork = lfNetworks.getLargest().orElseThrow(() -> new PowsyblException("Empty network"));
+
+            // complete definition of contingencies after network loading
+            PropagatedContingency.completeList(contingencies, lfParameters.isShuntCompensatorVoltageControlOn(),
+                    lfParameters.getBalanceType() == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD, lfParameters.isHvdcAcEmulation(), breakers);
+
             checkContingencies(lfNetwork, contingencies);
             checkLoadFlowParameters(lfParameters);
 

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -813,6 +813,11 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
         // create networks including all necessary switches
         try (LfNetworkList lfNetworks = Networks.load(network, lfNetworkParameters, allSwitchesToOpen, Collections.emptySet(), reporter)) {
             LfNetwork lfNetwork = lfNetworks.getLargest().orElseThrow(() -> new PowsyblException("Empty network"));
+
+            // complete definition of contingencies after network loading
+            PropagatedContingency.completeList(contingencies, false,
+                    lfParameters.getBalanceType() == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD, false, breakers);
+
             checkContingencies(lfNetwork, contingencies);
             checkLoadFlowParameters(lfParameters);
 

--- a/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProvider.java
@@ -24,7 +24,6 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.Switch;
 import com.powsybl.iidm.network.VariantManagerConstants;
 import com.powsybl.iidm.xml.NetworkXml;
-import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.json.LoadFlowParametersJsonModule;
 import com.powsybl.math.matrix.MatrixFactory;
 import com.powsybl.math.matrix.SparseMatrixFactory;
@@ -155,9 +154,7 @@ public class OpenSensitivityAnalysisProvider implements SensitivityAnalysisProvi
             // Contingency propagation leads to numerous zero impedance branches, that are managed as min impedance
             // branches in sensitivity analysis. It could lead to issues with voltage controls in AC analysis.
             Set<Switch> allSwitchesToOpen = new HashSet<>();
-            List<PropagatedContingency> propagatedContingencies = PropagatedContingency.createList(network, contingencies, allSwitchesToOpen, Collections.emptySet(), false, false,
-                    sensitivityAnalysisParameters.getLoadFlowParameters().getBalanceType() == LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD,
-                    sensitivityAnalysisParameters.getLoadFlowParameters().isHvdcAcEmulation() && !sensitivityAnalysisParameters.getLoadFlowParameters().isDc());
+            List<PropagatedContingency> propagatedContingencies = PropagatedContingency.createList(network, contingencies, allSwitchesToOpen, false);
 
             SensitivityFactorReader decoratedFactorReader = factorReader;
 

--- a/src/test/java/com/powsybl/openloadflow/sa/LfActionTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/LfActionTest.java
@@ -64,7 +64,8 @@ class LfActionTest extends AbstractConverterTest {
             String loadId = "LOAD";
             Contingency contingency = new Contingency(loadId, new LoadContingency("LD"));
             PropagatedContingency propagatedContingency = PropagatedContingency.createList(network,
-                    Collections.singletonList(contingency), new HashSet<>(), new HashSet<>(), true, false, false, false).get(0);
+                    Collections.singletonList(contingency), new HashSet<>(), true).get(0);
+            PropagatedContingency.completeList(List.of(propagatedContingency), false, false, false, true);
             propagatedContingency.toLfContingency(lfNetwork).ifPresent(lfContingency -> {
                 LfAction.apply(List.of(lfAction), lfNetwork, lfContingency, acParameters.getNetworkParameters());
                 assertTrue(lfNetwork.getBranchById("C").isDisabled());

--- a/src/test/java/com/powsybl/openloadflow/sa/LfContingencyTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/LfContingencyTest.java
@@ -74,7 +74,8 @@ class LfContingencyTest extends AbstractConverterTest {
         String branchId = "LINE_S3S4";
         Contingency contingency = new Contingency(branchId, new BranchContingency(branchId));
         List<PropagatedContingency> propagatedContingencies =
-            PropagatedContingency.createList(network, Collections.singletonList(contingency), new HashSet<>(), new HashSet<>(), true, false, false, false);
+            PropagatedContingency.createList(network, Collections.singletonList(contingency), new HashSet<>(), false);
+        PropagatedContingency.completeList(propagatedContingencies, false, false, false, false);
 
         List<LfContingency> lfContingencies = propagatedContingencies.stream()
                 .flatMap(propagatedContingency -> propagatedContingency.toLfContingency(mainNetwork).stream())
@@ -103,7 +104,7 @@ class LfContingencyTest extends AbstractConverterTest {
         String generatorId = "GEN";
         Contingency contingency = new Contingency(generatorId, new GeneratorContingency(generatorId));
         assertThrows(PowsyblException.class, () ->
-                        PropagatedContingency.createList(network, Collections.singletonList(contingency), new HashSet<>(), new HashSet<>(), true, false, false, false),
+                        PropagatedContingency.createList(network, Collections.singletonList(contingency), new HashSet<>(), true),
                 "Generator 'GEN' not found in the network");
     }
 
@@ -119,7 +120,7 @@ class LfContingencyTest extends AbstractConverterTest {
         String loadId = "LOAD";
         Contingency contingency = new Contingency(loadId, new LoadContingency(loadId));
         assertThrows(PowsyblException.class, () ->
-                        PropagatedContingency.createList(network, Collections.singletonList(contingency), new HashSet<>(), new HashSet<>(), true, false, false, false),
+                        PropagatedContingency.createList(network, Collections.singletonList(contingency), new HashSet<>(), true),
                 "Load 'LOAD' not found in the network");
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisGraphTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisGraphTest.java
@@ -162,7 +162,7 @@ class OpenSecurityAnalysisGraphTest {
 
         // try to find all switches impacted by at least one contingency
         Set<Switch> allSwitchesToOpen = new HashSet<>();
-        List<PropagatedContingency> propagatedContingencies = PropagatedContingency.createList(network, contingencies, allSwitchesToOpen, Collections.emptySet(), true, false, false, false);
+        List<PropagatedContingency> propagatedContingencies = PropagatedContingency.createList(network, contingencies, allSwitchesToOpen, true);
 
         LfNetworkParameters networkParameters = new LfNetworkParameters()
                 .setConnectivityFactory(connectivityFactory)
@@ -170,6 +170,8 @@ class OpenSecurityAnalysisGraphTest {
 
         // create networks including all necessary switches
         LfNetworkList lfNetworks = Networks.load(network, networkParameters, allSwitchesToOpen, Collections.emptySet(), Reporter.NO_OP);
+
+        PropagatedContingency.completeList(propagatedContingencies, false, false, false, true);
 
         // run simulation on each network
         List<List<LfContingency>> listLfContingencies = new ArrayList<>();

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -1835,12 +1835,11 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
     void testLoadContingencyNoImpact() {
         Network network = SecurityAnalysisTestNetworkFactory.createWithFixedCurrentLimits();
         List<Contingency> contingencies = List.of(new Contingency("Load contingency", new LoadContingency("LD1")));
-        // SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies);
-        // assertEquals(1, result.getPostContingencyResults().size());
+        SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies);
+        assertEquals(1, result.getPostContingencyResults().size());
         contingencies = List.of(new Contingency("Load contingency", new LoadContingency("LD1")),
                                 new Contingency("Switch contingency", new SwitchContingency("S1VL1_BBS1_GEN_DISCONNECTOR")));
-        SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies);
-        // FIXME load contingency has no impact when simulated with a switch contingency !
+        result = runSecurityAnalysis(network, contingencies);
         assertEquals(2, result.getPostContingencyResults().size());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -18,6 +18,7 @@ import com.powsybl.iidm.network.extensions.LoadDetailAdder;
 import com.powsybl.iidm.network.extensions.StandbyAutomatonAdder;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
+import com.powsybl.iidm.network.test.SecurityAnalysisTestNetworkFactory;
 import com.powsybl.loadflow.LoadFlow;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.LoadFlowResult;
@@ -1828,5 +1829,18 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         List<StateMonitor> monitors = createAllBranchesMonitors(network);
         SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies, monitors, securityAnalysisParameters);
         assertTrue(result.getPostContingencyResults().isEmpty());
+    }
+
+    @Test
+    void testLoadContingencyNoImpact() {
+        Network network = SecurityAnalysisTestNetworkFactory.createWithFixedCurrentLimits();
+        List<Contingency> contingencies = List.of(new Contingency("Load contingency", new LoadContingency("LD1")));
+        SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies);
+        assertEquals(1, result.getPostContingencyResults().size());
+        contingencies = List.of(new Contingency("Load contingency", new LoadContingency("LD1")),
+                                new Contingency("Switch contingency", new SwitchContingency("S1VL1_BBS1_GEN_DISCONNECTOR")));
+        result = runSecurityAnalysis(network, contingencies);
+        // FIXME load contingency has no impact when simulated with a switch contingency !
+        assertEquals(2, result.getPostContingencyResults().size());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -1835,11 +1835,11 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
     void testLoadContingencyNoImpact() {
         Network network = SecurityAnalysisTestNetworkFactory.createWithFixedCurrentLimits();
         List<Contingency> contingencies = List.of(new Contingency("Load contingency", new LoadContingency("LD1")));
-        SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies);
-        assertEquals(1, result.getPostContingencyResults().size());
+        // SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies);
+        // assertEquals(1, result.getPostContingencyResults().size());
         contingencies = List.of(new Contingency("Load contingency", new LoadContingency("LD1")),
                                 new Contingency("Switch contingency", new SwitchContingency("S1VL1_BBS1_GEN_DISCONNECTOR")));
-        result = runSecurityAnalysis(network, contingencies);
+        SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies);
         // FIXME load contingency has no impact when simulated with a switch contingency !
         assertEquals(2, result.getPostContingencyResults().size());
     }

--- a/src/test/java/com/powsybl/openloadflow/sensi/dc/DcSensitivityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/dc/DcSensitivityAnalysisTest.java
@@ -828,8 +828,7 @@ class DcSensitivityAnalysisTest extends AbstractSensitivityAnalysisTest {
         Network network = NodeBreakerNetworkFactory.create();
         List<Contingency> contingencies = List.of(new Contingency("c1", new BranchContingency("L1")));
 
-        List<PropagatedContingency> propagatedContingencies = PropagatedContingency.createList(network, contingencies,
-                Collections.emptySet(), Collections.emptySet(), false, false, false, false);
+        List<PropagatedContingency> propagatedContingencies = PropagatedContingency.createList(network, contingencies, Collections.emptySet(), false);
         assertEquals(1, propagatedContingencies.size());
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When a load contingency is simulated in a list with a another switch contingency, it has not the same behavior as if it is simulated alone.


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
