### PR TITLE
Fix generators update after forcing a bus to remain PV

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -520,6 +520,10 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
             qToDispatch = dispatchQ(generatorsThatControlVoltage, reactiveLimits, qToDispatch);
         }
         if (!initialGeneratorsThatControlVoltage.isEmpty() && Math.abs(qToDispatch) > Q_DISPATCH_EPSILON) {
+            // FIXME
+            // We have to much reactive power to dispatch, which is linked to a bus that has been forced to remain PV to
+            // ease the convergence. Updating a generator reactive power outside its reactive limits is a quick fix.
+            // It could be better to return a global failed status.
             dispatchQ(initialGeneratorsThatControlVoltage, false, qToDispatch);
         }
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -491,9 +491,11 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     void updateGeneratorsState(double generationQ, boolean reactiveLimits) {
         double qToDispatch = generationQ;
         List<LfGenerator> generatorsThatControlVoltage = new LinkedList<>();
+        List<LfGenerator> initialGeneratorsThatControlVoltage = new LinkedList<>();
         for (LfGenerator generator : generators) {
             if (generator.getGeneratorControlType() == LfGenerator.GeneratorControlType.VOLTAGE) {
                 generatorsThatControlVoltage.add(generator);
+                initialGeneratorsThatControlVoltage.add(generator);
             } else {
                 qToDispatch -= generator.getTargetQ();
             }
@@ -504,6 +506,9 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
         }
         while (!generatorsThatControlVoltage.isEmpty() && Math.abs(qToDispatch) > Q_DISPATCH_EPSILON) {
             qToDispatch = dispatchQ(generatorsThatControlVoltage, reactiveLimits, qToDispatch);
+        }
+        if (!initialGeneratorsThatControlVoltage.isEmpty() && Math.abs(qToDispatch) > Q_DISPATCH_EPSILON) {
+            dispatchQ(initialGeneratorsThatControlVoltage, false, qToDispatch);
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -503,16 +503,14 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     void updateGeneratorsState(double generationQ, boolean reactiveLimits) {
         double qToDispatch = generationQ;
         List<LfGenerator> generatorsThatControlVoltage = new LinkedList<>();
-        List<LfGenerator> initialGeneratorsThatControlVoltage = new LinkedList<>();
         for (LfGenerator generator : generators) {
             if (generator.getGeneratorControlType() == LfGenerator.GeneratorControlType.VOLTAGE) {
                 generatorsThatControlVoltage.add(generator);
-                initialGeneratorsThatControlVoltage.add(generator);
             } else {
                 qToDispatch -= generator.getTargetQ();
             }
         }
-
+        List<LfGenerator> initialGeneratorsThatControlVoltage = new LinkedList<>(generatorsThatControlVoltage);
         for (LfGenerator generator : generatorsThatControlVoltage) {
             generator.setCalculatedQ(0);
         }

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
@@ -415,7 +415,7 @@ class AcLoadFlowEurostagTutorialExample1Test {
     @Test
     void testGeneratorReactiveLimits() {
         Network network = EurostagTutorialExample1Factory.create();
-        network.getGenerator("GEN").newMinMaxReactiveLimits().setMinQ(0).setMaxQ(120).add();
+        network.getGenerator("GEN").newMinMaxReactiveLimits().setMinQ(0).setMaxQ(150).add();
         network.getVoltageLevel("VLGEN").newGenerator().setId("GEN1")
                 .setBus("NGEN").setConnectableBus("NGEN")
                 .setMinP(-9999.99D).setMaxP(9999.99D)
@@ -432,8 +432,8 @@ class AcLoadFlowEurostagTutorialExample1Test {
                 assertTrue(-gen.getTerminal().getQ() >= ((MinMaxReactiveLimits) gen.getReactiveLimits()).getMinQ());
             }
         });
-        assertEquals(-120, network.getGenerator("GEN").getTerminal().getQ());
-        assertEquals(-160, network.getGenerator("GEN1").getTerminal().getQ(), 0.01);
+        assertEquals(-150, network.getGenerator("GEN").getTerminal().getQ(), 0.01);
+        assertEquals(-153.86, network.getGenerator("GEN1").getTerminal().getQ(), 0.01);
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/network/BoundaryFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/BoundaryFactory.java
@@ -388,4 +388,59 @@ public class BoundaryFactory extends AbstractLoadFlowNetworkFactory {
 
         return network;
     }
+
+    /**
+     *   b1 --- b2
+     *   |
+     *   g1
+     */
+    public static Network createWithoutLoads() {
+        Network network = Network.create("dl", "test");
+        Substation s1 = network.newSubstation()
+                .setId("S1")
+                .add();
+        Substation s2 = network.newSubstation()
+                .setId("S2")
+                .add();
+
+        VoltageLevel vl1 = s1.newVoltageLevel()
+                .setId("vl1")
+                .setNominalV(225)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl1.getBusBreakerView().newBus()
+                .setId("b1")
+                .add();
+        var g1 = vl1.newGenerator()
+                .setId("g1")
+                .setConnectableBus("b1")
+                .setBus("b1")
+                .setTargetP(1E-6)
+                .setTargetV(224.18)
+                .setMinP(0)
+                .setMaxP(245)
+                .setVoltageRegulatorOn(true)
+                .add();
+        g1.newMinMaxReactiveLimits().setMinQ(-80).setMaxQ(86).add();
+
+        VoltageLevel vl2 = s2.newVoltageLevel()
+                .setId("vl2")
+                .setNominalV(225)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl2.getBusBreakerView().newBus()
+                .setId("b2")
+                .add();
+        network.newLine()
+                .setId("l1")
+                .setBus1("b1")
+                .setBus2("b2")
+                .setR(1.316)
+                .setX(6.865)
+                .setB1(0.0017)
+                .setB2(0.0017)
+                .add();
+
+        return network;
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
With reactive limits enabled, bus Q balance may be non zero in the case of a bus forced to remain PV.



**What is the new behavior (if this is a feature change)?**
fixed bus Q balance


**Does this PR introduce a breaking change or deprecate an API?**
No


**Other information**:
Note that the solution produced would leave generators outside reactive limits. We may want to revise this strategy in another PR (e.g. make this behavior optional, or flag the component as non converged).
