### PR TITLE
Fix infinity voltage shift in secondary voltage control outer loop

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
@@ -261,19 +261,24 @@ public class SecondaryVoltageControlOuterLoop implements OuterLoop {
         // supposing we want all controllers to shift to same amount of reactive power
         double dq = pilotDv / Arrays.stream(sensiVq.si).sum();
 
-        LOGGER.trace("Control units of zone '{}' need to be adjusted of {} MW", zoneName, dq * PerUnit.SB);
+        LOGGER.trace("Control units of zone '{}' need to be adjusted of {} MVar", zoneName, dq * PerUnit.SB);
 
         for (LfBus controlledBus : controlledBuses) {
             double pvcDv = 0;
             for (LfBus controllerBus : getControllerBuses(controlledBus)) {
-                pvcDv += dq / sensiVq.getSqi(controllerBus);
+                double sqi = sensiVq.getSqi(controllerBus);
+                if (sqi != 0) {
+                    pvcDv += dq / sqi;
+                }
             }
-            var pvc = controlledBus.getGeneratorVoltageControl().orElseThrow();
-            double newPvcTargetV = pvc.getTargetValue() + pvcDv;
-            LOGGER.trace("Adjust primary voltage control target of bus '{}': {} -> {}",
-                    controlledBus.getId(), pvc.getTargetValue() * controlledBus.getNominalV(),
-                    newPvcTargetV * controlledBus.getNominalV());
-            pvc.setTargetValue(newPvcTargetV);
+            if (pvcDv != 0) {
+                var pvc = controlledBus.getGeneratorVoltageControl().orElseThrow();
+                double newPvcTargetV = pvc.getTargetValue() + pvcDv;
+                LOGGER.trace("Adjust primary voltage control target of bus '{}': {} -> {}",
+                        controlledBus.getId(), pvc.getTargetValue() * controlledBus.getNominalV(),
+                        newPvcTargetV * controlledBus.getNominalV());
+                pvc.setTargetValue(newPvcTargetV);
+            }
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -739,7 +739,8 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
                             .flatMap(regulatingTerminal -> Optional.ofNullable(getLfBus(regulatingTerminal, lfNetwork, parameters.isBreakers())).stream())
                             .collect(Collectors.toCollection((Supplier<Set<LfBus>>) LinkedHashSet::new));
                     if (controlledBuses.size() != controlZone.getControlUnits().size()) {
-                        LOGGER.debug("{}/{} control units have been mapped to a LF bus", controlledBuses.size(), controlZone.getControlUnits().size());
+                        LOGGER.debug("{}/{} control units of control zone '{}' have been mapped to a LF bus",
+                                controlledBuses.size(), controlZone.getControlUnits().size(), controlZone.getName());
                     }
                     if (!controlledBuses.isEmpty()) {
                         var lfSvc = new LfSecondaryVoltageControl(controlZone.getName(), lfPilotBus, targetV, controlledBuses);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Very low voltage controlled sensitivity to set point end up to a double infinity value to the shifted target voltage.


**What is the new behavior (if this is a feature change)?**
Very low voltage controlled sensitivity are correctly skipped.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
