### PR TITLE
Improve performance of reference flow calculation in a DC sensi analysis

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
@@ -11,10 +11,12 @@ import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.math.matrix.MatrixException;
 import com.powsybl.openloadflow.dc.equations.DcEquationType;
 import com.powsybl.openloadflow.dc.equations.DcVariableType;
-import com.powsybl.openloadflow.equations.*;
+import com.powsybl.openloadflow.equations.EquationSystem;
+import com.powsybl.openloadflow.equations.JacobianMatrix;
+import com.powsybl.openloadflow.equations.TargetVector;
+import com.powsybl.openloadflow.equations.Variable;
 import com.powsybl.openloadflow.lf.LoadFlowEngine;
 import com.powsybl.openloadflow.lf.outerloop.OuterLoopStatus;
-import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.network.LfNetwork;
 import com.powsybl.openloadflow.network.LfNetworkLoader;
@@ -22,11 +24,12 @@ import com.powsybl.openloadflow.network.util.ActivePowerDistribution;
 import com.powsybl.openloadflow.network.util.UniformValueVoltageInitializer;
 import com.powsybl.openloadflow.network.util.VoltageInitializer;
 import com.powsybl.openloadflow.util.Reports;
-import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -47,7 +50,7 @@ public class DcLoadFlowEngine implements LoadFlowEngine<DcVariableType, DcEquati
         return context;
     }
 
-    private static void distributeSlack(Collection<LfBus> buses, LoadFlowParameters.BalanceType balanceType) {
+    public static void distributeSlack(Collection<LfBus> buses, LoadFlowParameters.BalanceType balanceType) {
         double mismatch = getActivePowerMismatch(buses);
         ActivePowerDistribution activePowerDistribution = ActivePowerDistribution.create(balanceType, false);
         activePowerDistribution.run(buses, mismatch);
@@ -144,14 +147,22 @@ public class DcLoadFlowEngine implements LoadFlowEngine<DcVariableType, DcEquati
         return succeeded;
     }
 
-    public DcLoadFlowResult run() {
-        boolean succeeded = run(Collections.emptyList(), Collections.emptyList(), context.getNetwork().getReporter()).getLeft();
-        return new DcLoadFlowResult(context.getNetwork(), getActivePowerMismatch(context.getNetwork().getBuses()), succeeded);
+    public static boolean solve(double[] targetVectorArray,
+                                JacobianMatrix<DcVariableType, DcEquationType> jacobianMatrix,
+                                Reporter reporter) {
+        try {
+            jacobianMatrix.solveTransposed(targetVectorArray);
+            return true;
+        } catch (MatrixException e) {
+            Reports.reportDcLfSolverFailure(reporter, e.getMessage());
+            LOGGER.error("Failed to solve linear system for DC load flow", e);
+            return false;
+        }
     }
 
-    public Pair<Boolean, double[]> run(Collection<LfBus> disabledBuses, Collection<LfBranch> disabledBranches,
-                                       Reporter reporter) {
+    public DcLoadFlowResult run() {
         LfNetwork network = context.getNetwork();
+        Reporter reporter = network.getReporter();
         EquationSystem<DcVariableType, DcEquationType> equationSystem = context.getEquationSystem();
         DcLoadFlowParameters parameters = context.getParameters();
         TargetVector<DcVariableType, DcEquationType> targetVector = context.getTargetVector();
@@ -165,47 +176,17 @@ public class DcLoadFlowEngine implements LoadFlowEngine<DcVariableType, DcEquati
 
         initStateVector(network, equationSystem, new UniformValueVoltageInitializer());
 
-        Collection<LfBus> remainingBuses = new LinkedHashSet<>(network.getBuses());
-        remainingBuses.removeAll(disabledBuses);
-
         if (parameters.isDistributedSlack()) {
-            distributeSlack(remainingBuses, parameters.getBalanceType());
+            distributeSlack(network.getBuses(), parameters.getBalanceType());
         }
 
-        // we need to copy the target array because:
-        //  - in case of disabled buses or branches some elements could be overwriten to zero
-        //  - JacobianMatrix.solveTransposed take as an input the second member and reuse the array
-        //    to fill with the solution
+        // we need to copy the target array because JacobianMatrix.solveTransposed take as an input the second member
+        // and reuse the array to fill with the solution
         // so we need to copy to later the target as it is and reusable for next run
         var targetVectorArray = targetVector.getArray().clone();
 
-        if (!disabledBuses.isEmpty()) {
-            // set buses injections and transformers to 0
-            disabledBuses.stream()
-                .flatMap(lfBus -> equationSystem.getEquation(lfBus.getNum(), DcEquationType.BUS_TARGET_P).stream())
-                .map(Equation::getColumn)
-                .forEach(column -> targetVectorArray[column] = 0);
-        }
-
-        if (!disabledBranches.isEmpty()) {
-            // set transformer phase shift to 0
-            disabledBranches.stream()
-                .flatMap(lfBranch -> equationSystem.getEquation(lfBranch.getNum(), DcEquationType.BRANCH_TARGET_ALPHA1).stream())
-                .map(Equation::getColumn)
-                .forEach(column -> targetVectorArray[column] = 0);
-        }
-
         // First linear system solution
-        boolean succeeded;
-        try {
-            context.getJacobianMatrix().solveTransposed(targetVectorArray);
-            succeeded = true;
-        } catch (MatrixException e) {
-            succeeded = false;
-
-            Reports.reportDcLfSolverFailure(reporter, e.getMessage());
-            LOGGER.error("Failed to solve linear system for DC load flow", e);
-        }
+        boolean succeeded = solve(targetVectorArray, context.getJacobianMatrix(), reporter);
 
         equationSystem.getStateVector().set(targetVectorArray);
         updateNetwork(network, equationSystem, targetVectorArray);
@@ -225,7 +206,7 @@ public class DcLoadFlowEngine implements LoadFlowEngine<DcVariableType, DcEquati
         Reports.reportDcLfComplete(reporter, succeeded);
         LOGGER.info("DC load flow completed (succeed={})", succeeded);
 
-        return Pair.of(succeeded, targetVectorArray);
+        return new DcLoadFlowResult(context.getNetwork(), getActivePowerMismatch(context.getNetwork().getBuses()), succeeded);
     }
 
     public static <T> List<DcLoadFlowResult> run(T network, LfNetworkLoader<T> networkLoader, DcLoadFlowParameters parameters, Reporter reporter) {

--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
@@ -109,7 +109,7 @@ public class DcLoadFlowEngine implements LoadFlowEngine<DcVariableType, DcEquati
         }
     }
 
-    private boolean runPhaseShifterOuterLoop(DcIncrementalPhaseControlOuterLoop outerLoop, DcOuterLoopContext outerLoopContext) {
+    private boolean runPhaseControlOuterLoop(DcIncrementalPhaseControlOuterLoop outerLoop, DcOuterLoopContext outerLoopContext) {
         Reporter olReporter = Reports.createOuterLoopReporter(outerLoopContext.getNetwork().getReporter(), outerLoop.getType());
         OuterLoopStatus outerLoopStatus;
         int outerLoopIteration = 0;
@@ -189,7 +189,7 @@ public class DcLoadFlowEngine implements LoadFlowEngine<DcVariableType, DcEquati
 
         // continue with PST active power control outer loop only if first linear system solution has succeeded
         if (succeeded && parameters.getNetworkParameters().isPhaseControl()) {
-            succeeded = runPhaseShifterOuterLoop(phaseShifterControlOuterLoop, outerLoopContext);
+            succeeded = runPhaseControlOuterLoop(phaseShifterControlOuterLoop, outerLoopContext);
         }
 
         // set all calculated voltages to NaN

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
@@ -88,6 +88,16 @@ public abstract class AbstractClosedBranchDcFlowEquationTerm extends AbstractEle
 
     protected abstract double calculateSensi(double ph1, double ph2, double a1);
 
+    @Override
+    public double eval() {
+        return calculateSensi(ph1(), ph2(), a1());
+    }
+
+    @Override
+    public double eval(StateVector sv) {
+        return calculateSensi(ph1(sv), ph2(sv), a1(sv));
+    }
+
     protected double a1(StateVector sv) {
         return a1Var != null ? sv.get(a1Var.getRow()) : element.getPiModel().getA1();
     }

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
@@ -8,6 +8,7 @@ package com.powsybl.openloadflow.dc.equations;
 
 import com.powsybl.math.matrix.DenseMatrix;
 import com.powsybl.openloadflow.equations.AbstractElementEquationTerm;
+import com.powsybl.openloadflow.equations.StateVector;
 import com.powsybl.openloadflow.equations.Variable;
 import com.powsybl.openloadflow.equations.VariableSet;
 import com.powsybl.openloadflow.network.LfBranch;
@@ -69,18 +70,30 @@ public abstract class AbstractClosedBranchDcFlowEquationTerm extends AbstractEle
         return calculateSensi(dph1, dph2, da1);
     }
 
-    protected double ph1() {
+    protected double ph1(StateVector sv) {
         return sv.get(ph1Var.getRow());
     }
 
-    protected double ph2() {
+    protected double ph1() {
+        return ph1(sv);
+    }
+
+    protected double ph2(StateVector sv) {
         return sv.get(ph2Var.getRow());
+    }
+
+    protected double ph2() {
+        return ph2(sv);
     }
 
     protected abstract double calculateSensi(double ph1, double ph2, double a1);
 
-    protected double a1() {
+    protected double a1(StateVector sv) {
         return a1Var != null ? sv.get(a1Var.getRow()) : element.getPiModel().getA1();
+    }
+
+    protected double a1() {
+        return a1(sv);
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide1DcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide1DcFlowEquationTerm.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.openloadflow.dc.equations;
 
-import com.powsybl.openloadflow.equations.StateVector;
 import com.powsybl.openloadflow.equations.Variable;
 import com.powsybl.openloadflow.equations.VariableSet;
 import com.powsybl.openloadflow.network.LfBranch;
@@ -38,16 +37,6 @@ public final class ClosedBranchSide1DcFlowEquationTerm extends AbstractClosedBra
     protected double calculateSensi(double ph1, double ph2, double a1) {
         double deltaPhase = ph2 - ph1 + A2 - a1;
         return -power * deltaPhase;
-    }
-
-    @Override
-    public double eval() {
-        return calculateSensi(ph1(), ph2(), a1());
-    }
-
-    @Override
-    public double eval(StateVector sv) {
-        return calculateSensi(ph1(sv), ph2(sv), a1(sv));
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide1DcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide1DcFlowEquationTerm.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.openloadflow.dc.equations;
 
+import com.powsybl.openloadflow.equations.StateVector;
 import com.powsybl.openloadflow.equations.Variable;
 import com.powsybl.openloadflow.equations.VariableSet;
 import com.powsybl.openloadflow.network.LfBranch;
@@ -42,6 +43,11 @@ public final class ClosedBranchSide1DcFlowEquationTerm extends AbstractClosedBra
     @Override
     public double eval() {
         return calculateSensi(ph1(), ph2(), a1());
+    }
+
+    @Override
+    public double eval(StateVector sv) {
+        return calculateSensi(ph1(sv), ph2(sv), a1(sv));
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide2DcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide2DcFlowEquationTerm.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.openloadflow.dc.equations;
 
-import com.powsybl.openloadflow.equations.StateVector;
 import com.powsybl.openloadflow.equations.Variable;
 import com.powsybl.openloadflow.equations.VariableSet;
 import com.powsybl.openloadflow.network.LfBranch;
@@ -39,16 +38,6 @@ public final class ClosedBranchSide2DcFlowEquationTerm extends AbstractClosedBra
     protected double calculateSensi(double ph1, double ph2, double a1) {
         double deltaPhase = ph2 - ph1 + A2 - a1;
         return power * deltaPhase;
-    }
-
-    @Override
-    public double eval() {
-        return calculateSensi(ph1(), ph2(), a1());
-    }
-
-    @Override
-    public double eval(StateVector sv) {
-        return calculateSensi(ph1(sv), ph2(sv), a1(sv));
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide2DcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide2DcFlowEquationTerm.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.openloadflow.dc.equations;
 
+import com.powsybl.openloadflow.equations.StateVector;
 import com.powsybl.openloadflow.equations.Variable;
 import com.powsybl.openloadflow.equations.VariableSet;
 import com.powsybl.openloadflow.network.LfBranch;
@@ -43,6 +44,11 @@ public final class ClosedBranchSide2DcFlowEquationTerm extends AbstractClosedBra
     @Override
     public double eval() {
         return calculateSensi(ph1(), ph2(), a1());
+    }
+
+    @Override
+    public double eval(StateVector sv) {
+        return calculateSensi(ph1(sv), ph2(sv), a1(sv));
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationTerm.java
@@ -165,6 +165,10 @@ public interface EquationTerm<V extends Enum<V> & Quantity, E extends Enum<E> & 
      */
     double eval();
 
+    /**
+     * Evaluate the equation term with an alternative state vector.
+     * @return value of the equation term
+     */
     default double eval(StateVector sv) {
         throw new UnsupportedOperationException("Not implemented");
     }

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationTerm.java
@@ -165,6 +165,10 @@ public interface EquationTerm<V extends Enum<V> & Quantity, E extends Enum<E> & 
      */
     double eval();
 
+    default double eval(StateVector sv) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
     /**
      * Get partial derivative.
      *

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -275,7 +275,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
         }
 
         // we need to copy the target array because:
-        //  - in case of disabled buses or branches some elements could be overwriten to zero
+        //  - in case of disabled buses or branches some elements could be overwritten to zero
         //  - JacobianMatrix.solveTransposed take as an input the second member and reuse the array
         //    to fill with the solution
         // so we need to copy to later the target as it is and reusable for next run

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -29,6 +29,7 @@ import com.powsybl.openloadflow.dc.equations.DcVariableType;
 import com.powsybl.openloadflow.equations.Equation;
 import com.powsybl.openloadflow.equations.EquationSystem;
 import com.powsybl.openloadflow.equations.EquationTerm;
+import com.powsybl.openloadflow.equations.StateVector;
 import com.powsybl.openloadflow.graph.GraphConnectivity;
 import com.powsybl.openloadflow.graph.GraphConnectivityFactory;
 import com.powsybl.openloadflow.network.*;
@@ -236,29 +237,76 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
                                                     List<LfSensitivityFactor<DcVariableType, DcEquationType>> factors, List<ParticipatingElement> participatingElements,
                                                     Collection<LfBus> disabledBuses, Collection<LfBranch> disabledBranches,
                                                     Reporter reporter) {
-
         List<BusState> busStates = Collections.emptyList();
         DcLoadFlowParameters parameters = loadFlowContext.getParameters();
         if (parameters.isDistributedSlack()) {
             busStates = ElementState.save(participatingElements.stream()
-                .map(ParticipatingElement::getLfBus)
-                .collect(Collectors.toSet()), BusState::save);
+                    .map(ParticipatingElement::getLfBus)
+                    .collect(Collectors.toSet()), BusState::save);
         }
-        // the A1 variables will be set to 0 for disabledBranches, so we need to restore them at the end
-        List<BranchState> branchStates = ElementState.save(disabledBranches, BranchState::save);
 
-        double[] dx = new DcLoadFlowEngine(loadFlowContext).run(disabledBuses, disabledBranches, reporter).getRight();
+        double[] dx = runDcLoadFlow(loadFlowContext, disabledBuses, disabledBranches, reporter);
 
+        StateVector sv = new StateVector(dx);
         for (LfSensitivityFactor<DcVariableType, DcEquationType> factor : factors) {
-            factor.setFunctionReference(factor.getFunctionEquationTerm().eval());
+            factor.setFunctionReference(factor.getFunctionEquationTerm().eval(sv)); // pass explicitly the previously calculated state vector
         }
 
         if (parameters.isDistributedSlack()) {
             ElementState.restore(busStates);
         }
-        ElementState.restore(branchStates);
 
         return new DenseMatrix(dx.length, 1, dx);
+    }
+
+    /**
+     * A simplified version of DcLoadFlowEngine that supports on the fly bus and branch disabling and that do not
+     * update the state vector and the network at the end (because we don't need it to just evaluate a few equations)
+     */
+    public double[] runDcLoadFlow(DcLoadFlowContext loadFlowContext, Collection<LfBus> disabledBuses, Collection<LfBranch> disabledBranches,
+                                  Reporter reporter) {
+        Collection<LfBus> remainingBuses;
+        if (disabledBuses.isEmpty()) {
+            remainingBuses = loadFlowContext.getNetwork().getBuses();
+        } else {
+            remainingBuses = new LinkedHashSet<>(loadFlowContext.getNetwork().getBuses());
+            remainingBuses.removeAll(disabledBuses);
+        }
+
+        DcLoadFlowParameters parameters = loadFlowContext.getParameters();
+        if (parameters.isDistributedSlack()) {
+            DcLoadFlowEngine.distributeSlack(remainingBuses, parameters.getBalanceType());
+        }
+
+        // we need to copy the target array because:
+        //  - in case of disabled buses or branches some elements could be overwriten to zero
+        //  - JacobianMatrix.solveTransposed take as an input the second member and reuse the array
+        //    to fill with the solution
+        // so we need to copy to later the target as it is and reusable for next run
+        var targetVectorArray = loadFlowContext.getTargetVector().getArray().clone();
+
+        if (!disabledBuses.isEmpty()) {
+            // set buses injections and transformers to 0
+            disabledBuses.stream()
+                    .flatMap(lfBus -> loadFlowContext.getEquationSystem().getEquation(lfBus.getNum(), DcEquationType.BUS_TARGET_P).stream())
+                    .map(Equation::getColumn)
+                    .forEach(column -> targetVectorArray[column] = 0);
+        }
+
+        if (!disabledBranches.isEmpty()) {
+            // set transformer phase shift to 0
+            disabledBranches.stream()
+                    .flatMap(lfBranch -> loadFlowContext.getEquationSystem().getEquation(lfBranch.getNum(), DcEquationType.BRANCH_TARGET_ALPHA1).stream())
+                    .map(Equation::getColumn)
+                    .forEach(column -> targetVectorArray[column] = 0);
+        }
+
+        boolean succeeded = DcLoadFlowEngine.solve(targetVectorArray, loadFlowContext.getJacobianMatrix(), reporter);
+        if (!succeeded) {
+            throw new PowsyblException("DC solver failed");
+        }
+
+        return targetVectorArray; // now contains dx
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Performance improvement


**What is the current behavior?**
<!-- You can also link to an open issue here -->
For reference flow calculation, we need to calculate pre-contingency state using DcLoadFlowEngine. The problem with current implementation is that we integrate the calculated state into the state vector and update the network which in consequence invalidate the Jacobian which will be needed to be recalculated (identically to before invalidation...).


**What is the new behavior (if this is a feature change)?**
We use a special version of the DcLoadFlowEngine that do not  update the state vector nor the network. Flow are calculated from equation terme using a special eval method that can take al alternative state vector.

In a real test case 10000 buses, 100 factors and 100000 contingencies, DC sensitivity calculation is now 4 times faster.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
