### PR TITLE
Synthetic discarded transformer voltage control log

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoadingReport.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoadingReport.java
@@ -34,4 +34,6 @@ public class LfNetworkLoadingReport {
     int generatorsWithInconsistentTargetVoltage = 0;
 
     int generatorsWithZeroRemoteVoltageControlReactivePowerKey = 0;
+
+    int transformerVoltageControlDiscardedBecauseControllerBranchIsOpen = 0;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
We have one warning log for each transformer voltage control discarded because controller branch is open.


**What is the new behavior (if this is a feature change)?**
This is now only traces and one synthetic warn has been added.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
