### PR TITLE
Add log to reactive limit outer loop when limit has changed

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/ReactiveLimitsOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/ReactiveLimitsOuterLoop.java
@@ -282,6 +282,9 @@ public class ReactiveLimitsOuterLoop implements AcOuterLoop {
             status = OuterLoopStatus.UNSTABLE;
         }
         if (!busesWithUpdatedQLimits.isEmpty()) {
+            LOGGER.info("{} buses blocked to a reactive limit have been adjusted because reactive limit has changed",
+                    busesWithUpdatedQLimits.size());
+
             status = OuterLoopStatus.UNSTABLE;
         }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature



**What is the new behavior (if this is a feature change)?**
We write a synthetic log when a bus that is to a reactive limit need to update its q because reactive limit has changed.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
