### PR TITLE
Fix calculated load Q when distributed slack on loads with constant power factor

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLoadImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLoadImpl.java
@@ -99,8 +99,8 @@ class LfLoadImpl extends AbstractPropertyBag implements LfLoad {
         double newLoadTargetQ = 0;
         for (int i = 0; i < loadsRefs.size(); i++) {
             Load load = loadsRefs.get(i).get();
-            double updatedP0 = load.getP0() / PerUnit.SB + diffTargetP * getParticipationFactor(i);
-            newLoadTargetQ += getPowerFactor(load) * updatedP0;
+            double updatedQ0 = load.getQ0() / PerUnit.SB + getPowerFactor(load) * diffTargetP * getParticipationFactor(i);
+            newLoadTargetQ += updatedQ0;
         }
         return newLoadTargetQ;
     }

--- a/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnLoadTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnLoadTest.java
@@ -214,4 +214,27 @@ class DistributedSlackOnLoadTest {
         assertEquals(0.0, sumBus, 10E-6);
         assertPowerFactor(network);
     }
+
+    @Test
+    void testPowerFactorConstant3() {
+        Network network = DistributedSlackNetworkFactory.createNetworkWithLoads2();
+        parameters.setBalanceType(LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD);
+        parametersExt.setLoadPowerFactorConstant(true);
+        network.getLoad("l4").newExtension(LoadDetailAdder.class)
+                .withFixedActivePower(0)
+                .withFixedReactivePower(0)
+                .withVariableActivePower(0)
+                .withVariableReactivePower(50)
+                .add();
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        double sumBus = 0.0;
+        sumBus += network.getLine("l14").getTerminal2().getQ();
+        sumBus += network.getLine("l24").getTerminal2().getQ();
+        sumBus += network.getLine("l34").getTerminal2().getQ();
+        sumBus += network.getLoad("l4").getTerminal().getQ();
+        sumBus += network.getLoad("l5").getTerminal().getQ();
+        assertEquals(0.0, sumBus, 10E-6);
+        assertPowerFactor(network);
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnLoadTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnLoadTest.java
@@ -220,11 +220,22 @@ class DistributedSlackOnLoadTest {
         Network network = DistributedSlackNetworkFactory.createNetworkWithLoads2();
         parameters.setBalanceType(LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD);
         parametersExt.setLoadPowerFactorConstant(true);
-        network.getLoad("l4").newExtension(LoadDetailAdder.class)
+        network.getGenerator("g1").setTargetP(-208);
+        Load l4 = network.getLoad("l4");
+        l4.setP0(0.0).setQ0(-50);
+        l4.newExtension(LoadDetailAdder.class)
                 .withFixedActivePower(0)
                 .withFixedReactivePower(0)
                 .withVariableActivePower(0)
-                .withVariableReactivePower(50)
+                .withVariableReactivePower(-50)
+                .add();
+        Load l5 = network.getLoad("l5");
+        l5.setP0(-10.0).setQ0(0.0);
+        l5.newExtension(LoadDetailAdder.class)
+                .withFixedActivePower(-10)
+                .withFixedReactivePower(0)
+                .withVariableActivePower(0)
+                .withVariableReactivePower(0.0)
                 .add();
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isOk());
@@ -234,7 +245,7 @@ class DistributedSlackOnLoadTest {
         sumBus += network.getLine("l34").getTerminal2().getQ();
         sumBus += network.getLoad("l4").getTerminal().getQ();
         sumBus += network.getLoad("l5").getTerminal().getQ();
-        assertEquals(0.0, sumBus, 10E-6);
+        assertEquals(0.0, sumBus, 10E-3);
         assertPowerFactor(network);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fix constant power factor when distributing slack on loads


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Slack is not correctly distributed on some types of loads, when only the variableReactivePower is not 0.


**What is the new behavior (if this is a feature change)?**
Slack will always be correctly distributed


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
