### PR TITLE
OlfThreeWindingsTransformerResult constructor public

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/OlfThreeWindingsTransformerResult.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/OlfThreeWindingsTransformerResult.java
@@ -26,7 +26,7 @@ public class OlfThreeWindingsTransformerResult extends AbstractExtension<ThreeWi
 
     private final double angle3;
 
-    OlfThreeWindingsTransformerResult(double v1, double v2, double v3, double angle1, double angle2, double angle3) {
+    public OlfThreeWindingsTransformerResult(double v1, double v2, double v3, double angle1, double angle2, double angle3) {
         this.v1 = v1;
         this.v2 = v2;
         this.v3 = v3;


### PR DESCRIPTION
Make constructor public for OlfThreeWindingsTransformerResult like for OlfBranchResult instead of package private.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
missing constructor from #875


**What is the new behavior (if this is a feature change)?**
added constructor to OlfThreeWindingsTransformerResult 


**Does this PR introduce a breaking change or deprecate an API?**
No


**Other information**:
See #875
