### PR TITLE
Clean indexed terms when removing an equation

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/equations/EquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationSystem.java
@@ -152,6 +152,14 @@ public class EquationSystem<V extends Enum<V> & Quantity, E extends Enum<E> & Qu
         if (equation != null) {
             Pair<ElementType, Integer> element = Pair.of(type.getElementType(), num);
             equationsByElement.get(element).remove(equation);
+            if (equationTermsByElement != null) {
+                for (EquationTerm<V, E> term : equation.getTerms()) {
+                    List<EquationTerm<V, E>> termsForThisElement = equationTermsByElement.get(Pair.of(term.getElementType(), term.getElementNum()));
+                    if (termsForThisElement != null) {
+                        termsForThisElement.remove(term);
+                    }
+                }
+            }
             notifyEquationChange(equation, EquationEventType.EQUATION_REMOVED);
         }
         return equation;

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationSystem.java
@@ -146,6 +146,18 @@ public class EquationSystem<V extends Enum<V> & Quantity, E extends Enum<E> & Qu
         return equations.containsKey(p);
     }
 
+    private void deindexTerm(EquationTerm<V, E> term) {
+        if (term.getElementType() != null && term.getElementNum() != -1) {
+            List<EquationTerm<V, E>> termsForThisElement = equationTermsByElement.get(Pair.of(term.getElementType(), term.getElementNum()));
+            if (termsForThisElement != null) {
+                termsForThisElement.remove(term);
+            }
+        }
+        for (EquationTerm<V, E> child : term.getChildren()) {
+            deindexTerm(child);
+        }
+    }
+
     public Equation<V, E> removeEquation(int num, E type) {
         Pair<Integer, E> p = Pair.of(num, type);
         Equation<V, E> equation = equations.remove(p);
@@ -154,10 +166,7 @@ public class EquationSystem<V extends Enum<V> & Quantity, E extends Enum<E> & Qu
             equationsByElement.get(element).remove(equation);
             if (equationTermsByElement != null) {
                 for (EquationTerm<V, E> term : equation.getTerms()) {
-                    List<EquationTerm<V, E>> termsForThisElement = equationTermsByElement.get(Pair.of(term.getElementType(), term.getElementNum()));
-                    if (termsForThisElement != null) {
-                        termsForThisElement.remove(term);
-                    }
+                    deindexTerm(term);
                 }
             }
             notifyEquationChange(equation, EquationEventType.EQUATION_REMOVED);

--- a/src/test/java/com/powsybl/openloadflow/equations/EquationSystemTest.java
+++ b/src/test/java/com/powsybl/openloadflow/equations/EquationSystemTest.java
@@ -274,9 +274,17 @@ class EquationSystemTest {
                 .create();
         assertEquals(13, equationSystem.getEquations().size());
         assertEquals(3, equationSystem.getEquations(ElementType.BUS, 1).size());
+        assertEquals(4, equationSystem.getEquationTerms(ElementType.BRANCH, 0).size());
+        assertEquals(4, equationSystem.getEquationTerms(ElementType.BRANCH, 1).size());
+        assertEquals(4, equationSystem.getEquationTerms(ElementType.BRANCH, 2).size());
+        assertEquals(4, equationSystem.getEquationTerms(ElementType.BRANCH, 3).size());
 
         equationSystem.removeEquation(1, AcEquationType.BUS_TARGET_P);
         assertEquals(12, equationSystem.getEquations().size());
         assertEquals(2, equationSystem.getEquations(ElementType.BUS, 1).size());
+        assertEquals(3, equationSystem.getEquationTerms(ElementType.BRANCH, 0).size());
+        assertEquals(3, equationSystem.getEquationTerms(ElementType.BRANCH, 1).size());
+        assertEquals(3, equationSystem.getEquationTerms(ElementType.BRANCH, 2).size());
+        assertEquals(4, equationSystem.getEquationTerms(ElementType.BRANCH, 3).size());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When an equation is removed, corresponding indexed terms are not cleaned. 


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
