### PR TITLE
Fix dcUseTransformerRatio not taken into account in DC sensi

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
@@ -44,12 +44,16 @@ public abstract class AbstractClosedBranchDcFlowEquationTerm extends AbstractEle
         ph1Var = variableSet.getVariable(bus1.getNum(), DcVariableType.BUS_PHI);
         ph2Var = variableSet.getVariable(bus2.getNum(), DcVariableType.BUS_PHI);
         a1Var = deriveA1 ? variableSet.getVariable(branch.getNum(), DcVariableType.BRANCH_ALPHA1) : null;
-        power = 1 / piModel.getX() * (useTransformerRatio ? piModel.getR1() * R2 : 1);
+        power = calculatePower(useTransformerRatio, piModel);
         if (a1Var != null) {
             variables = List.of(ph1Var, ph2Var, a1Var);
         } else {
             variables = List.of(ph1Var, ph2Var);
         }
+    }
+
+    public static double calculatePower(boolean useTransformerRatio, PiModel piModel) {
+        return 1d / piModel.getX() * (useTransformerRatio ? piModel.getR1() * R2 : 1);
     }
 
     public Variable<DcVariableType> getPh1Var() {

--- a/src/test/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysisTest.java
@@ -15,6 +15,7 @@ import com.powsybl.contingency.Contingency;
 import com.powsybl.contingency.ContingencyContext;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.loadflow.LoadFlow;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.LoadFlowResult;
 import com.powsybl.math.matrix.DenseMatrixFactory;
@@ -45,6 +46,10 @@ public abstract class AbstractSensitivityAnalysisTest extends AbstractConverterT
     protected final OpenSensitivityAnalysisProvider sensiProvider = new OpenSensitivityAnalysisProvider(matrixFactory);
 
     protected final SensitivityAnalysis.Runner sensiRunner = new SensitivityAnalysis.Runner(sensiProvider);
+
+    protected final OpenLoadFlowProvider loadFlowProvider = new OpenLoadFlowProvider(matrixFactory);
+
+    protected final LoadFlow.Runner runner = new LoadFlow.Runner(loadFlowProvider);
 
     protected static SensitivityAnalysisParameters createParameters(boolean dc, String slackBusId, boolean distributedSlack) {
         return createParameters(dc, List.of(slackBusId), distributedSlack);

--- a/src/test/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysisContingenciesTest.java
@@ -2266,18 +2266,11 @@ class DcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
 
     @Test
     void testDcUseTransformerRatioIssue() {
-        SensitivityAnalysisResult result = testDcUseTransformerRatioIssue(false);
-        assertEquals(-0.002712, result.getBranchFlow1SensitivityValue("B1-G", "L10-11-1", SensitivityVariableType.INJECTION_ACTIVE_POWER), 1E-6d);
-        assertEquals(-0.002333, result.getBranchFlow1SensitivityValue("T4-9-1", "B1-G", "L10-11-1", SensitivityVariableType.INJECTION_ACTIVE_POWER), 1E-6d);
-        assertEquals(0d, result.getBranchFlow1SensitivityValue("T5-6-1", "B1-G", "L10-11-1", SensitivityVariableType.INJECTION_ACTIVE_POWER), 1E-6d);
-
-        result = testDcUseTransformerRatioIssue(true);
-        assertEquals(-0.002815, result.getBranchFlow1SensitivityValue("B1-G", "L10-11-1", SensitivityVariableType.INJECTION_ACTIVE_POWER), 1E-6d);
-        assertEquals(-0.00244, result.getBranchFlow1SensitivityValue("T4-9-1", "B1-G", "L10-11-1", SensitivityVariableType.INJECTION_ACTIVE_POWER), 1E-6d);
-        assertEquals(0d, result.getBranchFlow1SensitivityValue("T5-6-1", "B1-G", "L10-11-1", SensitivityVariableType.INJECTION_ACTIVE_POWER), 1E-6d);
+        testDcUseTransformerRatioIssue(false);
+        testDcUseTransformerRatioIssue(true);
     }
 
-    private SensitivityAnalysisResult testDcUseTransformerRatioIssue(boolean dcUseTransformerRatio) {
+    private void testDcUseTransformerRatioIssue(boolean dcUseTransformerRatio) {
         Network network = IeeeCdfNetworkFactory.create14();
         var ps56 = network.getTwoWindingsTransformer("T5-6-1");
         ps56.newPhaseTapChanger()
@@ -2306,11 +2299,12 @@ class DcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
                 .endStep()
                 .add();
         Line l1011 = network.getLine("L10-11-1");
+        Generator g1 = network.getGenerator("B1-G");
         List<SensitivityFactor> factors = List.of(new SensitivityFactor(
                 SensitivityFunctionType.BRANCH_ACTIVE_POWER_1,
                 l1011.getId(),
                 SensitivityVariableType.INJECTION_ACTIVE_POWER,
-                "B1-G",
+                g1.getId(),
                 false,
                 ContingencyContext.all()));
         Contingency cont49And56 = new Contingency(ps49.getId() + " " + ps56.getId(), new BranchContingency(ps49.getId()), new BranchContingency(ps56.getId()));
@@ -2324,31 +2318,54 @@ class DcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
                 .setDcUseTransformerRatio(dcUseTransformerRatio)
                 .setDistributedSlack(false);
         SensitivityAnalysisResult result = sensiRunner.run(network, factors, contingencies, Collections.emptyList(), sensiParameters);
-        double l45p1 = result.getBranchFlow1FunctionReferenceValue(l1011.getId());
-        double l45p1ContPs49 = result.getBranchFlow1FunctionReferenceValue(ps49.getId(), l1011.getId());
-        double l45p1ContPs56 = result.getBranchFlow1FunctionReferenceValue(ps56.getId(), l1011.getId());
-        double l45p1ContPs49And56 = result.getBranchFlow1FunctionReferenceValue(cont49And56.getId(), l1011.getId());
+        double l1011p1 = result.getBranchFlow1FunctionReferenceValue(l1011.getId());
+        double l1011p1ContPs49 = result.getBranchFlow1FunctionReferenceValue(ps49.getId(), l1011.getId());
+        double l1011p1ContPs56 = result.getBranchFlow1FunctionReferenceValue(ps56.getId(), l1011.getId());
+        double l1011p1ContPs49And56 = result.getBranchFlow1FunctionReferenceValue(cont49And56.getId(), l1011.getId());
 
         runner.run(network, sensiParameters.getLoadFlowParameters());
-        assertActivePowerEquals(l45p1, l1011.getTerminal1());
+        assertActivePowerEquals(l1011p1, l1011.getTerminal1());
+
+        double epsSensiCompLf = 1E-13;
+        assertEquals(calculateSensiFromLf(network, g1, l1011, sensiParameters.getLoadFlowParameters()),
+                     result.getBranchFlow1SensitivityValue(g1.getId(), l1011.getId(), SensitivityVariableType.INJECTION_ACTIVE_POWER),
+                     epsSensiCompLf);
 
         ps49.getTerminal1().disconnect();
         ps49.getTerminal2().disconnect();
         runner.run(network, sensiParameters.getLoadFlowParameters());
-        assertActivePowerEquals(l45p1ContPs49, l1011.getTerminal1());
+        assertActivePowerEquals(l1011p1ContPs49, l1011.getTerminal1());
+
+        assertEquals(calculateSensiFromLf(network, g1, l1011, sensiParameters.getLoadFlowParameters()),
+                     result.getBranchFlow1SensitivityValue(ps49.getId(), g1.getId(), l1011.getId(), SensitivityVariableType.INJECTION_ACTIVE_POWER),
+                     epsSensiCompLf);
 
         ps49.getTerminal1().connect();
         ps49.getTerminal2().connect();
         ps56.getTerminal1().disconnect();
         ps56.getTerminal2().disconnect();
         runner.run(network, sensiParameters.getLoadFlowParameters());
-        assertActivePowerEquals(l45p1ContPs56, l1011.getTerminal1());
+        assertActivePowerEquals(l1011p1ContPs56, l1011.getTerminal1());
+
+        assertEquals(calculateSensiFromLf(network, g1, l1011, sensiParameters.getLoadFlowParameters()),
+                     result.getBranchFlow1SensitivityValue(ps56.getId(), g1.getId(), l1011.getId(), SensitivityVariableType.INJECTION_ACTIVE_POWER),
+                     epsSensiCompLf);
 
         ps49.getTerminal1().disconnect();
         ps49.getTerminal2().disconnect();
         runner.run(network, sensiParameters.getLoadFlowParameters());
-        assertActivePowerEquals(l45p1ContPs49And56, l1011.getTerminal1());
+        assertActivePowerEquals(l1011p1ContPs49And56, l1011.getTerminal1());
 
-        return result;
+        assertEquals(calculateSensiFromLf(network, g1, l1011, sensiParameters.getLoadFlowParameters()),
+                     result.getBranchFlow1SensitivityValue(cont49And56.getId(), g1.getId(), l1011.getId(), SensitivityVariableType.INJECTION_ACTIVE_POWER),
+                     epsSensiCompLf);
+    }
+
+    private double calculateSensiFromLf(Network network, Generator g, Line l, LoadFlowParameters parameters) {
+        double p1Before = l.getTerminal1().getP();
+        g.setTargetP(g.getTargetP() + 1);
+        runner.run(network, parameters);
+        g.setTargetP(g.getTargetP() - 1);
+        return l.getTerminal1().getP() - p1Before;
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sensi/dc/DcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/dc/DcSensitivityAnalysisContingenciesTest.java
@@ -2308,10 +2308,11 @@ class DcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
                 "B1-G",
                 false,
                 ContingencyContext.all()));
+        Contingency cont49And56 = new Contingency(ps49.getId() + " " + ps56.getId(), new BranchContingency(ps49.getId()), new BranchContingency(ps56.getId()));
         List<Contingency> contingencies = List.of(
                 Contingency.twoWindingsTransformer(ps49.getId()),
-                Contingency.twoWindingsTransformer(ps56.getId())
-        );
+                Contingency.twoWindingsTransformer(ps56.getId()),
+                cont49And56);
         SensitivityAnalysisParameters sensiParameters = createParameters(true, "VL1_0");
         sensiParameters.getLoadFlowParameters()
                 .setDcUseTransformerRatio(dcUseTransformerRatio)
@@ -2320,6 +2321,7 @@ class DcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
         double l45p1 = result.getBranchFlow1FunctionReferenceValue(l45.getId());
         double l45p1ContPs49 = result.getBranchFlow1FunctionReferenceValue(ps49.getId(), l45.getId());
         double l45p1ContPs56 = result.getBranchFlow1FunctionReferenceValue(ps56.getId(), l45.getId());
+        double l45p1ContPs49And56 = result.getBranchFlow1FunctionReferenceValue(cont49And56.getId(), l45.getId());
 
         runner.run(network, sensiParameters.getLoadFlowParameters());
         assertActivePowerEquals(l45p1, l45.getTerminal1());
@@ -2335,5 +2337,10 @@ class DcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
         ps56.getTerminal2().disconnect();
         runner.run(network, sensiParameters.getLoadFlowParameters());
         assertActivePowerEquals(l45p1ContPs56, l45.getTerminal1());
+
+        ps49.getTerminal1().disconnect();
+        ps49.getTerminal2().disconnect();
+        runner.run(network, sensiParameters.getLoadFlowParameters());
+        assertActivePowerEquals(l45p1ContPs49And56, l45.getTerminal1());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When dcUseTransformerRatio option is to true, the post contingency reference flows are not consistent with the one calculated from a DC LF. This ratio seems not to have been taken into account in the alpha calculation that allow us to calculate post contingence reference flow from pre contingency reference flow.


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
