### PR TITLE
Fix invalid factors in specific contingency context

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
@@ -9,6 +9,7 @@ package com.powsybl.openloadflow.sensi;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.reporter.Reporter;
 import com.powsybl.contingency.ContingencyContext;
+import com.powsybl.contingency.ContingencyContextType;
 import com.powsybl.iidm.network.*;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.math.matrix.DenseMatrix;
@@ -716,26 +717,30 @@ abstract class AbstractSensitivityAnalysis<V extends Enum<V> & Quantity, E exten
         Map<String, Integer> contingencyIndexById = new HashMap<>();
         contingencies.stream().forEach(contingency -> contingencyIndexById.put(contingency.getContingency().getId(), contingency.getIndex()));
         for (var factor : factorHolder.getAllFactors()) {
-            // directly write output for zero and invalid factors
+            Optional<Double> sensitivityVariableToWrite = Optional.empty();
             if (factor.getStatus() == LfSensitivityFactor.Status.ZERO) {
                 // ZERO status is for factors where variable element is in the main connected component and reference element is not.
                 // Therefore, the sensitivity is known to value 0, but the reference cannot be known and is set to NaN.
                 if (!filterSensitivityValue(0, factor.getVariableType(), factor.getFunctionType(), parameters)) {
-                    if (factor.getContingencyContext().getContingencyId() == null) {
-                        resultWriter.writeSensitivityValue(factor.getIndex(), -1, 0, Double.NaN);
-                    } else {
-                        resultWriter.writeSensitivityValue(factor.getIndex(), contingencyIndexById.get(factor.getContingencyContext().getContingencyId()), 0, Double.NaN);
-                    }
+                    sensitivityVariableToWrite = Optional.of(0.0);
                 }
             } else if (factor.getStatus() == LfSensitivityFactor.Status.SKIP) {
-                if (factor.getContingencyContext().getContingencyId() == null) {
-                    resultWriter.writeSensitivityValue(factor.getIndex(), -1, Double.NaN, Double.NaN);
-                } else {
-                    resultWriter.writeSensitivityValue(factor.getIndex(), contingencyIndexById.get(factor.getContingencyContext().getContingencyId()), Double.NaN, Double.NaN);
-                }
+                sensitivityVariableToWrite = Optional.of(Double.NaN);
                 skippedVariables.add(factor.getVariableId());
             } else {
                 validFactorHolder.addFactor(factor);
+            }
+            if (sensitivityVariableToWrite.isPresent()) {
+                // directly write output for zero and invalid factors
+                double value = sensitivityVariableToWrite.get();
+                if (factor.getContingencyContext().getContextType() == ContingencyContextType.NONE) {
+                    resultWriter.writeSensitivityValue(factor.getIndex(), -1, value, Double.NaN);
+                } else if (factor.getContingencyContext().getContextType() == ContingencyContextType.SPECIFIC) {
+                    resultWriter.writeSensitivityValue(factor.getIndex(), contingencyIndexById.get(factor.getContingencyContext().getContingencyId()), value, Double.NaN);
+                } else if (factor.getContingencyContext().getContextType() == ContingencyContextType.ALL) {
+                    resultWriter.writeSensitivityValue(factor.getIndex(), -1, value, Double.NaN);
+                    contingencyIndexById.values().forEach(index -> resultWriter.writeSensitivityValue(factor.getIndex(), index, value, Double.NaN));
+                }
             }
         }
         if (!skippedVariables.isEmpty() && LOGGER.isWarnEnabled()) {

--- a/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
@@ -242,7 +242,7 @@ public class AcSensitivityAnalysis extends AbstractSensitivityAnalysis<AcVariabl
             LOGGER.info("Running AC sensitivity analysis with {} factors and {} contingencies", allLfFactors.size(), contingencies.size());
 
             // next we only work with valid and valid only for function factors
-            var validFactorHolder = writeInvalidFactors(allFactorHolder, resultWriter);
+            var validFactorHolder = writeInvalidFactors(allFactorHolder, resultWriter, contingencies);
             var validLfFactors = validFactorHolder.getAllFactors();
 
             // create AC engine

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -857,7 +857,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
             var dcLoadFlowParameters = createDcLoadFlowParameters(lfNetworkParameters, matrixFactory, lfParameters, lfParametersExt);
 
             // next we only work with valid factors
-            var validFactorHolder = writeInvalidFactors(allFactorHolder, resultWriter);
+            var validFactorHolder = writeInvalidFactors(allFactorHolder, resultWriter, contingencies);
             var validLfFactors = validFactorHolder.getAllFactors();
             LOGGER.info("{}/{} factors are valid", validLfFactors.size(), allLfFactors.size());
 

--- a/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisContingenciesTest.java
@@ -1205,24 +1205,19 @@ class AcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
         network.getLine("l25").getTerminal1().disconnect();
         network.getLine("l25").getTerminal2().disconnect();
         SensitivityAnalysisParameters sensiParameters = createParameters(true, "b1_vl_0", true);
-        List<SensitivityFactor> factors = List.of(createBranchFlowPerInjectionIncrease("l46", "g1"));
-        // no contingency for the moment
-        SensitivityAnalysisResult result = sensiRunner.run(network, factors, Collections.emptyList(), Collections.emptyList(), sensiParameters);
-        assertEquals(0.0, result.getBranchFlow1SensitivityValue("g1", "l46", SensitivityVariableType.INJECTION_ACTIVE_POWER), LoadFlowAssert.DELTA_POWER);
-        assertEquals(Double.NaN, result.getBranchFlow1FunctionReferenceValue("l46"), LoadFlowAssert.DELTA_POWER);
-        // with a contingency
+        // with contingency context all
         List<Contingency> contingencies = Collections.singletonList(new Contingency("l12", new BranchContingency("l12")));
-        factors = List.of(createBranchFlowPerInjectionIncrease("l46", "g1")); // all contingency context.
-        result = sensiRunner.run(network, factors, contingencies, Collections.emptyList(), sensiParameters);
+        List<SensitivityFactor> factors = List.of(createBranchFlowPerInjectionIncrease("l46", "g1")); // all contingency context.
+        SensitivityAnalysisResult result = sensiRunner.run(network, factors, contingencies, Collections.emptyList(), sensiParameters);
         assertEquals(0.0, result.getBranchFlow1SensitivityValue("g1", "l46", SensitivityVariableType.INJECTION_ACTIVE_POWER), LoadFlowAssert.DELTA_POWER);
         assertEquals(Double.NaN, result.getBranchFlow1FunctionReferenceValue("l46"), LoadFlowAssert.DELTA_POWER);
         assertTrue(result.getValues("l12").isEmpty()); // nothing because invalid factor in pre contingency state.
         // with contingency context specific (no pre contingency state asked...)
         factors = List.of(createBranchFlowPerInjectionIncrease("l46", "g1", "l12")); // all contingency context.
         result = sensiRunner.run(network, factors, contingencies, Collections.emptyList(), sensiParameters);
-        assertEquals(0.0, result.getBranchFlow1SensitivityValue("g1", "l46", SensitivityVariableType.INJECTION_ACTIVE_POWER), LoadFlowAssert.DELTA_POWER);
-        assertEquals(Double.NaN, result.getBranchFlow1FunctionReferenceValue("l46"), LoadFlowAssert.DELTA_POWER);
-        assertTrue(result.getValues("l12").isEmpty()); // nothing because invalid factor in pre contingency state.
+        assertEquals(0.0, result.getBranchFlow1SensitivityValue("l12", "g1", "l46", SensitivityVariableType.INJECTION_ACTIVE_POWER), LoadFlowAssert.DELTA_POWER);
+        assertEquals(Double.NaN, result.getBranchFlow1FunctionReferenceValue("l12", "l46"), LoadFlowAssert.DELTA_POWER);
+        assertTrue(result.getValues(null).isEmpty()); // nothing because invalid factor in pre contingency state.
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisContingenciesTest.java
@@ -1211,9 +1211,10 @@ class AcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
         SensitivityAnalysisResult result = sensiRunner.run(network, factors, contingencies, Collections.emptyList(), sensiParameters);
         assertEquals(0.0, result.getBranchFlow1SensitivityValue("g1", "l46", SensitivityVariableType.INJECTION_ACTIVE_POWER), LoadFlowAssert.DELTA_POWER);
         assertEquals(Double.NaN, result.getBranchFlow1FunctionReferenceValue("l46"), LoadFlowAssert.DELTA_POWER);
-        assertTrue(result.getValues("l12").isEmpty()); // nothing because invalid factor in pre contingency state.
+        assertEquals(0.0, result.getBranchFlow1SensitivityValue("l12", "g1", "l46", SensitivityVariableType.INJECTION_ACTIVE_POWER), LoadFlowAssert.DELTA_POWER);
+        assertEquals(Double.NaN, result.getBranchFlow1FunctionReferenceValue("l12", "l46"), LoadFlowAssert.DELTA_POWER);
         // with contingency context specific (no pre contingency state asked...)
-        factors = List.of(createBranchFlowPerInjectionIncrease("l46", "g1", "l12")); // all contingency context.
+        factors = List.of(createBranchFlowPerInjectionIncrease("l46", "g1", "l12")); // specific contingency context.
         result = sensiRunner.run(network, factors, contingencies, Collections.emptyList(), sensiParameters);
         assertEquals(0.0, result.getBranchFlow1SensitivityValue("l12", "g1", "l46", SensitivityVariableType.INJECTION_ACTIVE_POWER), LoadFlowAssert.DELTA_POWER);
         assertEquals(Double.NaN, result.getBranchFlow1FunctionReferenceValue("l12", "l46"), LoadFlowAssert.DELTA_POWER);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

When we have an invalid factor, we write the results for pre-contingency state only. If the factor is also associated to a contingency, nothing is written for this contingency. But... we have now specific contingency context, so it means that for these factors, the pre contingency state is not asked. But we provide results for it. 

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

For the moment, nothing. Two solutions:
- We output all results.
- We output pre contingency state for contingency context none or all, and for a specific contingency only if contingency context specific.

**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
