### PR TITLE
Exception: No more <elementType> participating to slack distribution

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
@@ -75,8 +75,11 @@ public final class ActivePowerDistribution {
         while (!participatingElements.isEmpty()
                 && Math.abs(remainingMismatch) > P_RESIDUE_EPS) {
 
-            remainingMismatch -= step.run(participatingElements, iteration, remainingMismatch);
-
+            if (ParticipatingElement.participationFactorNorm(participatingElements) > 0.0) {
+                remainingMismatch -= step.run(participatingElements, iteration, remainingMismatch);
+            } else {
+                break;
+            }
             iteration++;
         }
 

--- a/src/main/java/com/powsybl/openloadflow/network/util/GenerationActivePowerDistributionStep.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/GenerationActivePowerDistributionStep.java
@@ -58,7 +58,7 @@ public class GenerationActivePowerDistributionStep implements ActivePowerDistrib
     public double run(List<ParticipatingElement> participatingElements, int iteration, double remainingMismatch) {
         // normalize participation factors at each iteration start as some
         // generators might have reach a limit and have been discarded
-        ParticipatingElement.normalizeParticipationFactors(participatingElements, "generator");
+        ParticipatingElement.normalizeParticipationFactors(participatingElements);
 
         double done = 0d;
         int modifiedBuses = 0;

--- a/src/main/java/com/powsybl/openloadflow/network/util/LoadActivePowerDistributionStep.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/LoadActivePowerDistributionStep.java
@@ -50,7 +50,7 @@ public class LoadActivePowerDistributionStep implements ActivePowerDistribution.
     public double run(List<ParticipatingElement> participatingElements, int iteration, double remainingMismatch) {
         // normalize participation factors at each iteration start as some
         // loads might have reach zero and have been discarded.
-        ParticipatingElement.normalizeParticipationFactors(participatingElements, "load");
+        ParticipatingElement.normalizeParticipationFactors(participatingElements);
 
         double done = 0d;
         int modifiedBuses = 0;

--- a/src/main/java/com/powsybl/openloadflow/network/util/ParticipatingElement.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ParticipatingElement.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.openloadflow.network.util;
 
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.network.LfGenerator;
 
@@ -34,13 +33,14 @@ public class ParticipatingElement {
         return factor;
     }
 
-    public static void normalizeParticipationFactors(List<ParticipatingElement> participatingElements, String elementType) {
-        double factorSum = participatingElements.stream()
+    public static double participationFactorNorm(List<ParticipatingElement> participatingElements) {
+        return participatingElements.stream()
                 .mapToDouble(participatingGenerator -> participatingGenerator.factor)
                 .sum();
-        if (factorSum == 0) {
-            throw new PowsyblException("No more " + elementType + " participating to slack distribution");
-        }
+    }
+
+    public static void normalizeParticipationFactors(List<ParticipatingElement> participatingElements, String elementType) {
+        double factorSum = participationFactorNorm(participatingElements);
         for (ParticipatingElement participatingElement : participatingElements) {
             participatingElement.factor /= factorSum;
         }

--- a/src/main/java/com/powsybl/openloadflow/network/util/ParticipatingElement.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ParticipatingElement.java
@@ -39,7 +39,7 @@ public class ParticipatingElement {
                 .sum();
     }
 
-    public static void normalizeParticipationFactors(List<ParticipatingElement> participatingElements, String elementType) {
+    public static void normalizeParticipationFactors(List<ParticipatingElement> participatingElements) {
         double factorSum = participationFactorNorm(participatingElements);
         for (ParticipatingElement participatingElement : participatingElements) {
             participatingElement.factor /= factorSum;

--- a/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
@@ -623,7 +623,7 @@ public abstract class AbstractSensitivityAnalysis<V extends Enum<V> & Quantity, 
     protected List<ParticipatingElement> getParticipatingElements(Collection<LfBus> buses, LoadFlowParameters.BalanceType balanceType, OpenLoadFlowParameters openLoadFlowParameters) {
         ActivePowerDistribution.Step step = ActivePowerDistribution.getStep(balanceType, openLoadFlowParameters.isLoadPowerFactorConstant());
         List<ParticipatingElement> participatingElements = step.getParticipatingElements(buses);
-        ParticipatingElement.normalizeParticipationFactors(participatingElements, "bus");
+        ParticipatingElement.normalizeParticipationFactors(participatingElements);
         return participatingElements;
     }
 

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -616,7 +616,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
                                 .filter(participatingElement -> !participatingGeneratorsToRemove.contains(participatingElement.getElement()))
                                 .map(participatingElement -> new ParticipatingElement(participatingElement.getElement(), participatingElement.getFactor()))
                                 .collect(Collectors.toList());
-                        normalizeParticipationFactors(newParticipatingElements, "LfGenerators");
+                        normalizeParticipationFactors(newParticipatingElements);
                     } else { // slack distribution on loads
                         newParticipatingElements = getParticipatingElements(lfNetwork.getBuses(), lfParameters.getBalanceType(), lfParametersExt);
                     }

--- a/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnLoadTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnLoadTest.java
@@ -174,4 +174,14 @@ class DistributedSlackOnLoadTest {
         assertActivePowerEquals(611.405, network3.getLoad("LOAD").getTerminal());
         assertActivePowerEquals(-9.809, network3.getLoad("LOAD1").getTerminal());
     }
+
+    @Test
+    void testNetworkWithoutConformingLoad() {
+        parameters
+                .setBalanceType(LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD)
+                .getExtension(OpenLoadFlowParameters.class)
+                .setThrowsExceptionInCaseOfSlackDistributionFailure(false);
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnLoadTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnLoadTest.java
@@ -22,10 +22,11 @@ import com.powsybl.openloadflow.util.LoadFlowResultBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CompletionException;
+
 import static com.powsybl.openloadflow.util.LoadFlowAssert.assertActivePowerEquals;
 import static com.powsybl.openloadflow.util.LoadFlowAssert.assertLoadFlowResultsEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Anne Tilloy <anne.tilloy at rte-france.com>
@@ -183,5 +184,9 @@ class DistributedSlackOnLoadTest {
                 .setThrowsExceptionInCaseOfSlackDistributionFailure(false);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isOk());
+
+        parameters.getExtension(OpenLoadFlowParameters.class)
+                .setThrowsExceptionInCaseOfSlackDistributionFailure(true);
+        assertThrows(CompletionException.class, () -> loadFlowRunner.run(network, parameters));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
Slack distribution: Exception is thown although option is set to not throw in case of slack distribution failure.
Happens if network has right from start no element of requested type.



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
