### PR TITLE
Fix three windings transformer with disconnected leg monitoring

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
@@ -11,6 +11,7 @@ import com.powsybl.iidm.network.*;
 import com.powsybl.openloadflow.network.*;
 import com.powsybl.openloadflow.util.PerUnit;
 import com.powsybl.security.results.BranchResult;
+import com.powsybl.security.results.ThreeWindingsTransformerResult;
 
 import java.util.*;
 
@@ -191,5 +192,19 @@ public final class LfLegBranch extends AbstractImpedantLfBranch {
         // Star bus is always on side 2.
         getLeg().getTerminal().setP(p1 * PerUnit.SB)
                 .setQ(q1 * PerUnit.SB);
+    }
+
+    public static ThreeWindingsTransformerResult createThreeWindingsTransformerResult(LfNetwork network, String threeWindingsTransformerId) {
+        LfLegBranch leg1 = (LfLegBranch) network.getBranchById(LfLegBranch.getId(threeWindingsTransformerId, 1));
+        LfLegBranch leg2 = (LfLegBranch) network.getBranchById(LfLegBranch.getId(threeWindingsTransformerId, 2));
+        LfLegBranch leg3 = (LfLegBranch) network.getBranchById(LfLegBranch.getId(threeWindingsTransformerId, 3));
+
+        double i1Base = leg1.isConnectedAtBothSides() ? PerUnit.ib(leg1.getBus1().getNominalV()) : PerUnit.ib(leg1.legRef.get().getTerminal().getVoltageLevel().getNominalV());
+        double i2Base = leg2.isConnectedAtBothSides() ? PerUnit.ib(leg2.getBus1().getNominalV()) : PerUnit.ib(leg2.legRef.get().getTerminal().getVoltageLevel().getNominalV());
+        double i3Base = leg3.isConnectedAtBothSides() ? PerUnit.ib(leg3.getBus1().getNominalV()) : PerUnit.ib(leg3.legRef.get().getTerminal().getVoltageLevel().getNominalV());
+        return new ThreeWindingsTransformerResult(threeWindingsTransformerId,
+                leg1.getP1().eval() * PerUnit.SB, leg1.getQ1().eval() * PerUnit.SB, leg1.getI1().eval() * i1Base,
+                leg2.getP1().eval() * PerUnit.SB, leg2.getQ1().eval() * PerUnit.SB, leg2.getI1().eval() * i2Base,
+                leg3.getP1().eval() * PerUnit.SB, leg3.getQ1().eval() * PerUnit.SB, leg3.getI1().eval() * i3Base);
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
@@ -199,9 +199,9 @@ public final class LfLegBranch extends AbstractImpedantLfBranch {
         LfLegBranch leg2 = (LfLegBranch) network.getBranchById(LfLegBranch.getId(threeWindingsTransformerId, 2));
         LfLegBranch leg3 = (LfLegBranch) network.getBranchById(LfLegBranch.getId(threeWindingsTransformerId, 3));
 
-        double i1Base = leg1.isConnectedAtBothSides() ? PerUnit.ib(leg1.getBus1().getNominalV()) : PerUnit.ib(leg1.legRef.get().getTerminal().getVoltageLevel().getNominalV());
-        double i2Base = leg2.isConnectedAtBothSides() ? PerUnit.ib(leg2.getBus1().getNominalV()) : PerUnit.ib(leg2.legRef.get().getTerminal().getVoltageLevel().getNominalV());
-        double i3Base = leg3.isConnectedAtBothSides() ? PerUnit.ib(leg3.getBus1().getNominalV()) : PerUnit.ib(leg3.legRef.get().getTerminal().getVoltageLevel().getNominalV());
+        double i1Base = PerUnit.ib(leg1.legRef.get().getTerminal().getVoltageLevel().getNominalV());
+        double i2Base = PerUnit.ib(leg2.legRef.get().getTerminal().getVoltageLevel().getNominalV());
+        double i3Base = PerUnit.ib(leg3.legRef.get().getTerminal().getVoltageLevel().getNominalV());
         return new ThreeWindingsTransformerResult(threeWindingsTransformerId,
                 leg1.getP1().eval() * PerUnit.SB, leg1.getQ1().eval() * PerUnit.SB, leg1.getI1().eval() * i1Base,
                 leg2.getP1().eval() * PerUnit.SB, leg2.getQ1().eval() * PerUnit.SB, leg2.getI1().eval() * i2Base,

--- a/src/main/java/com/powsybl/openloadflow/sa/AbstractNetworkResult.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AbstractNetworkResult.java
@@ -74,8 +74,8 @@ public abstract class AbstractNetworkResult {
         LfBranch leg2 = network.getBranchById(LfLegBranch.getId(threeWindingsTransformerId, 2));
         LfBranch leg3 = network.getBranchById(LfLegBranch.getId(threeWindingsTransformerId, 3));
         double i1Base = leg1.isConnectedAtBothSides() ? PerUnit.ib(leg1.getBus1().getNominalV()) : Double.NaN;
-        double i2Base = leg2.isConnectedAtBothSides() ? PerUnit.ib(leg2.getBus1().getNominalV()) :  Double.NaN;
-        double i3Base = leg3.isConnectedAtBothSides() ? PerUnit.ib(leg3.getBus1().getNominalV()) :  Double.NaN;
+        double i2Base = leg2.isConnectedAtBothSides() ? PerUnit.ib(leg2.getBus1().getNominalV()) : Double.NaN;
+        double i3Base = leg3.isConnectedAtBothSides() ? PerUnit.ib(leg3.getBus1().getNominalV()) : Double.NaN;
         return new ThreeWindingsTransformerResult(threeWindingsTransformerId,
                                                   leg1.getP1().eval() * PerUnit.SB, leg1.getQ1().eval() * PerUnit.SB, leg1.getI1().eval() * i1Base,
                                                   leg2.getP1().eval() * PerUnit.SB, leg2.getQ1().eval() * PerUnit.SB, leg2.getI1().eval() * i2Base,

--- a/src/main/java/com/powsybl/openloadflow/sa/AbstractNetworkResult.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AbstractNetworkResult.java
@@ -73,9 +73,9 @@ public abstract class AbstractNetworkResult {
         LfBranch leg1 = network.getBranchById(LfLegBranch.getId(threeWindingsTransformerId, 1));
         LfBranch leg2 = network.getBranchById(LfLegBranch.getId(threeWindingsTransformerId, 2));
         LfBranch leg3 = network.getBranchById(LfLegBranch.getId(threeWindingsTransformerId, 3));
-        double i1Base = PerUnit.ib(leg1.getBus1().getNominalV());
-        double i2Base = PerUnit.ib(leg2.getBus1().getNominalV());
-        double i3Base = PerUnit.ib(leg3.getBus1().getNominalV());
+        double i1Base = leg1.isConnectedAtBothSides() ? PerUnit.ib(leg1.getBus1().getNominalV()) : Double.NaN;
+        double i2Base = leg2.isConnectedAtBothSides() ? PerUnit.ib(leg2.getBus1().getNominalV()) :  Double.NaN;
+        double i3Base = leg3.isConnectedAtBothSides() ? PerUnit.ib(leg3.getBus1().getNominalV()) :  Double.NaN;
         return new ThreeWindingsTransformerResult(threeWindingsTransformerId,
                                                   leg1.getP1().eval() * PerUnit.SB, leg1.getQ1().eval() * PerUnit.SB, leg1.getI1().eval() * i1Base,
                                                   leg2.getP1().eval() * PerUnit.SB, leg2.getQ1().eval() * PerUnit.SB, leg2.getI1().eval() * i2Base,

--- a/src/main/java/com/powsybl/openloadflow/sa/AbstractNetworkResult.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AbstractNetworkResult.java
@@ -10,7 +10,6 @@ import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.LfNetwork;
 import com.powsybl.openloadflow.network.impl.LfLegBranch;
 import com.powsybl.openloadflow.network.impl.LfStarBus;
-import com.powsybl.openloadflow.util.PerUnit;
 import com.powsybl.security.monitor.StateMonitor;
 import com.powsybl.security.monitor.StateMonitorIndex;
 import com.powsybl.security.results.BranchResult;
@@ -60,26 +59,13 @@ public abstract class AbstractNetworkResult {
         if (!monitor.getThreeWindingsTransformerIds().isEmpty()) {
             monitor.getThreeWindingsTransformerIds().stream()
                     .filter(id -> network.getBusById(LfStarBus.getId(id)) != null && !network.getBusById(LfStarBus.getId(id)).isDisabled())
-                    .forEach(id -> threeWindingsTransformerResults.add(createThreeWindingsTransformerResult(id, network)));
+                    .forEach(id -> threeWindingsTransformerResults.add(LfLegBranch.createThreeWindingsTransformerResult(network, id)));
         }
     }
 
     protected void clear() {
         busResults.clear();
         threeWindingsTransformerResults.clear();
-    }
-
-    private static ThreeWindingsTransformerResult createThreeWindingsTransformerResult(String threeWindingsTransformerId, LfNetwork network) {
-        LfBranch leg1 = network.getBranchById(LfLegBranch.getId(threeWindingsTransformerId, 1));
-        LfBranch leg2 = network.getBranchById(LfLegBranch.getId(threeWindingsTransformerId, 2));
-        LfBranch leg3 = network.getBranchById(LfLegBranch.getId(threeWindingsTransformerId, 3));
-        double i1Base = leg1.isConnectedAtBothSides() ? PerUnit.ib(leg1.getBus1().getNominalV()) : Double.NaN;
-        double i2Base = leg2.isConnectedAtBothSides() ? PerUnit.ib(leg2.getBus1().getNominalV()) : Double.NaN;
-        double i3Base = leg3.isConnectedAtBothSides() ? PerUnit.ib(leg3.getBus1().getNominalV()) : Double.NaN;
-        return new ThreeWindingsTransformerResult(threeWindingsTransformerId,
-                                                  leg1.getP1().eval() * PerUnit.SB, leg1.getQ1().eval() * PerUnit.SB, leg1.getI1().eval() * i1Base,
-                                                  leg2.getP1().eval() * PerUnit.SB, leg2.getQ1().eval() * PerUnit.SB, leg2.getI1().eval() * i2Base,
-                                                  leg3.getP1().eval() * PerUnit.SB, leg3.getQ1().eval() * PerUnit.SB, leg3.getI1().eval() * i3Base);
     }
 
     public List<BusResult> getBusResults() {

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -463,6 +463,25 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
     }
 
     @Test
+    void testSaMonitoring3wtWithDisconnectedLeg() {
+        Network network = T3wtFactory.create();
+
+        network.getThreeWindingsTransformer("3wt").getLeg3().getTerminal().disconnect();
+
+        // Testing all contingencies at once
+        List<StateMonitor> monitors = List.of(
+                new StateMonitor(ContingencyContext.all(), emptySet(), emptySet(), Collections.singleton("3wt"))
+        );
+
+        SecurityAnalysisResult result = runSecurityAnalysis(network, createAllBranchesContingencies(network), monitors);
+
+        assertEquals(1, result.getPreContingencyResult().getNetworkResult().getThreeWindingsTransformerResults().size());
+        assertAlmostEquals(new ThreeWindingsTransformerResult("3wt", 161, 82, 258,
+                        -161, -74, 435, 0, 0, 0),
+                result.getPreContingencyResult().getNetworkResult().getThreeWindingsTransformerResults().get(0), 1);
+    }
+
+    @Test
     void testSaDcMode() {
         Network fourBusNetwork = FourBusNetworkFactory.create();
         SecurityAnalysisParameters securityAnalysisParameters = new SecurityAnalysisParameters();

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -448,37 +448,24 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
     @Test
     void testSaWithStateMonitorLfLeg() {
         Network network = T3wtFactory.create();
+        List<Contingency> contingencies = network.getBranchStream()
+                .limit(1)
+                .map(b -> new Contingency(b.getId(), new BranchContingency(b.getId())))
+                .collect(Collectors.toList());
 
-        // Testing all contingencies at once
-        List<StateMonitor> monitors = List.of(
-            new StateMonitor(ContingencyContext.all(), emptySet(), emptySet(), Collections.singleton("3wt"))
-        );
-
+        List<StateMonitor> monitors = List.of(new StateMonitor(ContingencyContext.all(), emptySet(), emptySet(), Collections.singleton("3wt")));
         SecurityAnalysisResult result = runSecurityAnalysis(network, createAllBranchesContingencies(network), monitors);
-
         assertEquals(1, result.getPreContingencyResult().getNetworkResult().getThreeWindingsTransformerResults().size());
         assertAlmostEquals(new ThreeWindingsTransformerResult("3wt", 161, 82, 258,
-                                                              -161, -74, 435, 0, 0, 0),
+                        -161, -74, 435, 0, 0, 0),
                 result.getPreContingencyResult().getNetworkResult().getThreeWindingsTransformerResults().get(0), 1);
-    }
-
-    @Test
-    void testSaMonitoring3wtWithDisconnectedLeg() {
-        Network network = T3wtFactory.create();
 
         network.getThreeWindingsTransformer("3wt").getLeg3().getTerminal().disconnect();
-
-        // Testing all contingencies at once
-        List<StateMonitor> monitors = List.of(
-                new StateMonitor(ContingencyContext.all(), emptySet(), emptySet(), Collections.singleton("3wt"))
-        );
-
-        SecurityAnalysisResult result = runSecurityAnalysis(network, createAllBranchesContingencies(network), monitors);
-
-        assertEquals(1, result.getPreContingencyResult().getNetworkResult().getThreeWindingsTransformerResults().size());
+        SecurityAnalysisResult result2 = runSecurityAnalysis(network, createAllBranchesContingencies(network), monitors);
+        assertEquals(1, result2.getPreContingencyResult().getNetworkResult().getThreeWindingsTransformerResults().size());
         assertAlmostEquals(new ThreeWindingsTransformerResult("3wt", 161, 82, 258,
                         -161, -74, 435, NaN, NaN, NaN),
-                result.getPreContingencyResult().getNetworkResult().getThreeWindingsTransformerResults().get(0), 1);
+                result2.getPreContingencyResult().getNetworkResult().getThreeWindingsTransformerResults().get(0), 1);
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -477,7 +477,7 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
 
         assertEquals(1, result.getPreContingencyResult().getNetworkResult().getThreeWindingsTransformerResults().size());
         assertAlmostEquals(new ThreeWindingsTransformerResult("3wt", 161, 82, 258,
-                        -161, -74, 435, 0, 0, 0),
+                        -161, -74, 435, NaN, NaN, NaN),
                 result.getPreContingencyResult().getNetworkResult().getThreeWindingsTransformerResults().get(0), 1);
     }
 


### PR DESCRIPTION
When monitoring three windings transformer with a disconnected leg, the SA result production fails with NPE. Probably just missing a null check. I added a test to show the issue, I will add a fix soon.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
