### PR TITLE
Fix null BusBarSections ids 

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
@@ -16,6 +16,7 @@ import com.powsybl.openloadflow.network.LfAsymBus;
 import com.powsybl.openloadflow.util.PerUnit;
 import com.powsybl.security.results.BusResult;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -40,7 +41,7 @@ public class LfBusImpl extends AbstractLfBus {
 
     private final Country country;
 
-    private List<String> bbsIds = null;
+    private final List<String> bbsIds;
 
     protected LfBusImpl(Bus bus, LfNetwork network, double v, double angle, LfNetworkParameters parameters,
                         boolean participating) {
@@ -58,6 +59,8 @@ public class LfBusImpl extends AbstractLfBus {
                     .filter(BusbarSection.class::isInstance)
                     .map(Connectable::getId)
                     .collect(Collectors.toList());
+        } else {
+            bbsIds = Collections.emptyList();
         }
     }
 


### PR DESCRIPTION
Empty list instead of null for bbsIds (and make final).

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
