### PR TITLE
Fix NPE in remote reactive power control

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -213,6 +213,10 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
 
     private static void createRemoteReactivePowerControl(LfBranch controlledBranch, ControlledSide side, LfBus controllerBus,
                                                          double targetQ) {
+        if (!controlledBranch.isConnectedAtBothSides()) {
+            LOGGER.warn("Controlled branch '{}' must be connected at both sides: remote reactive power control discarded", controlledBranch.getId());
+            return;
+        }
         ReactivePowerControl control = new ReactivePowerControl(controlledBranch, side, controllerBus, targetQ);
         controllerBus.setReactivePowerControl(control);
         controlledBranch.setReactivePowerControl(control);
@@ -231,6 +235,10 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
                 if (generators.size() == 1) {
                     LfGenerator lfGenerator = generators.get(0);
                     LfBranch controlledBranch = lfGenerator.getControlledBranch();
+                    if (controlledBranch == null) {
+                        LOGGER.warn("Controlled branch of generator '{}' is out of voltage or in a different synchronous component: remote reactive power control discarded", generators.get(0).getId());
+                        continue;
+                    }
                     Optional<ReactivePowerControl> control = controlledBranch.getReactivePowerControl();
                     if (control.isPresent()) {
                         LOGGER.warn("Branch {} is remotely controlled by a generator: no new remote reactive control created", controlledBranch.getId());

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -211,17 +211,6 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         }
     }
 
-    private static void createRemoteReactivePowerControl(LfBranch controlledBranch, ControlledSide side, LfBus controllerBus,
-                                                         double targetQ) {
-        if (!controlledBranch.isConnectedAtBothSides()) {
-            LOGGER.warn("Controlled branch '{}' must be connected at both sides: remote reactive power control discarded", controlledBranch.getId());
-            return;
-        }
-        ReactivePowerControl control = new ReactivePowerControl(controlledBranch, side, controllerBus, targetQ);
-        controllerBus.setReactivePowerControl(control);
-        controlledBranch.setReactivePowerControl(control);
-    }
-
     private static void createReactivePowerControls(List<LfBus> lfBuses) {
         for (LfBus controllerBus : lfBuses) {
             List<LfGenerator> generators = controllerBus.getGenerators().stream()
@@ -235,21 +224,33 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
                 if (generators.size() == 1) {
                     LfGenerator lfGenerator = generators.get(0);
                     LfBranch controlledBranch = lfGenerator.getControlledBranch();
-                    if (controlledBranch == null) {
-                        LOGGER.warn("Controlled branch of generator '{}' is out of voltage or in a different synchronous component: remote reactive power control discarded", generators.get(0).getId());
-                        continue;
-                    }
-                    Optional<ReactivePowerControl> control = controlledBranch.getReactivePowerControl();
-                    if (control.isPresent()) {
-                        LOGGER.warn("Branch {} is remotely controlled by a generator: no new remote reactive control created", controlledBranch.getId());
-                    } else {
-                        createRemoteReactivePowerControl(lfGenerator.getControlledBranch(), lfGenerator.getControlledBranchSide(), controllerBus, lfGenerator.getRemoteTargetQ());
-                    }
+                    createRemoteReactivePowerControl(controllerBus, lfGenerator, controlledBranch);
                 } else { // generators.size() > 1 (as > 0 and not equal to 1)
                     LOGGER.warn("Bus {} has more than one generator controlling reactive power remotely: not yet supported", controllerBus.getId());
                 }
             }
         }
+    }
+
+    private static void createRemoteReactivePowerControl(LfBus controllerBus, LfGenerator lfGenerator, LfBranch controlledBranch) {
+        if (controlledBranch == null) {
+            LOGGER.warn("Controlled branch of generator '{}' is out of voltage or in a different synchronous component: remote reactive power control discarded", lfGenerator.getId());
+            return;
+        }
+        if (!controlledBranch.isConnectedAtBothSides()) {
+            LOGGER.warn("Controlled branch '{}' must be connected at both sides: remote reactive power control discarded", controlledBranch.getId());
+            return;
+        }
+        Optional<ReactivePowerControl> optionalControl = controlledBranch.getReactivePowerControl();
+        if (optionalControl.isPresent()) {
+            LOGGER.warn("Branch {} is already remotely controlled by a generator: no new remote reactive control created", controlledBranch.getId());
+            return;
+        }
+        ControlledSide side = lfGenerator.getControlledBranchSide();
+        double targetQ = lfGenerator.getRemoteTargetQ();
+        ReactivePowerControl control = new ReactivePowerControl(controlledBranch, side, controllerBus, targetQ);
+        controllerBus.setReactivePowerControl(control);
+        controlledBranch.setReactivePowerControl(control);
     }
 
     private static LfBusImpl createBus(Bus bus, LfNetworkParameters parameters, LfNetwork lfNetwork, LoadingContext loadingContext,

--- a/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
@@ -394,6 +394,37 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
     }
 
     @Test
+    void testDiscardedRemoteReactivePowerControls() {
+        // create a basic 4-buses network
+        Network network = FourBusNetworkFactory.createBaseNetwork();
+        Generator g4 = network.getGenerator("g4");
+        Line l34 = network.getLine("l34");
+        l34.getTerminal1().disconnect();
+
+        double targetQ = 1.0;
+
+        // disable voltage control on g4
+        g4.setTargetQ(0).setVoltageRegulatorOn(false);
+
+        // first test: generator g4 regulates reactive power on line 4->3 (on side of g4)
+        g4.newExtension(RemoteReactivePowerControlAdder.class)
+                .withTargetQ(targetQ)
+                .withRegulatingTerminal(l34.getTerminal(Branch.Side.TWO))
+                .withEnabled(true).add();
+
+        parameters.getExtension(OpenLoadFlowParameters.class).setReactivePowerRemoteControl(true);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isOk());
+        assertReactivePowerEquals(0.0, l34.getTerminal(Branch.Side.TWO));
+
+        l34.getTerminal2().disconnect();
+        LoadFlowResult result2 = loadFlowRunner.run(network, parameters);
+        assertTrue(result2.isOk());
+        assertReactivePowerEquals(Double.NaN, l34.getTerminal(Branch.Side.TWO));
+    }
+
+    @Test
     void testSharedRemoteReactivePowerControl() {
         // we create a basic 4-buses network
         Network network = FourBusNetworkFactory.createBaseNetwork();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

#832 

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
throws NullPointerException if controlledBranch is in another component


**What is the new behavior (if this is a feature change)?**
remote reactive power control is disabled, warning is issued.


**Does this PR introduce a breaking change or deprecate an API?**
No

