### PR TITLE
Reduce the number of zero reactive key log error

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/GeneratorVoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/GeneratorVoltageControl.java
@@ -7,18 +7,15 @@
 package com.powsybl.openloadflow.network;
 
 import com.powsybl.openloadflow.util.PerUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * @author Anne Tilloy <anne.tilloy at rte-france.com>
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
 public class GeneratorVoltageControl extends VoltageControl<LfBus> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(GeneratorVoltageControl.class);
 
     private static final int PRIORITY = 0;
 
@@ -123,10 +120,7 @@ public class GeneratorVoltageControl extends VoltageControl<LfBus> {
             LfBus controllerBus = controllerBuses.get(i);
             for (LfGenerator generator : controllerBus.getGenerators()) {
                 double qKey = generator.getRemoteControlReactiveKey().orElse(Double.NaN);
-                if (Double.isNaN(qKey) || qKey == 0) {
-                    if (qKey == 0) {
-                        LOGGER.error("Generator '{}' remote control reactive key value is zero", generator.getId());
-                    }
+                if (Double.isNaN(qKey)) {
                     // in case of one missing key, we fallback to keys based on reactive power range
                     return createReactiveKeysFromMaxReactivePowerRange(controllerBuses);
                 } else {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -730,6 +730,11 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
                     lfNetwork, report.generatorsWithInconsistentTargetVoltage);
         }
 
+        if (report.generatorsWithZeroRemoteVoltageControlReactivePowerKey > 0) {
+            LOGGER.warn("Network {}: {} generators have an zero remote voltage control reactive power key",
+                    lfNetwork, report.generatorsWithZeroRemoteVoltageControlReactivePowerKey);
+        }
+
         if (parameters.getDebugDir() != null) {
             Path debugDir = DebugUtil.getDebugDir(parameters.getDebugDir());
             String dateStr = DateTime.now().toString(DATE_TIME_FORMAT);

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -730,7 +730,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         }
 
         if (report.generatorsWithZeroRemoteVoltageControlReactivePowerKey > 0) {
-            LOGGER.warn("Network {}: {} generators have an zero remote voltage control reactive power key",
+            LOGGER.warn("Network {}: {} generators have a zero remote voltage control reactive power key",
                     lfNetwork, report.generatorsWithZeroRemoteVoltageControlReactivePowerKey);
         }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoadingReport.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoadingReport.java
@@ -32,4 +32,6 @@ public class LfNetworkLoadingReport {
     int nonImpedantBranches = 0;
 
     int generatorsWithInconsistentTargetVoltage = 0;
+
+    int generatorsWithZeroRemoteVoltageControlReactivePowerKey = 0;
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
@@ -17,6 +17,7 @@ import com.powsybl.math.matrix.DenseMatrixFactory;
 import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.OpenLoadFlowProvider;
 import com.powsybl.openloadflow.network.*;
+import com.powsybl.openloadflow.network.impl.LfNetworkLoaderImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -642,5 +643,12 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
         LoadFlowResult result3 = loadFlowRunner.run(network, parameters);
         assertTrue(result3.isOk());
         assertVoltageEquals(164.88, nload);
+    }
+
+    @Test
+    void testWithZeroReactiveKey() {
+        g1.newExtension(CoordinatedReactiveControlAdder.class).withQPercent(0).add();
+        LfNetwork lfNetwork = LfNetwork.load(network, new LfNetworkLoaderImpl(), new LfNetworkParameters()).get(0);
+        assertTrue(lfNetwork.getGeneratorById(g1.getId()).getRemoteControlReactiveKey().isEmpty()); // zero is fixed to empty
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Each time we have a generator with a zero reactive key, we log an error.


**What is the new behavior (if this is a feature change)?**
We only warn about the number of generator with a zero reactive key, detailed logs are only at trace level.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
