### PR TITLE
Fix already converged case in fast restart mode

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/AcLoadFlowFromCache.java
+++ b/src/main/java/com/powsybl/openloadflow/AcLoadFlowFromCache.java
@@ -14,6 +14,8 @@ import com.powsybl.openloadflow.ac.AcLoadFlowContext;
 import com.powsybl.openloadflow.ac.AcLoadFlowParameters;
 import com.powsybl.openloadflow.ac.AcLoadFlowResult;
 import com.powsybl.openloadflow.ac.AcloadFlowEngine;
+import com.powsybl.openloadflow.ac.nr.NewtonRaphsonStatus;
+import com.powsybl.openloadflow.lf.outerloop.OuterLoopStatus;
 import com.powsybl.openloadflow.network.impl.LfNetworkList;
 import com.powsybl.openloadflow.network.impl.Networks;
 import org.slf4j.Logger;
@@ -93,13 +95,16 @@ public class AcLoadFlowFromCache {
     }
 
     private static AcLoadFlowResult run(AcLoadFlowContext context) {
-        if (context.getNetwork().isValid() && context.isNetworkUpdated()) {
+        if (!context.getNetwork().isValid()) {
+            return AcLoadFlowResult.createNoCalculationResult(context.getNetwork());
+        }
+        if (context.isNetworkUpdated()) {
             AcLoadFlowResult result = new AcloadFlowEngine(context)
                     .run();
             context.setNetworkUpdated(false);
             return result;
         }
-        return AcLoadFlowResult.createNoCalculationResult(context.getNetwork());
+        return new AcLoadFlowResult(context.getNetwork(), 0, 0, NewtonRaphsonStatus.CONVERGED, OuterLoopStatus.STABLE, 0d, 0d);
     }
 
     public List<AcLoadFlowResult> run() {

--- a/src/main/java/com/powsybl/openloadflow/NetworkCache.java
+++ b/src/main/java/com/powsybl/openloadflow/NetworkCache.java
@@ -15,6 +15,7 @@ import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.network.LfShunt;
 import com.powsybl.openloadflow.network.GeneratorVoltageControl;
 import com.powsybl.openloadflow.network.*;
+import com.powsybl.openloadflow.network.impl.AbstractLfGenerator;
 import com.powsybl.openloadflow.network.util.PreviousValueVoltageInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,8 +135,18 @@ public enum NetworkCache {
                 if (attribute.equals("targetV")) {
                     double valueShift = (double) newValue - (double) oldValue;
                     GeneratorVoltageControl voltageControl = lfBus.getGeneratorVoltageControl().orElseThrow();
-                    double newTargetV = voltageControl.getTargetValue() + valueShift / lfBus.getNominalV();
-                    voltageControl.setTargetValue(newTargetV);
+                    double nominalV = voltageControl.getControlledBus().getNominalV();
+                    double newTargetV = voltageControl.getTargetValue() + valueShift / nominalV;
+                    if (AbstractLfGenerator.checkTargetV(generator.getId(), newTargetV, nominalV, new LfNetworkParameters(), null)) { // FIXME
+                        voltageControl.setTargetValue(newTargetV);
+                    } else {
+                        context.getNetwork().getGeneratorById(generator.getId()).setGeneratorControlType(LfGenerator.GeneratorControlType.OFF);
+                        if (lfBus.getGenerators().stream().noneMatch(gen -> gen.getGeneratorControlType() == LfGenerator.GeneratorControlType.VOLTAGE)) {
+                            lfBus.setGeneratorVoltageControlEnabled(false);
+                        }
+
+                    }
+                    context.getNetwork().validate(LoadFlowModel.AC, null);
                     return true;
                 }
                 return false;

--- a/src/main/java/com/powsybl/openloadflow/NetworkCache.java
+++ b/src/main/java/com/powsybl/openloadflow/NetworkCache.java
@@ -137,14 +137,14 @@ public enum NetworkCache {
                     GeneratorVoltageControl voltageControl = lfBus.getGeneratorVoltageControl().orElseThrow();
                     double nominalV = voltageControl.getControlledBus().getNominalV();
                     double newTargetV = voltageControl.getTargetValue() + valueShift / nominalV;
-                    if (AbstractLfGenerator.checkTargetV(generator.getId(), newTargetV, nominalV, new LfNetworkParameters(), null)) { // FIXME
+                    LfNetworkParameters networkParameters = context.getParameters().getNetworkParameters();
+                    if (AbstractLfGenerator.checkTargetV(generator.getId(), newTargetV, nominalV, networkParameters, null)) {
                         voltageControl.setTargetValue(newTargetV);
                     } else {
                         context.getNetwork().getGeneratorById(generator.getId()).setGeneratorControlType(LfGenerator.GeneratorControlType.OFF);
                         if (lfBus.getGenerators().stream().noneMatch(gen -> gen.getGeneratorControlType() == LfGenerator.GeneratorControlType.VOLTAGE)) {
                             lfBus.setGeneratorVoltageControlEnabled(false);
                         }
-
                     }
                     context.getNetwork().validate(LoadFlowModel.AC, null);
                     return true;

--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
@@ -130,7 +130,7 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
         List<LoadFlowResult.ComponentResult> componentResults = new ArrayList<>(results.size());
         for (AcLoadFlowResult result : results) {
             // update network state
-            if (result.getNewtonRaphsonStatus() == NewtonRaphsonStatus.CONVERGED || parametersExt.isAlwaysUpdateNetwork()) {
+            if ((result.getNewtonRaphsonStatus() == NewtonRaphsonStatus.CONVERGED && result.getNewtonRaphsonIterations() > 0) || parametersExt.isAlwaysUpdateNetwork()) {
                 var updateParameters = new LfNetworkStateUpdateParameters(parameters.isUseReactiveLimits(),
                                                                           parameters.isWriteSlackBus(),
                                                                           parameters.isPhaseShifterRegulationOn(),

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -492,14 +492,17 @@ public class LfNetwork extends AbstractPropertyBag implements PropertyBag {
         if (loadFlowModel == LoadFlowModel.AC) {
             boolean hasAtLeastOneBusVoltageControlled = false;
             for (LfBus bus : busesByIndex) {
-                if (bus.isGeneratorVoltageControlled()) {
+                if (bus.isGeneratorVoltageControlled() &&
+                        bus.getGeneratorVoltageControl().get().getControllerElements().stream().anyMatch(LfBus::isGeneratorVoltageControlEnabled)) {
                     hasAtLeastOneBusVoltageControlled = true;
                     break;
                 }
             }
             if (!hasAtLeastOneBusVoltageControlled) {
                 LOGGER.error("Network {} must have at least one bus voltage controlled", this);
-                Reports.reportNetworkMustHaveAtLeastOneBusVoltageControlled(reporter);
+                if (reporter != null) {
+                    Reports.reportNetworkMustHaveAtLeastOneBusVoltageControlled(reporter);
+                }
                 valid = false;
             }
         }

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -490,18 +490,17 @@ public class LfNetwork extends AbstractPropertyBag implements PropertyBag {
 
     private void validateBuses(LoadFlowModel loadFlowModel, Reporter reporter) {
         if (loadFlowModel == LoadFlowModel.AC) {
-            boolean hasAtLeastOneBusVoltageControlled = false;
+            boolean hasAtLeastOneBusGeneratorVoltageControlEnabled = false;
             for (LfBus bus : busesByIndex) {
-                if (bus.isGeneratorVoltageControlled() &&
-                        bus.getGeneratorVoltageControl().orElseThrow().getControllerElements().stream().anyMatch(LfBus::isGeneratorVoltageControlEnabled)) {
-                    hasAtLeastOneBusVoltageControlled = true;
+                if (bus.isGeneratorVoltageControlEnabled()) {
+                    hasAtLeastOneBusGeneratorVoltageControlEnabled = true;
                     break;
                 }
             }
-            if (!hasAtLeastOneBusVoltageControlled) {
-                LOGGER.error("Network {} must have at least one bus voltage controlled", this);
+            if (!hasAtLeastOneBusGeneratorVoltageControlEnabled) {
+                LOGGER.error("Network {} must have at least one bus with generator voltage control enabled", this);
                 if (reporter != null) {
-                    Reports.reportNetworkMustHaveAtLeastOneBusVoltageControlled(reporter);
+                    Reports.reportNetworkMustHaveAtLeastOneBusGeneratorVoltageControlEnabled(reporter);
                 }
                 valid = false;
             }

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -493,7 +493,7 @@ public class LfNetwork extends AbstractPropertyBag implements PropertyBag {
             boolean hasAtLeastOneBusVoltageControlled = false;
             for (LfBus bus : busesByIndex) {
                 if (bus.isGeneratorVoltageControlled() &&
-                        bus.getGeneratorVoltageControl().get().getControllerElements().stream().anyMatch(LfBus::isGeneratorVoltageControlEnabled)) {
+                        bus.getGeneratorVoltageControl().orElseThrow().getControllerElements().stream().anyMatch(LfBus::isGeneratorVoltageControlEnabled)) {
                     hasAtLeastOneBusVoltageControlled = true;
                     break;
                 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
@@ -212,7 +212,7 @@ public abstract class AbstractLfGenerator extends AbstractPropertyBag implements
             LOGGER.warn("Regulating terminal of LfGenerator {} is not in the same synchronous component: voltage control discarded", getId());
             return;
         }
-        if (!checkTargetV(targetV / regulatingTerminal.getVoltageLevel().getNominalV(), regulatingTerminal.getVoltageLevel().getNominalV(), parameters, report)) {
+        if (!checkTargetV(getId(), targetV / regulatingTerminal.getVoltageLevel().getNominalV(), regulatingTerminal.getVoltageLevel().getNominalV(), parameters, report)) {
             return;
         }
         this.controlledBusId = controlledBus.getId();
@@ -262,13 +262,15 @@ public abstract class AbstractLfGenerator extends AbstractPropertyBag implements
         return consistency;
     }
 
-    protected boolean checkTargetV(double targetV, double nominalV, LfNetworkParameters parameters, LfNetworkLoadingReport report) {
+    public static boolean checkTargetV(String generatorId, double targetV, double nominalV, LfNetworkParameters parameters, LfNetworkLoadingReport report) {
         // check that targetV has a plausible value (wrong nominal voltage issue)
         if (nominalV > parameters.getMinNominalVoltageTargetVoltageCheck() &&
                 (targetV < parameters.getMinPlausibleTargetVoltage() || targetV > parameters.getMaxPlausibleTargetVoltage())) {
             LOGGER.trace("Generator '{}' has an inconsistent target voltage: {} pu: generator voltage control discarded",
-                getId(), targetV);
-            report.generatorsWithInconsistentTargetVoltage++;
+                generatorId, targetV);
+            if (report != null) {
+                report.generatorsWithInconsistentTargetVoltage++;
+            }
             return false;
         }
         return true;

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineGenerator.java
@@ -31,7 +31,7 @@ public final class LfDanglingLineGenerator extends AbstractLfGenerator {
         // local control only
         if (danglingLine.getGeneration().isVoltageRegulationOn() && checkVoltageControlConsistency(parameters, report)) {
             // The controlled bus cannot be reached from the DanglingLine parameters (there is no terminal in DanglingLine.Generation)
-            if (checkTargetV(danglingLine.getGeneration().getTargetV() / danglingLine.getTerminal().getVoltageLevel().getNominalV(),
+            if (checkTargetV(getId(), danglingLine.getGeneration().getTargetV() / danglingLine.getTerminal().getVoltageLevel().getNominalV(),
                     danglingLine.getTerminal().getVoltageLevel().getNominalV(), parameters, report)) {
                 this.controlledBusId = Objects.requireNonNull(controlledLfBusId);
                 this.targetV = danglingLine.getGeneration().getTargetV() / danglingLine.getTerminal().getVoltageLevel().getNominalV();

--- a/src/main/java/com/powsybl/openloadflow/util/Reports.java
+++ b/src/main/java/com/powsybl/openloadflow/util/Reports.java
@@ -47,10 +47,10 @@ public final class Reports {
                 .build());
     }
 
-    public static void reportNetworkMustHaveAtLeastOneBusVoltageControlled(Reporter reporter) {
+    public static void reportNetworkMustHaveAtLeastOneBusGeneratorVoltageControlEnabled(Reporter reporter) {
         reporter.report(Report.builder()
-                .withKey("networkMustHaveAtLeastOneBusVoltageControlled")
-                .withDefaultMessage("Network must have at least one bus voltage controlled")
+                .withKey("networkMustHaveAtLeastOneBusGeneratorVoltageControlEnabled")
+                .withDefaultMessage("Network must have at least one bus with generator voltage control enabled")
                 .build());
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
@@ -288,7 +288,7 @@ class AcLoadFlowEurostagTutorialExample1Test {
         ReporterModel postLoadingReporter = createNetworkReporter.getSubReporters().get(0);
         assertEquals("postLoadingProcessing", postLoadingReporter.getTaskKey());
         assertEquals(1, postLoadingReporter.getReports().size());
-        assertEquals("Network must have at least one bus voltage controlled",
+        assertEquals("Network must have at least one bus with generator voltage control enabled",
                 postLoadingReporter.getReports().iterator().next().getDefaultMessage());
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowWithCachingTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowWithCachingTest.java
@@ -345,4 +345,20 @@ class AcLoadFlowWithCachingTest {
         result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.FAILED, result.getComponentResults().get(0).getStatus());
     }
+
+    @Test
+    @Disabled
+    void testInitiallyInvalidNetwork() {
+        var network = EurostagFactory.fix(EurostagTutorialExample1Factory.create());
+        var gen = network.getGenerator("GEN");
+        gen.setTargetV(1000);
+        var result = loadFlowRunner.run(network, parameters);
+        assertEquals(LoadFlowResult.ComponentResult.Status.FAILED, result.getComponentResults().get(0).getStatus());
+
+        assertNotNull(NetworkCache.INSTANCE.findEntry(network).orElseThrow().getContexts());
+
+        gen.setTargetV(24);
+        result = loadFlowRunner.run(network, parameters);
+        assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowWithCachingTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowWithCachingTest.java
@@ -347,7 +347,7 @@ class AcLoadFlowWithCachingTest {
     }
 
     @Test
-    @Disabled
+    @Disabled("To support later")
     void testInitiallyInvalidNetwork() {
         var network = EurostagFactory.fix(EurostagTutorialExample1Factory.create());
         var gen = network.getGenerator("GEN");

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowWithCachingTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowWithCachingTest.java
@@ -74,8 +74,7 @@ class AcLoadFlowWithCachingTest {
 
         result = loadFlowRunner.run(network, parameters);
         assertEquals(1, NetworkCache.INSTANCE.getEntryCount());
-        // FIXME NO_CALCULATION should be added to API
-        assertEquals(LoadFlowResult.ComponentResult.Status.FAILED, result.getComponentResults().get(0).getStatus());
+        assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
         assertEquals(0, result.getComponentResults().get(0).getIterationCount());
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowWithCachingTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowWithCachingTest.java
@@ -336,9 +336,13 @@ class AcLoadFlowWithCachingTest {
     @Test
     void testInvalidNetwork() {
         var network = EurostagFactory.fix(EurostagTutorialExample1Factory.create());
+        var result = loadFlowRunner.run(network, parameters);
+
+        assertNotNull(NetworkCache.INSTANCE.findEntry(network).orElseThrow().getContexts());
+
         var gen = network.getGenerator("GEN");
         gen.setTargetV(1000);
-        var result = loadFlowRunner.run(network, parameters);
+        result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.FAILED, result.getComponentResults().get(0).getStatus());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowWithCachingTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowWithCachingTest.java
@@ -332,4 +332,13 @@ class AcLoadFlowWithCachingTest {
         assertActivePowerEquals(301.884, l1.getTerminal1());
         assertActivePowerEquals(301.884, l2.getTerminal1());
     }
+
+    @Test
+    void testInvalidNetwork() {
+        var network = EurostagFactory.fix(EurostagTutorialExample1Factory.create());
+        var gen = network.getGenerator("GEN");
+        gen.setTargetV(1000);
+        var result = loadFlowRunner.run(network, parameters);
+        assertEquals(LoadFlowResult.ComponentResult.Status.FAILED, result.getComponentResults().get(0).getStatus());
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
In fast restart mode, when re-running a LF without any network change we get a FAILED status. 


**What is the new behavior (if this is a feature change)?**
We get a CONVERGED status (in really this should be a ALREADY_CONVERGED)


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
