### PR TITLE
Fix small reference flow values instead of strict zero

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -55,7 +55,7 @@ import static com.powsybl.openloadflow.network.util.ParticipatingElement.normali
 public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariableType, DcEquationType> {
 
     private static final double CONNECTIVITY_LOSS_THRESHOLD = 10e-7;
-    private static final double REFERENCE_FUNCTION_ZER0_THRESHOLD = 1e-13;
+    private static final double FUNCTION_REFERENCE_ZER0_THRESHOLD = 1e-13;
 
     static final class ComputedContingencyElement {
 
@@ -333,7 +333,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
             }
         }
 
-        functionValue = fixZeroReferenceFunction(contingency, functionValue);
+        functionValue = fixZeroFunctionReference(contingency, functionValue);
 
         double unscaledSensi = unscaleSensitivity(factor, sensitivityValue);
         if (!filterSensitivityValue(unscaledSensi, factor.getVariableType(), factor.getFunctionType(), parameters)) {
@@ -345,9 +345,9 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
      * Post contingency reference flow, that should be strictly zero, for numeric reason and because it is computed
      * from shifting pre-contingency non-zero flow, cannot end up to a strict zero: very small values are converted to zero.
      */
-    private static double fixZeroReferenceFunction(PropagatedContingency contingency, double functionValue) {
+    private static double fixZeroFunctionReference(PropagatedContingency contingency, double functionValue) {
         if (contingency != null) {
-            return Math.abs(functionValue) < REFERENCE_FUNCTION_ZER0_THRESHOLD ? 0 : functionValue;
+            return Math.abs(functionValue) < FUNCTION_REFERENCE_ZER0_THRESHOLD ? 0 : functionValue;
         }
         return functionValue;
     }

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -55,7 +55,7 @@ import static com.powsybl.openloadflow.network.util.ParticipatingElement.normali
 public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariableType, DcEquationType> {
 
     private static final double CONNECTIVITY_LOSS_THRESHOLD = 10e-7;
-    private static final double REFERENCE_FLOW_ZER0_THRESHOLD = 1e-13;
+    private static final double REFERENCE_FUNCTION_ZER0_THRESHOLD = 1e-13;
 
     static final class ComputedContingencyElement {
 
@@ -333,7 +333,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
             }
         }
 
-        functionValue = fixZeroReferenceFlow(contingency, functionValue);
+        functionValue = fixZeroReferenceFunction(contingency, functionValue);
 
         double unscaledSensi = unscaleSensitivity(factor, sensitivityValue);
         if (!filterSensitivityValue(unscaledSensi, factor.getVariableType(), factor.getFunctionType(), parameters)) {
@@ -343,12 +343,11 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
 
     /**
      * Post contingency reference flow, that should be strictly zero, for numeric reason and because it is computed
-     * from shifting pre-contingency non zero flow, we cannot end up to a strict zero: so we convert to zero very
-     * small values.
+     * from shifting pre-contingency non-zero flow, cannot end up to a strict zero: very small values are converted to zero.
      */
-    private static double fixZeroReferenceFlow(PropagatedContingency contingency, double functionValue) {
+    private static double fixZeroReferenceFunction(PropagatedContingency contingency, double functionValue) {
         if (contingency != null) {
-            return Math.abs(functionValue) < REFERENCE_FLOW_ZER0_THRESHOLD ? 0 : functionValue;
+            return Math.abs(functionValue) < REFERENCE_FUNCTION_ZER0_THRESHOLD ? 0 : functionValue;
         }
         return functionValue;
     }

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -57,6 +57,7 @@ import static com.powsybl.openloadflow.network.util.ParticipatingElement.normali
 public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariableType, DcEquationType> {
 
     private static final double CONNECTIVITY_LOSS_THRESHOLD = 10e-7;
+    private static final double REFERENCE_FLOW_ZER0_THRESHOLD = 1e-13;
 
     private static final class ComputedContingencyElement {
 
@@ -288,10 +289,24 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
             }
         }
 
+        functionValue = fixZeroReferenceFlow(contingency, functionValue);
+
         double unscaledSensi = unscaleSensitivity(factor, sensitivityValue);
         if (!filterSensitivityValue(unscaledSensi, factor.getVariableType(), factor.getFunctionType(), parameters)) {
             resultWriter.writeSensitivityValue(factor.getIndex(), contingency != null ? contingency.getIndex() : -1, unscaledSensi, unscaleFunction(factor, functionValue));
         }
+    }
+
+    /**
+     * Post contingency reference flow, that should be strictly zero, for numeric reason and because it is computed
+     * from shifting pre-contingency non zero flow, we cannot end up to a strict zero: so we convert to zero very
+     * small values.
+     */
+    private static double fixZeroReferenceFlow(PropagatedContingency contingency, double functionValue) {
+        if (contingency != null) {
+            return Math.abs(functionValue) < REFERENCE_FLOW_ZER0_THRESHOLD ? 0 : functionValue;
+        }
+        return functionValue;
     }
 
     /**

--- a/src/test/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysisContingenciesTest.java
@@ -2328,7 +2328,6 @@ class DcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
         SensitivityAnalysisResult result = sensiRunner.run(network, factors, contingencies, Collections.emptyList(), sensiParameters);
 
         assertEquals(303.5d, result.getBranchFlow1FunctionReferenceValue("NHV1_NHV2_1_2"), LoadFlowAssert.DELTA_POWER);
-        // FIXME strict zero would be expected
-        assertEquals(1.7763568394002505E-13, result.getBranchFlow1FunctionReferenceValue("NHV1_NHV2_1_1", "NHV1_NHV2_1_2"), 0d);
+        assertEquals(0, result.getBranchFlow1FunctionReferenceValue("NHV1_NHV2_1_1", "NHV1_NHV2_1_2"), 0d); // strict zero and not anymore a small value
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysisContingenciesTest.java
@@ -14,6 +14,7 @@ import com.powsybl.contingency.*;
 import com.powsybl.ieeecdf.converter.IeeeCdfNetworkFactory;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.HvdcAngleDroopActivePowerControlAdder;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.PhaseShifterTestCaseFactory;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.openloadflow.OpenLoadFlowParameters;
@@ -2261,5 +2262,64 @@ class DcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
         SensitivityAnalysisResult result = sensiRunner.run(network, factors, contingencies, Collections.emptyList(), sensiParameters);
         assertEquals(0, result.getBranchFlow1SensitivityValue("l23", "l23", "l12", SensitivityVariableType.TRANSFORMER_PHASE), LoadFlowAssert.DELTA_POWER);
         assertEquals(Double.NaN, result.getBranchFlow1SensitivityValue("l23", "l23", "l23", SensitivityVariableType.TRANSFORMER_PHASE), LoadFlowAssert.DELTA_POWER);
+    }
+
+    @Test
+    void testOneOfTwoSerialLinesContingency() {
+        Network network = EurostagTutorialExample1Factory.create();
+        network.getLine("NHV1_NHV2_1").remove();
+        Substation p3 = network.newSubstation()
+                .setId("P3")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vlhv3 = p3.newVoltageLevel()
+                .setId("VLHV3")
+                .setNominalV(380)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vlhv3.getBusBreakerView().newBus()
+                .setId("NHV3")
+                .add();
+        network.newLine()
+                .setId("NHV1_NHV2_1_1")
+                .setVoltageLevel1("VLHV1")
+                .setBus1("NHV1")
+                .setVoltageLevel2("VLHV3")
+                .setBus2("NHV3")
+                .setR(3.0 / 2)
+                .setX(33.0 / 2)
+                .setB1(386E-6 / 4)
+                .setB2(386E-6 / 3)
+                .add();
+        network.newLine()
+                .setId("NHV1_NHV2_1_2")
+                .setVoltageLevel1("VLHV3")
+                .setBus1("NHV3")
+                .setVoltageLevel2("VLHV2")
+                .setBus2("NHV2")
+                .setR(3.0 / 2)
+                .setX(33.0 / 2)
+                .setB1(386E-6 / 4)
+                .setB2(386E-6 / 3)
+                .add();
+
+        SensitivityAnalysisParameters sensiParameters = createParameters(true, "VLLOAD_0");
+
+        List<SensitivityFactor> factors = List.of(new SensitivityFactor(
+                SensitivityFunctionType.BRANCH_ACTIVE_POWER_1,
+                "NHV1_NHV2_1_2",
+                SensitivityVariableType.INJECTION_ACTIVE_POWER,
+                "GEN",
+                false,
+                ContingencyContext.all())
+        );
+
+        List<Contingency> contingencies = List.of(Contingency.line("NHV1_NHV2_1_1"));
+
+        SensitivityAnalysisResult result = sensiRunner.run(network, factors, contingencies, Collections.emptyList(), sensiParameters);
+
+        assertEquals(303.5d, result.getBranchFlow1FunctionReferenceValue("NHV1_NHV2_1_2"), LoadFlowAssert.DELTA_POWER);
+        // FIXME strict zero would be expected
+        assertEquals(1.7763568394002505E-13, result.getBranchFlow1FunctionReferenceValue("NHV1_NHV2_1_1", "NHV1_NHV2_1_2"), 0d);
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysisContingenciesTest.java
@@ -2264,6 +2264,15 @@ class DcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
         assertEquals(Double.NaN, result.getBranchFlow1SensitivityValue("l23", "l23", "l23", SensitivityVariableType.TRANSFORMER_PHASE), LoadFlowAssert.DELTA_POWER);
     }
 
+    /**
+     *                      NHV1_NHV1
+     *              --------------------------
+     *             /                          \
+     * NGEN --- NHV1                           NHV2 --- NLOAD
+     *            \                            /
+     *             ----------- NHV3 -----------
+     *             NHV1_NHV2_1      NHV1_NHV2_2
+     */
     @Test
     void testOneOfTwoSerialLinesContingency() {
         Network network = EurostagTutorialExample1Factory.create();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When computing the post contingency reference flow of a line which is in series with another line which is itself the contingency, we would expected to post contingency active power flow to be zero. Instead we have a very small value. 


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
