### PR TITLE
Add literal annotation in author's email address

### DIFF
--- a/src/main/java-templates/com/powsybl/openloadflow/util/PowsyblOpenLoadFlowVersion.java
+++ b/src/main/java-templates/com/powsybl/openloadflow/util/PowsyblOpenLoadFlowVersion.java
@@ -10,7 +10,7 @@ import com.google.auto.service.AutoService;
 import com.powsybl.tools.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(Version.class)
 public class PowsyblOpenLoadFlowVersion extends AbstractVersion {

--- a/src/main/java/com/powsybl/openloadflow/AbstractAcOuterLoopConfig.java
+++ b/src/main/java/com/powsybl/openloadflow/AbstractAcOuterLoopConfig.java
@@ -14,7 +14,7 @@ import com.powsybl.openloadflow.util.PerUnit;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 abstract class AbstractAcOuterLoopConfig implements AcOuterLoopConfig {
 

--- a/src/main/java/com/powsybl/openloadflow/AcLoadFlowFromCache.java
+++ b/src/main/java/com/powsybl/openloadflow/AcLoadFlowFromCache.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AcLoadFlowFromCache {
 

--- a/src/main/java/com/powsybl/openloadflow/AcOuterLoopConfig.java
+++ b/src/main/java/com/powsybl/openloadflow/AcOuterLoopConfig.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface AcOuterLoopConfig {
 

--- a/src/main/java/com/powsybl/openloadflow/DefaultAcOuterLoopConfig.java
+++ b/src/main/java/com/powsybl/openloadflow/DefaultAcOuterLoopConfig.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DefaultAcOuterLoopConfig extends AbstractAcOuterLoopConfig {
 

--- a/src/main/java/com/powsybl/openloadflow/ExplicitAcOuterLoopConfig.java
+++ b/src/main/java/com/powsybl/openloadflow/ExplicitAcOuterLoopConfig.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ExplicitAcOuterLoopConfig extends AbstractAcOuterLoopConfig {
 

--- a/src/main/java/com/powsybl/openloadflow/FullVoltageInitializer.java
+++ b/src/main/java/com/powsybl/openloadflow/FullVoltageInitializer.java
@@ -18,7 +18,7 @@ import java.util.Objects;
  * A voltage initializer that rely on {@link VoltageMagnitudeInitializer} for magnitude calculation and on
  * {@link DcValueVoltageInitializer} for angle calculation.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class FullVoltageInitializer implements VoltageInitializer {
 

--- a/src/main/java/com/powsybl/openloadflow/NetworkCache.java
+++ b/src/main/java/com/powsybl/openloadflow/NetworkCache.java
@@ -24,7 +24,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiPredicate;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum NetworkCache {
     INSTANCE;

--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameterJsonSerializer.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameterJsonSerializer.java
@@ -19,7 +19,7 @@ import com.powsybl.loadflow.LoadFlowParameters;
 import java.io.IOException;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class OpenLoadFlowParameterJsonSerializer implements ExtensionJsonSerializer<LoadFlowParameters, OpenLoadFlowParameters> {
 

--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
@@ -42,7 +42,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters> {
 

--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 @AutoService(LoadFlowProvider.class)
 public class OpenLoadFlowProvider implements LoadFlowProvider {

--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowReportConstants.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowReportConstants.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public final class OpenLoadFlowReportConstants {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/AcJacobianMatrix.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcJacobianMatrix.java
@@ -19,7 +19,7 @@ import com.powsybl.openloadflow.network.LfNetworkListener;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AcJacobianMatrix extends JacobianMatrix<AcVariableType, AcEquationType> {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/AcLoadFlowContext.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcLoadFlowContext.java
@@ -18,7 +18,7 @@ import com.powsybl.openloadflow.equations.TargetVector;
 import com.powsybl.openloadflow.network.LfNetwork;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AcLoadFlowContext extends AbstractLoadFlowContext<AcVariableType, AcEquationType, AcLoadFlowParameters> {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/AcLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcLoadFlowParameters.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AcLoadFlowParameters extends AbstractLoadFlowParameters {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/AcLoadFlowResult.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcLoadFlowResult.java
@@ -15,7 +15,7 @@ import com.powsybl.openloadflow.util.PerUnit;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AcLoadFlowResult extends AbstractLoadFlowResult {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/AcOuterLoopContext.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcOuterLoopContext.java
@@ -13,7 +13,7 @@ import com.powsybl.openloadflow.lf.outerloop.AbstractOuterLoopContext;
 import com.powsybl.openloadflow.network.LfNetwork;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AcOuterLoopContext extends AbstractOuterLoopContext<AcVariableType, AcEquationType, AcLoadFlowParameters, AcLoadFlowContext> {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/AcTargetVector.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcTargetVector.java
@@ -17,7 +17,7 @@ import com.powsybl.openloadflow.network.*;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AcTargetVector extends TargetVector<AcVariableType, AcEquationType> {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/AcloadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcloadFlowEngine.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AcloadFlowEngine implements LoadFlowEngine<AcVariableType, AcEquationType, AcLoadFlowParameters, AcLoadFlowResult> {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/VoltageMagnitudeInitializer.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/VoltageMagnitudeInitializer.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
  * This initializer is particularly useful for cases with a large range of voltage (many transformers with a ratio far
  * from 1pu for instance).
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class VoltageMagnitudeInitializer implements VoltageInitializer {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractBranchAcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractBranchAcFlowEquationTerm.java
@@ -11,7 +11,7 @@ import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.PiModel;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 abstract class AbstractBranchAcFlowEquationTerm extends AbstractElementEquationTerm<LfBranch, AcVariableType, AcEquationType> {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractClosedBranchAcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractClosedBranchAcFlowEquationTerm.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 import static com.powsybl.openloadflow.network.PiModel.A2;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractClosedBranchAcFlowEquationTerm extends AbstractBranchAcFlowEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractHvdcAcEmulationFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractHvdcAcEmulationFlowEquationTerm.java
@@ -15,7 +15,7 @@ import com.powsybl.openloadflow.network.LfHvdc;
 import java.util.List;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public abstract class AbstractHvdcAcEmulationFlowEquationTerm extends AbstractElementEquationTerm<LfHvdc, AcVariableType, AcEquationType> {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractLoadModelEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractLoadModelEquationTerm.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractLoadModelEquationTerm extends AbstractElementEquationTerm<LfBus, AcVariableType, AcEquationType> {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractOpenSide1BranchAcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractOpenSide1BranchAcFlowEquationTerm.java
@@ -14,7 +14,7 @@ import com.powsybl.openloadflow.network.LfBus;
 import java.util.List;
 
 /**
- * @author Gael Macherel <gael.macherel at artelys.com>
+ * @author Gael Macherel {@literal <gael.macherel at artelys.com>}
  */
 abstract class AbstractOpenSide1BranchAcFlowEquationTerm extends AbstractBranchAcFlowEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractOpenSide2BranchAcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractOpenSide2BranchAcFlowEquationTerm.java
@@ -14,7 +14,7 @@ import com.powsybl.openloadflow.network.LfBus;
 import java.util.List;
 
 /**
- * @author Gael Macherel <gael.macherel at artelys.com>
+ * @author Gael Macherel {@literal <gael.macherel at artelys.com>}
  */
 abstract class AbstractOpenSide2BranchAcFlowEquationTerm extends AbstractBranchAcFlowEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractShuntCompensatorEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractShuntCompensatorEquationTerm.java
@@ -15,7 +15,7 @@ import com.powsybl.openloadflow.network.LfShunt;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractShuntCompensatorEquationTerm extends AbstractElementEquationTerm<LfShunt, AcVariableType, AcEquationType> {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreationParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreationParameters.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.ac.equations;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AcEquationSystemCreationParameters {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
@@ -19,7 +19,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AcEquationSystemCreator {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AcEquationSystemUpdater extends AbstractEquationSystemUpdater<AcVariableType, AcEquationType> {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationType.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationType.java
@@ -10,7 +10,7 @@ import com.powsybl.openloadflow.equations.Quantity;
 import com.powsybl.openloadflow.network.ElementType;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum AcEquationType implements Quantity {
     BUS_TARGET_P("bus_target_p", ElementType.BUS), // bus active power target

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcVariableType.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcVariableType.java
@@ -10,7 +10,7 @@ import com.powsybl.openloadflow.equations.Quantity;
 import com.powsybl.openloadflow.network.ElementType;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum AcVariableType implements Quantity {
     BUS_V("v", ElementType.BUS), // bus voltage magnitude

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchI1xFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchI1xFlowEquationTerm.java
@@ -18,7 +18,7 @@ import net.jafama.FastMath;
 import java.util.Objects;
 
 /**
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 @SuppressWarnings("squid:S00107")
 public class ClosedBranchI1xFlowEquationTerm extends AbstractClosedBranchAcFlowEquationTerm {

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchI1yFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchI1yFlowEquationTerm.java
@@ -18,7 +18,7 @@ import net.jafama.FastMath;
 import java.util.Objects;
 
 /**
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 @SuppressWarnings("squid:S00107")
 public class ClosedBranchI1yFlowEquationTerm extends AbstractClosedBranchAcFlowEquationTerm {

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchI2xFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchI2xFlowEquationTerm.java
@@ -18,7 +18,7 @@ import net.jafama.FastMath;
 import java.util.Objects;
 
 /**
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 @SuppressWarnings("squid:S00107")
 public class ClosedBranchI2xFlowEquationTerm extends AbstractClosedBranchAcFlowEquationTerm {

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchI2yFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchI2yFlowEquationTerm.java
@@ -18,7 +18,7 @@ import net.jafama.FastMath;
 import java.util.Objects;
 
 /**
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 @SuppressWarnings("squid:S00107")
 public class ClosedBranchI2yFlowEquationTerm extends AbstractClosedBranchAcFlowEquationTerm {

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide1ActiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide1ActiveFlowEquationTerm.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 import static com.powsybl.openloadflow.network.PiModel.R2;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @SuppressWarnings("squid:S00107")
 public class ClosedBranchSide1ActiveFlowEquationTerm extends AbstractClosedBranchAcFlowEquationTerm {

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide1CurrentMagnitudeEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide1CurrentMagnitudeEquationTerm.java
@@ -19,7 +19,7 @@ import static com.powsybl.openloadflow.network.PiModel.A2;
 import static com.powsybl.openloadflow.network.PiModel.R2;
 
 /**
- * @author Gael Macherel <gael.macherel at artelys.com>
+ * @author Gael Macherel {@literal <gael.macherel at artelys.com>}
  */
 @SuppressWarnings("squid:S00107")
 public class ClosedBranchSide1CurrentMagnitudeEquationTerm extends AbstractClosedBranchAcFlowEquationTerm {

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide1ReactiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide1ReactiveFlowEquationTerm.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 import static com.powsybl.openloadflow.network.PiModel.R2;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @SuppressWarnings("squid:S00107")
 public class ClosedBranchSide1ReactiveFlowEquationTerm extends AbstractClosedBranchAcFlowEquationTerm {

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide2ActiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide2ActiveFlowEquationTerm.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 import static com.powsybl.openloadflow.network.PiModel.R2;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @SuppressWarnings("squid:S00107")
 public class ClosedBranchSide2ActiveFlowEquationTerm extends AbstractClosedBranchAcFlowEquationTerm {

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide2CurrentMagnitudeEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide2CurrentMagnitudeEquationTerm.java
@@ -19,7 +19,7 @@ import static com.powsybl.openloadflow.network.PiModel.A2;
 import static com.powsybl.openloadflow.network.PiModel.R2;
 
 /**
- * @author Gael Macherel <gael.macherel at artelys.com>
+ * @author Gael Macherel {@literal <gael.macherel at artelys.com>}
  */
 @SuppressWarnings("squid:S00107")
 public class ClosedBranchSide2CurrentMagnitudeEquationTerm extends AbstractClosedBranchAcFlowEquationTerm {

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide2ReactiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ClosedBranchSide2ReactiveFlowEquationTerm.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 import static com.powsybl.openloadflow.network.PiModel.R2;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @SuppressWarnings("squid:S00107")
 public class ClosedBranchSide2ReactiveFlowEquationTerm extends AbstractClosedBranchAcFlowEquationTerm {

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide1ActiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide1ActiveFlowEquationTerm.java
@@ -14,7 +14,7 @@ import com.powsybl.openloadflow.network.LfHvdc;
 import java.util.Objects;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class HvdcAcEmulationSide1ActiveFlowEquationTerm extends AbstractHvdcAcEmulationFlowEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide2ActiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide2ActiveFlowEquationTerm.java
@@ -14,7 +14,7 @@ import com.powsybl.openloadflow.network.LfHvdc;
 import java.util.Objects;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class HvdcAcEmulationSide2ActiveFlowEquationTerm extends AbstractHvdcAcEmulationFlowEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/LoadModelActiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/LoadModelActiveFlowEquationTerm.java
@@ -14,7 +14,7 @@ import com.powsybl.openloadflow.network.LfLoadModel;
 import java.util.Collection;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LoadModelActiveFlowEquationTerm extends AbstractLoadModelEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/LoadModelReactiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/LoadModelReactiveFlowEquationTerm.java
@@ -14,7 +14,7 @@ import com.powsybl.openloadflow.network.LfLoadModel;
 import java.util.Collection;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LoadModelReactiveFlowEquationTerm extends AbstractLoadModelEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide1ActiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide1ActiveFlowEquationTerm.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 import static com.powsybl.openloadflow.network.PiModel.R2;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class OpenBranchSide1ActiveFlowEquationTerm extends AbstractOpenSide1BranchAcFlowEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide1CurrentMagnitudeEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide1CurrentMagnitudeEquationTerm.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 import static com.powsybl.openloadflow.network.PiModel.R2;
 
 /**
- * @author Gael Macherel <gael.macherel at artelys.com>
+ * @author Gael Macherel {@literal <gael.macherel at artelys.com>}
  */
 @SuppressWarnings("squid:S00107")
 public class OpenBranchSide1CurrentMagnitudeEquationTerm extends AbstractOpenSide1BranchAcFlowEquationTerm {

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide1ReactiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide1ReactiveFlowEquationTerm.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 import static com.powsybl.openloadflow.network.PiModel.R2;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class OpenBranchSide1ReactiveFlowEquationTerm extends AbstractOpenSide1BranchAcFlowEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide2ActiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide2ActiveFlowEquationTerm.java
@@ -15,7 +15,7 @@ import net.jafama.FastMath;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class OpenBranchSide2ActiveFlowEquationTerm extends AbstractOpenSide2BranchAcFlowEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide2CurrentMagnitudeEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide2CurrentMagnitudeEquationTerm.java
@@ -15,7 +15,7 @@ import net.jafama.FastMath;
 import java.util.Objects;
 
 /**
- * @author Gael Macherel <gael.macherel at artelys.com>
+ * @author Gael Macherel {@literal <gael.macherel at artelys.com>}
  */
 @SuppressWarnings("squid:S00107")
 public class OpenBranchSide2CurrentMagnitudeEquationTerm extends AbstractOpenSide2BranchAcFlowEquationTerm {

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide2ReactiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/OpenBranchSide2ReactiveFlowEquationTerm.java
@@ -15,7 +15,7 @@ import net.jafama.FastMath;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class OpenBranchSide2ReactiveFlowEquationTerm extends AbstractOpenSide2BranchAcFlowEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ShuntCompensatorActiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ShuntCompensatorActiveFlowEquationTerm.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ShuntCompensatorActiveFlowEquationTerm extends AbstractShuntCompensatorEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/ShuntCompensatorReactiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/ShuntCompensatorReactiveFlowEquationTerm.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ShuntCompensatorReactiveFlowEquationTerm extends AbstractShuntCompensatorEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/asym/AbstractAsymmetricalBranchFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/asym/AbstractAsymmetricalBranchFlowEquationTerm.java
@@ -16,8 +16,8 @@ import com.powsybl.openloadflow.network.LfAsymLineAdmittanceMatrix;
 import com.powsybl.openloadflow.network.LfBranch;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at gmail.com>
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at gmail.com>}
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 abstract class AbstractAsymmetricalBranchFlowEquationTerm extends AbstractElementEquationTerm<LfBranch, AcVariableType, AcEquationType> {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/asym/AbstractAsymmetricalClosedBranchCoupledFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/asym/AbstractAsymmetricalClosedBranchCoupledFlowEquationTerm.java
@@ -24,8 +24,8 @@ import java.util.Objects;
 import static com.powsybl.openloadflow.network.PiModel.A2;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at gmail.com>
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at gmail.com>}
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 public abstract class AbstractAsymmetricalClosedBranchCoupledFlowEquationTerm extends AbstractAsymmetricalBranchFlowEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/asym/AbstractShuntFortescueCurrentEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/asym/AbstractShuntFortescueCurrentEquationTerm.java
@@ -17,7 +17,7 @@ import com.powsybl.openloadflow.util.Fortescue;
 import java.util.List;
 
 /**
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 public abstract class AbstractShuntFortescueCurrentEquationTerm extends AbstractShuntFortescueEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/asym/AbstractShuntFortescueEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/asym/AbstractShuntFortescueEquationTerm.java
@@ -19,8 +19,8 @@ import com.powsybl.openloadflow.util.Fortescue;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at gmail.com>
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at gmail.com>}
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 public abstract class AbstractShuntFortescueEquationTerm extends AbstractElementEquationTerm<LfBus, AcVariableType, AcEquationType> {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/asym/AsymmetricalAcEquationSystemCreator.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/asym/AsymmetricalAcEquationSystemCreator.java
@@ -16,8 +16,8 @@ import com.powsybl.openloadflow.util.ComplexPart;
 import com.powsybl.openloadflow.util.Fortescue.SequenceType;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at gmail.com>
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at gmail.com>}
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 public class AsymmetricalAcEquationSystemCreator extends AcEquationSystemCreator {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/asym/AsymmetricalClosedBranchCoupledCurrentEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/asym/AsymmetricalClosedBranchCoupledCurrentEquationTerm.java
@@ -39,7 +39,7 @@ import java.util.Objects;
  *           [ y_21_pz y_21_pp y_21_pn y_22_pz y_22_pp y_22_pn ]
  *           [ y_21_nz y_21_np y_21_nn y_22_nz y_22_np y_22_nn ]
  *
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 public class AsymmetricalClosedBranchCoupledCurrentEquationTerm extends AbstractAsymmetricalClosedBranchCoupledFlowEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/asym/AsymmetricalClosedBranchCoupledPowerEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/asym/AsymmetricalClosedBranchCoupledPowerEquationTerm.java
@@ -39,8 +39,8 @@ import java.util.Objects;
  *           [ y_21_pz y_21_pp y_21_pn y_22_pz y_22_pp y_22_pn ]
  *           [ y_21_nz y_21_np y_21_nn y_22_nz y_22_np y_22_nn ]
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at gmail.com>
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at gmail.com>}
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 public class AsymmetricalClosedBranchCoupledPowerEquationTerm extends AbstractAsymmetricalClosedBranchCoupledFlowEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/asym/LoadFortescuePowerEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/asym/LoadFortescuePowerEquationTerm.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 public class LoadFortescuePowerEquationTerm extends AbstractElementEquationTerm<LfBus, AcVariableType, AcEquationType> {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/asym/ShuntFortescueIxEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/asym/ShuntFortescueIxEquationTerm.java
@@ -18,7 +18,7 @@ import net.jafama.FastMath;
 import java.util.Objects;
 
 /**
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 public class ShuntFortescueIxEquationTerm extends AbstractShuntFortescueCurrentEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/asym/ShuntFortescueIyEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/asym/ShuntFortescueIyEquationTerm.java
@@ -18,7 +18,7 @@ import net.jafama.FastMath;
 import java.util.Objects;
 
 /**
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 public class ShuntFortescueIyEquationTerm extends AbstractShuntFortescueCurrentEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/DefaultNewtonRaphsonStoppingCriteria.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/DefaultNewtonRaphsonStoppingCriteria.java
@@ -13,7 +13,7 @@ import com.powsybl.openloadflow.equations.Vectors;
 import net.jafama.FastMath;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DefaultNewtonRaphsonStoppingCriteria implements NewtonRaphsonStoppingCriteria {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/LineSearchStateVectorScaling.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/LineSearchStateVectorScaling.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LineSearchStateVectorScaling implements StateVectorScaling {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/MaxVoltageChangeStateVectorScaling.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/MaxVoltageChangeStateVectorScaling.java
@@ -20,8 +20,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Limit voltage magnitude change and voltage angle change between NR iterations
  *
- * @author Damien Jeandemange <damien.jeandemange at artelys.com>
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class MaxVoltageChangeStateVectorScaling implements StateVectorScaling {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphson.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphson.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NewtonRaphson {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonParameters.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.ac.nr;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NewtonRaphsonParameters {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonResult.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonResult.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.ac.nr;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NewtonRaphsonResult {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonStatus.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonStatus.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.ac.nr;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum NewtonRaphsonStatus {
     CONVERGED,

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonStoppingCriteria.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonStoppingCriteria.java
@@ -11,7 +11,7 @@ import com.powsybl.openloadflow.ac.equations.AcVariableType;
 import com.powsybl.openloadflow.equations.EquationSystem;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface NewtonRaphsonStoppingCriteria {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonStoppingCriteriaType.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonStoppingCriteriaType.java
@@ -8,7 +8,7 @@
 package com.powsybl.openloadflow.ac.nr;
 
 /**
- * @author Alexandre Le Jean <alexandre.le-jean at artelys.com>
+ * @author Alexandre Le Jean {@literal <alexandre.le-jean at artelys.com>}
  */
 public enum NewtonRaphsonStoppingCriteriaType {
     UNIFORM_CRITERIA,

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/NoneStateVectorScaling.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/NoneStateVectorScaling.java
@@ -14,7 +14,7 @@ import com.powsybl.openloadflow.equations.EquationVector;
 import com.powsybl.openloadflow.equations.TargetVector;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NoneStateVectorScaling implements StateVectorScaling {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/PerEquationTypeStoppingCriteria.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/PerEquationTypeStoppingCriteria.java
@@ -15,7 +15,7 @@ import com.powsybl.openloadflow.equations.Vectors;
 import com.powsybl.openloadflow.util.PerUnit;
 
 /**
- * @author Alexandre Le Jean <alexandre.le-jean at artelys.com>
+ * @author Alexandre Le Jean {@literal <alexandre.le-jean at artelys.com>}
  */
 public class PerEquationTypeStoppingCriteria implements NewtonRaphsonStoppingCriteria {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/StateVectorScaling.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/StateVectorScaling.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 /**
  * State vector scaling.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface StateVectorScaling {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/nr/StateVectorScalingMode.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/nr/StateVectorScalingMode.java
@@ -8,7 +8,7 @@
 package com.powsybl.openloadflow.ac.nr;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum StateVectorScalingMode {
     NONE,

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/AbstractShuntVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/AbstractShuntVoltageControlOuterLoop.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.ac.outerloop;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 abstract class AbstractShuntVoltageControlOuterLoop implements AcOuterLoop {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/AbstractTransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/AbstractTransformerVoltageControlOuterLoop.java
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public abstract class AbstractTransformerVoltageControlOuterLoop implements AcOuterLoop {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcIncrementalPhaseControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcIncrementalPhaseControlOuterLoop.java
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AcIncrementalPhaseControlOuterLoop
         extends AbstractIncrementalPhaseControlOuterLoop<AcVariableType, AcEquationType, AcLoadFlowParameters, AcLoadFlowContext, AcOuterLoopContext>

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcOuterLoop.java
@@ -14,7 +14,7 @@ import com.powsybl.openloadflow.ac.equations.AcVariableType;
 import com.powsybl.openloadflow.lf.outerloop.OuterLoop;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface AcOuterLoop extends OuterLoop<AcVariableType, AcEquationType, AcLoadFlowParameters, AcLoadFlowContext, AcOuterLoopContext> {
 }

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/DistributedSlackOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/DistributedSlackOuterLoop.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DistributedSlackOuterLoop implements AcOuterLoop {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/IncrementalShuntVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/IncrementalShuntVoltageControlOuterLoop.java
@@ -28,8 +28,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * @author Hadrien Godard <hadrien.godard at artelys.com>
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Hadrien Godard {@literal <hadrien.godard at artelys.com>}
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class IncrementalShuntVoltageControlOuterLoop extends AbstractShuntVoltageControlOuterLoop {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/IncrementalTransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/IncrementalTransformerVoltageControlOuterLoop.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class IncrementalTransformerVoltageControlOuterLoop extends AbstractTransformerVoltageControlOuterLoop {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/MonitoringVoltageOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/MonitoringVoltageOuterLoop.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class MonitoringVoltageOuterLoop implements AcOuterLoop {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/PhaseControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/PhaseControlOuterLoop.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class PhaseControlOuterLoop
         extends AbstractPhaseControlOuterLoop<AcVariableType, AcEquationType, AcLoadFlowParameters, AcLoadFlowContext, AcOuterLoopContext>

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/ReactiveLimitsOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/ReactiveLimitsOuterLoop.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ReactiveLimitsOuterLoop implements AcOuterLoop {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/ShuntVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/ShuntVoltageControlOuterLoop.java
@@ -15,7 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class ShuntVoltageControlOuterLoop extends AbstractShuntVoltageControlOuterLoop {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/SimpleTransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/SimpleTransformerVoltageControlOuterLoop.java
@@ -13,7 +13,7 @@ import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.VoltageControl;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class SimpleTransformerVoltageControlOuterLoop extends AbstractTransformerVoltageControlOuterLoop {
 

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/TransformerVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/TransformerVoltageControlOuterLoop.java
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class TransformerVoltageControlOuterLoop extends AbstractTransformerVoltageControlOuterLoop {
 

--- a/src/main/java/com/powsybl/openloadflow/dc/DcIncrementalPhaseControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcIncrementalPhaseControlOuterLoop.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DcIncrementalPhaseControlOuterLoop
         extends AbstractIncrementalPhaseControlOuterLoop<DcVariableType, DcEquationType, DcLoadFlowParameters, DcLoadFlowContext, DcOuterLoopContext> {

--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowContext.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowContext.java
@@ -17,7 +17,7 @@ import com.powsybl.openloadflow.equations.TargetVector;
 import com.powsybl.openloadflow.network.LfNetwork;
 
 /**
- * @author Jean-Luc Bouchot (Artelys) <jlbouchot at gmail.com>
+ * @author Jean-Luc Bouchot (Artelys) {@literal <jlbouchot at gmail.com>}
  */
 public class DcLoadFlowContext extends AbstractLoadFlowContext<DcVariableType, DcEquationType, DcLoadFlowParameters> {
 

--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DcLoadFlowEngine implements LoadFlowEngine<DcVariableType, DcEquationType, DcLoadFlowParameters, DcLoadFlowResult> {
 

--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowParameters.java
@@ -15,7 +15,7 @@ import com.powsybl.openloadflow.network.LfNetworkParameters;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DcLoadFlowParameters extends AbstractLoadFlowParameters {
 

--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowResult.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowResult.java
@@ -10,7 +10,7 @@ import com.powsybl.openloadflow.lf.AbstractLoadFlowResult;
 import com.powsybl.openloadflow.network.LfNetwork;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DcLoadFlowResult extends AbstractLoadFlowResult {
 

--- a/src/main/java/com/powsybl/openloadflow/dc/DcOuterLoopContext.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcOuterLoopContext.java
@@ -12,7 +12,7 @@ import com.powsybl.openloadflow.lf.outerloop.AbstractOuterLoopContext;
 import com.powsybl.openloadflow.network.LfNetwork;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DcOuterLoopContext extends AbstractOuterLoopContext<DcVariableType, DcEquationType, DcLoadFlowParameters, DcLoadFlowContext> {
 

--- a/src/main/java/com/powsybl/openloadflow/dc/DcTargetVector.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcTargetVector.java
@@ -16,7 +16,7 @@ import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.LfNetwork;
 
 /**
- * @author Jean-Luc Bouchot (Artelys) <jlbouchot at gmail.com>
+ * @author Jean-Luc Bouchot (Artelys) {@literal <jlbouchot at gmail.com>}
  */
 public class DcTargetVector extends TargetVector<DcVariableType, DcEquationType> {
 

--- a/src/main/java/com/powsybl/openloadflow/dc/DcValueVoltageInitializer.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcValueVoltageInitializer.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DcValueVoltageInitializer implements VoltageInitializer {
 

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 import static com.powsybl.openloadflow.network.PiModel.R2;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractClosedBranchDcFlowEquationTerm extends AbstractElementEquationTerm<LfBranch, DcVariableType, DcEquationType> {
 

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide1DcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide1DcFlowEquationTerm.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 import static com.powsybl.openloadflow.network.PiModel.A2;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class ClosedBranchSide1DcFlowEquationTerm extends AbstractClosedBranchDcFlowEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide2DcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide2DcFlowEquationTerm.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 import static com.powsybl.openloadflow.network.PiModel.A2;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class ClosedBranchSide2DcFlowEquationTerm extends AbstractClosedBranchDcFlowEquationTerm {
 

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/DcApproximationType.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/DcApproximationType.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.dc.equations;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum DcApproximationType {
     IGNORE_R,

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationSystemCreationParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationSystemCreationParameters.java
@@ -11,7 +11,7 @@ import com.powsybl.loadflow.LoadFlowParameters;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DcEquationSystemCreationParameters {
 

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationSystemCreator.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationSystemCreator.java
@@ -15,7 +15,7 @@ import com.powsybl.openloadflow.util.EvaluableConstants;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DcEquationSystemCreator {
 

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationSystemUpdater.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationSystemUpdater.java
@@ -14,7 +14,7 @@ import com.powsybl.openloadflow.network.LfElement;
 import com.powsybl.openloadflow.network.LoadFlowModel;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class DcEquationSystemUpdater extends AbstractEquationSystemUpdater<DcVariableType, DcEquationType> {
 

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationType.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationType.java
@@ -10,7 +10,7 @@ import com.powsybl.openloadflow.equations.Quantity;
 import com.powsybl.openloadflow.network.ElementType;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum DcEquationType implements Quantity {
     BUS_TARGET_P("bus_target_p", ElementType.BUS), // bus active power target

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/DcVariableType.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/DcVariableType.java
@@ -10,7 +10,7 @@ import com.powsybl.openloadflow.equations.Quantity;
 import com.powsybl.openloadflow.network.ElementType;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum DcVariableType implements Quantity {
     BUS_PHI("\u03C6", ElementType.BUS), // bus voltage angle

--- a/src/main/java/com/powsybl/openloadflow/equations/AbstractElementEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/AbstractElementEquationTerm.java
@@ -12,7 +12,7 @@ import com.powsybl.openloadflow.network.LfElement;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractElementEquationTerm<T extends LfElement, V extends Enum<V> & Quantity, E extends Enum<E> & Quantity> extends AbstractNamedEquationTerm<V, E> {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/AbstractEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/AbstractEquationTerm.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractEquationTerm<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity> implements EquationTerm<V, E> {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/AbstractNamedEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/AbstractNamedEquationTerm.java
@@ -11,7 +11,7 @@ import java.io.Writer;
 import java.util.Iterator;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractNamedEquationTerm<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity> extends AbstractEquationTerm<V, E> {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/AbstractVector.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/AbstractVector.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.equations;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractVector<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity> implements Vector {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/Equation.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/Equation.java
@@ -17,7 +17,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class Equation<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity> implements Evaluable, Comparable<Equation<V, E>> {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationEventType.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationEventType.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.equations;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum EquationEventType {
     EQUATION_CREATED,

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationSystem.java
@@ -20,7 +20,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class EquationSystem<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity> {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationSystemIndex.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationSystemIndex.java
@@ -14,7 +14,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class EquationSystemIndex<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity>
         implements EquationSystemListener<V, E> {

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationSystemIndexListener.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationSystemIndexListener.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.equations;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface EquationSystemIndexListener<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity> {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationSystemListener.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationSystemListener.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.equations;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface EquationSystemListener<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity> {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationSystemPostProcessor.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationSystemPostProcessor.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.ServiceLoader;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface EquationSystemPostProcessor {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationTerm.java
@@ -20,7 +20,7 @@ import java.util.function.DoubleSupplier;
 /**
  * An equation term, i.e part of the equation sum.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface EquationTerm<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity> extends Evaluable {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationTermEventType.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationTermEventType.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.equations;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum EquationTermEventType {
     EQUATION_TERM_ADDED,

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationVector.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationVector.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 import static com.powsybl.openloadflow.util.Markers.PERFORMANCE_MARKER;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class EquationVector<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity> extends AbstractVector<V, E>
         implements StateVectorListener, AutoCloseable {

--- a/src/main/java/com/powsybl/openloadflow/equations/JacobianMatrix.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/JacobianMatrix.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 import static com.powsybl.openloadflow.util.Markers.PERFORMANCE_MARKER;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class JacobianMatrix<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity>
         implements EquationSystemIndexListener<V, E>, StateVectorListener, AutoCloseable {

--- a/src/main/java/com/powsybl/openloadflow/equations/Quantity.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/Quantity.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.equations;
 import com.powsybl.openloadflow.network.ElementType;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface Quantity {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/StateVector.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/StateVector.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class StateVector {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/StateVectorListener.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/StateVectorListener.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.equations;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface StateVectorListener {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/TargetVector.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/TargetVector.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class TargetVector<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity> extends AbstractVector<V, E> implements AutoCloseable {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/Variable.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/Variable.java
@@ -11,7 +11,7 @@ import java.io.Writer;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class Variable<V extends Enum<V> & Quantity> implements Comparable<Variable<V>> {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/VariableEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/VariableEquationTerm.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class VariableEquationTerm<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity> extends AbstractEquationTerm<V, E> {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/VariableSet.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/VariableSet.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class VariableSet<V extends Enum<V> & Quantity> {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/Vector.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/Vector.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.equations;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface Vector {
 

--- a/src/main/java/com/powsybl/openloadflow/equations/Vectors.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/Vectors.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.equations;
 import net.jafama.FastMath;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class Vectors {
 

--- a/src/main/java/com/powsybl/openloadflow/graph/AbstractEdgeModification.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/AbstractEdgeModification.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.graph;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public abstract class AbstractEdgeModification<V, E> implements GraphModification<V, E> {
     protected final E e;

--- a/src/main/java/com/powsybl/openloadflow/graph/AbstractGraphConnectivity.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/AbstractGraphConnectivity.java
@@ -14,7 +14,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public abstract class AbstractGraphConnectivity<V, E> implements GraphConnectivity<V, E> {
 

--- a/src/main/java/com/powsybl/openloadflow/graph/BridgesFinder.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/BridgesFinder.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 import java.util.function.ToIntFunction;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class BridgesFinder<V> {
 

--- a/src/main/java/com/powsybl/openloadflow/graph/EdgeAdd.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/EdgeAdd.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.graph;
 import org.jgrapht.Graph;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class EdgeAdd<V, E> extends AbstractEdgeModification<V, E> {
     public EdgeAdd(V vertex1, V vertex2, E e) {

--- a/src/main/java/com/powsybl/openloadflow/graph/EdgeRemove.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/EdgeRemove.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.graph;
 import org.jgrapht.Graph;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class EdgeRemove<V, E> extends AbstractEdgeModification<V, E> {
 

--- a/src/main/java/com/powsybl/openloadflow/graph/EvenShiloachGraphDecrementalConnectivity.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/EvenShiloachGraphDecrementalConnectivity.java
@@ -17,8 +17,8 @@ import java.util.stream.Collectors;
  * Due to time computation optimizations, this current implementation is only for graphs which initially have ONLY ONE
  * connected component. If more, an exception is thrown.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class EvenShiloachGraphDecrementalConnectivity<V, E> extends AbstractGraphConnectivity<V, E> {
 

--- a/src/main/java/com/powsybl/openloadflow/graph/EvenShiloachGraphDecrementalConnectivityFactory.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/EvenShiloachGraphDecrementalConnectivityFactory.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.graph;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class EvenShiloachGraphDecrementalConnectivityFactory<V, E> implements GraphConnectivityFactory<V, E> {
 

--- a/src/main/java/com/powsybl/openloadflow/graph/GraphConnectivity.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/GraphConnectivity.java
@@ -31,8 +31,8 @@ import java.util.Set;
  *     connectivity.undoTemporaryChanges();
  * </pre>
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public interface GraphConnectivity<V, E> {
 

--- a/src/main/java/com/powsybl/openloadflow/graph/GraphConnectivityFactory.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/GraphConnectivityFactory.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.graph;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface GraphConnectivityFactory<V, E> {
 

--- a/src/main/java/com/powsybl/openloadflow/graph/GraphModification.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/GraphModification.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.graph;
 import org.jgrapht.Graph;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public interface GraphModification<V, E> {
     void apply(Graph<V, E> graph);

--- a/src/main/java/com/powsybl/openloadflow/graph/MinimumSpanningTreeGraphConnectivity.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/MinimumSpanningTreeGraphConnectivity.java
@@ -14,7 +14,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class MinimumSpanningTreeGraphConnectivity<V, E> extends AbstractGraphConnectivity<V, E> {
 

--- a/src/main/java/com/powsybl/openloadflow/graph/MinimumSpanningTreeGraphConnectivityFactory.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/MinimumSpanningTreeGraphConnectivityFactory.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.graph;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class MinimumSpanningTreeGraphConnectivityFactory<V, E> implements GraphConnectivityFactory<V, E> {
 

--- a/src/main/java/com/powsybl/openloadflow/graph/ModificationsContext.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/ModificationsContext.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class ModificationsContext<V, E> {
 

--- a/src/main/java/com/powsybl/openloadflow/graph/NaiveGraphConnectivity.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/NaiveGraphConnectivity.java
@@ -16,7 +16,7 @@ import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NaiveGraphConnectivity<V, E> extends AbstractGraphConnectivity<V, E> {
 

--- a/src/main/java/com/powsybl/openloadflow/graph/NaiveGraphConnectivityFactory.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/NaiveGraphConnectivityFactory.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import java.util.function.ToIntFunction;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NaiveGraphConnectivityFactory<V, E> implements GraphConnectivityFactory<V, E> {
 

--- a/src/main/java/com/powsybl/openloadflow/graph/VertexAdd.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/VertexAdd.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.graph;
 import org.jgrapht.Graph;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class VertexAdd<V, E> implements GraphModification<V, E> {
     protected final V v;

--- a/src/main/java/com/powsybl/openloadflow/lf/AbstractEquationSystemUpdater.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/AbstractEquationSystemUpdater.java
@@ -15,7 +15,7 @@ import com.powsybl.openloadflow.network.*;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractEquationSystemUpdater<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity> extends AbstractLfNetworkListener {
 

--- a/src/main/java/com/powsybl/openloadflow/lf/AbstractLoadFlowContext.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/AbstractLoadFlowContext.java
@@ -15,7 +15,7 @@ import com.powsybl.openloadflow.network.LfNetwork;
 import java.util.Objects;
 
 /**
- * @author Jean-Luc Bouchot (Artelys) <jlbouchot at gmail.com>
+ * @author Jean-Luc Bouchot (Artelys) {@literal <jlbouchot at gmail.com>}
  */
 public abstract class AbstractLoadFlowContext <V extends Enum<V> & Quantity, E extends Enum<E> & Quantity, P extends AbstractLoadFlowParameters>
         implements LoadFlowContext<V, E, P>, AutoCloseable {

--- a/src/main/java/com/powsybl/openloadflow/lf/AbstractLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/AbstractLoadFlowParameters.java
@@ -13,7 +13,7 @@ import com.powsybl.openloadflow.network.LfNetworkParameters;
 import java.util.Objects;
 
 /**
- * @author Jean-Luc Bouchot (Artelys) <jlbouchot at gmail.com>
+ * @author Jean-Luc Bouchot (Artelys) {@literal <jlbouchot at gmail.com>}
  */
 public abstract class AbstractLoadFlowParameters {
 

--- a/src/main/java/com/powsybl/openloadflow/lf/AbstractLoadFlowResult.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/AbstractLoadFlowResult.java
@@ -12,7 +12,7 @@ import com.powsybl.openloadflow.network.LfNetwork;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractLoadFlowResult implements LoadFlowResult {
 

--- a/src/main/java/com/powsybl/openloadflow/lf/LoadFlowContext.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/LoadFlowContext.java
@@ -14,7 +14,7 @@ import com.powsybl.openloadflow.equations.TargetVector;
 import com.powsybl.openloadflow.network.LfNetwork;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LoadFlowContext<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity, P extends AbstractLoadFlowParameters> extends AutoCloseable {
 

--- a/src/main/java/com/powsybl/openloadflow/lf/LoadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/LoadFlowEngine.java
@@ -10,7 +10,7 @@ package com.powsybl.openloadflow.lf;
 import com.powsybl.openloadflow.equations.Quantity;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LoadFlowEngine<V extends Enum<V> & Quantity,
                                 E extends Enum<E> & Quantity,

--- a/src/main/java/com/powsybl/openloadflow/lf/LoadFlowResult.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/LoadFlowResult.java
@@ -10,7 +10,7 @@ package com.powsybl.openloadflow.lf;
 import com.powsybl.openloadflow.network.LfNetwork;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LoadFlowResult {
 

--- a/src/main/java/com/powsybl/openloadflow/lf/outerloop/AbstractIncrementalPhaseControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/outerloop/AbstractIncrementalPhaseControlOuterLoop.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractIncrementalPhaseControlOuterLoop<V extends Enum<V> & Quantity,
                                                                E extends Enum<E> & Quantity,

--- a/src/main/java/com/powsybl/openloadflow/lf/outerloop/AbstractOuterLoopContext.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/outerloop/AbstractOuterLoopContext.java
@@ -14,7 +14,7 @@ import com.powsybl.openloadflow.network.LfNetwork;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractOuterLoopContext<V extends Enum<V> & Quantity,
                                                E extends Enum<E> & Quantity,

--- a/src/main/java/com/powsybl/openloadflow/lf/outerloop/AbstractPhaseControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/outerloop/AbstractPhaseControlOuterLoop.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractPhaseControlOuterLoop<V extends Enum<V> & Quantity,
                                                     E extends Enum<E> & Quantity,

--- a/src/main/java/com/powsybl/openloadflow/lf/outerloop/DistributedSlackContextData.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/outerloop/DistributedSlackContextData.java
@@ -10,7 +10,7 @@ package com.powsybl.openloadflow.lf.outerloop;
 /**
  * Keeps track of distributed active power
  *
- * @author Damien Jeandemange <damien.jeandemange at artelys.com>
+ * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
  */
 public class DistributedSlackContextData {
     private double distributedActivePower = 0.0;

--- a/src/main/java/com/powsybl/openloadflow/lf/outerloop/IncrementalContextData.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/outerloop/IncrementalContextData.java
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class IncrementalContextData {
 

--- a/src/main/java/com/powsybl/openloadflow/lf/outerloop/OuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/outerloop/OuterLoop.java
@@ -12,7 +12,7 @@ import com.powsybl.openloadflow.lf.AbstractLoadFlowParameters;
 import com.powsybl.openloadflow.lf.LoadFlowContext;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface OuterLoop<V extends Enum<V> & Quantity,
                            E extends Enum<E> & Quantity,

--- a/src/main/java/com/powsybl/openloadflow/lf/outerloop/OuterLoopContext.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/outerloop/OuterLoopContext.java
@@ -12,7 +12,7 @@ import com.powsybl.openloadflow.lf.LoadFlowContext;
 import com.powsybl.openloadflow.network.LfNetwork;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface OuterLoopContext<V extends Enum<V> & Quantity,
                                   E extends Enum<E> & Quantity,

--- a/src/main/java/com/powsybl/openloadflow/lf/outerloop/OuterLoopStatus.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/outerloop/OuterLoopStatus.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.lf.outerloop;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum OuterLoopStatus {
     STABLE,

--- a/src/main/java/com/powsybl/openloadflow/network/AbstractElement.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractElement.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractElement extends AbstractPropertyBag implements LfElement {
 

--- a/src/main/java/com/powsybl/openloadflow/network/AbstractLfNetworkListener.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractLfNetworkListener.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractLfNetworkListener implements LfNetworkListener {
 

--- a/src/main/java/com/powsybl/openloadflow/network/AbstractLfNetworkLoaderPostProcessor.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractLfNetworkLoaderPostProcessor.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractLfNetworkLoaderPostProcessor implements LfNetworkLoaderPostProcessor {
 

--- a/src/main/java/com/powsybl/openloadflow/network/AbstractLfShunt.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractLfShunt.java
@@ -10,7 +10,7 @@ import com.powsybl.openloadflow.util.Evaluable;
 import com.powsybl.openloadflow.util.EvaluableConstants;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractLfShunt extends AbstractElement implements LfShunt {
 

--- a/src/main/java/com/powsybl/openloadflow/network/AbstractPropertyBag.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractPropertyBag.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractPropertyBag {
 

--- a/src/main/java/com/powsybl/openloadflow/network/AbstractSlackBusSelector.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractSlackBusSelector.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractSlackBusSelector implements SlackBusSelector {
 

--- a/src/main/java/com/powsybl/openloadflow/network/AdmittanceShift.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AdmittanceShift.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AdmittanceShift {
 

--- a/src/main/java/com/powsybl/openloadflow/network/AllowedDirection.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AllowedDirection.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public enum AllowedDirection {
     INCREASE,

--- a/src/main/java/com/powsybl/openloadflow/network/BranchState.java
+++ b/src/main/java/com/powsybl/openloadflow/network/BranchState.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Gael Macherel <gael.macherel at artelys.com>
+ * @author Gael Macherel {@literal <gael.macherel at artelys.com>}
  */
 public class BranchState extends ElementState<LfBranch> {
 

--- a/src/main/java/com/powsybl/openloadflow/network/BusDcState.java
+++ b/src/main/java/com/powsybl/openloadflow/network/BusDcState.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class BusDcState extends ElementState<LfBus> {
 

--- a/src/main/java/com/powsybl/openloadflow/network/BusState.java
+++ b/src/main/java/com/powsybl/openloadflow/network/BusState.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class BusState extends BusDcState {
 

--- a/src/main/java/com/powsybl/openloadflow/network/Control.java
+++ b/src/main/java/com/powsybl/openloadflow/network/Control.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class Control {
 

--- a/src/main/java/com/powsybl/openloadflow/network/ControlledSide.java
+++ b/src/main/java/com/powsybl/openloadflow/network/ControlledSide.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum ControlledSide {
     ONE,

--- a/src/main/java/com/powsybl/openloadflow/network/Direction.java
+++ b/src/main/java/com/powsybl/openloadflow/network/Direction.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public enum Direction {
     INCREASE(AllowedDirection.INCREASE),

--- a/src/main/java/com/powsybl/openloadflow/network/DisabledNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/DisabledNetwork.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class DisabledNetwork {
 

--- a/src/main/java/com/powsybl/openloadflow/network/DiscreteVoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/DiscreteVoltageControl.java
@@ -9,8 +9,8 @@ package com.powsybl.openloadflow.network;
 import java.util.Optional;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class DiscreteVoltageControl<T extends LfElement> extends VoltageControl<T> {
 

--- a/src/main/java/com/powsybl/openloadflow/network/ElementState.java
+++ b/src/main/java/com/powsybl/openloadflow/network/ElementState.java
@@ -13,7 +13,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ElementState<T extends LfElement> {
 

--- a/src/main/java/com/powsybl/openloadflow/network/ElementType.java
+++ b/src/main/java/com/powsybl/openloadflow/network/ElementType.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum ElementType {
     BUS,

--- a/src/main/java/com/powsybl/openloadflow/network/FirstSlackBusSelector.java
+++ b/src/main/java/com/powsybl/openloadflow/network/FirstSlackBusSelector.java
@@ -14,7 +14,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class FirstSlackBusSelector extends AbstractSlackBusSelector {
 

--- a/src/main/java/com/powsybl/openloadflow/network/GeneratorVoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/GeneratorVoltageControl.java
@@ -12,8 +12,8 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class GeneratorVoltageControl extends VoltageControl<LfBus> {
 

--- a/src/main/java/com/powsybl/openloadflow/network/GraphVizGraphBuilder.java
+++ b/src/main/java/com/powsybl/openloadflow/network/GraphVizGraphBuilder.java
@@ -13,7 +13,7 @@ import java.util.Locale;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class GraphVizGraphBuilder {
 

--- a/src/main/java/com/powsybl/openloadflow/network/HvdcState.java
+++ b/src/main/java/com/powsybl/openloadflow/network/HvdcState.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class HvdcState extends ElementState<LfHvdc> {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LargestGeneratorSlackBusSelector.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LargestGeneratorSlackBusSelector.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LargestGeneratorSlackBusSelector extends AbstractSlackBusSelector {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfAction.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfAction.java
@@ -19,8 +19,8 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
- * @author Jean-Luc Bouchot (Artelys) <jlbouchot at gmail.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
+ * @author Jean-Luc Bouchot (Artelys) {@literal <jlbouchot at gmail.com>}
  */
 public final class LfAction {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfAsymBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfAsymBus.java
@@ -14,7 +14,7 @@ import com.powsybl.openloadflow.util.EvaluableConstants;
 import java.util.Objects;
 
 /**
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 public class LfAsymBus {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfAsymGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfAsymGenerator.java
@@ -9,7 +9,7 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 public class LfAsymGenerator {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfAsymLine.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfAsymLine.java
@@ -14,7 +14,7 @@ import java.util.Objects;
  * This is an extension to a LfBranch Line to describe the asymmetry of a line to be used for an
  * unbalanced load flow.
  *
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 public class LfAsymLine {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfAsymLineAdmittanceMatrix.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfAsymLineAdmittanceMatrix.java
@@ -86,7 +86,7 @@ import com.powsybl.openloadflow.util.MatrixUtil;
  *           [ y_21_pz y_21_pp y_21_pn y_22_pz y_22_pp y_22_pn ]
  *           [ y_21_nz y_21_np y_21_nn y_22_nz y_22_np y_22_nn ]
  *
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 public class LfAsymLineAdmittanceMatrix {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LfBranch extends LfElement {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBus.java
@@ -13,7 +13,7 @@ import com.powsybl.security.results.BusResult;
 import java.util.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LfBus extends LfElement {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfContingency.java
@@ -17,7 +17,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfContingency {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfElement.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfElement.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LfElement extends PropertyBag {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfGenerator.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import java.util.OptionalDouble;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LfGenerator extends PropertyBag {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfHvdc.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfHvdc.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import com.powsybl.openloadflow.util.Evaluable;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public interface LfHvdc extends LfElement {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfLoad.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfLoad.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public interface LfLoad extends PropertyBag {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfLoadModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfLoadModel.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 /**
  * Generic load model as a sum of exponential terms: sum_i(ci * v^ni)
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfLoadModel {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfLostLoad.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfLostLoad.java
@@ -13,7 +13,7 @@ import java.util.Set;
  * A LfLoad is an aggregation of several classical network loads. The loss of a network load is modeled by a power
  * shift, that is a partial shift of the full LfLoad.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfLostLoad {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 import static com.powsybl.openloadflow.util.Markers.PERFORMANCE_MARKER;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfNetwork extends AbstractPropertyBag implements PropertyBag {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetworkListener.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetworkListener.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LfNetworkListener {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetworkListenerTracer.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetworkListenerTracer.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfNetworkListenerTracer implements LfNetworkListener {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetworkLoader.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetworkLoader.java
@@ -11,7 +11,7 @@ import com.powsybl.commons.reporter.Reporter;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LfNetworkLoader<T> {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetworkLoaderPostProcessor.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetworkLoaderPostProcessor.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.ServiceLoader;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LfNetworkLoaderPostProcessor {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetworkParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetworkParameters.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfNetworkParameters {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetworkStateUpdateParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetworkStateUpdateParameters.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfNetworkStateUpdateParameters {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfSecondaryVoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfSecondaryVoltageControl.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfSecondaryVoltageControl {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfShunt.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfShunt.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LfShunt extends LfElement {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfStandbyAutomatonShunt.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfStandbyAutomatonShunt.java
@@ -14,8 +14,8 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public final class LfStandbyAutomatonShunt extends AbstractLfShunt {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfStaticVarCompensator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfStaticVarCompensator.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LfStaticVarCompensator extends LfGenerator {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfTopoConfig.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfTopoConfig.java
@@ -12,7 +12,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfTopoConfig {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfVscConverterStation.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfVscConverterStation.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LfVscConverterStation extends LfGenerator {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfZeroImpedanceNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfZeroImpedanceNetwork.java
@@ -17,7 +17,7 @@ import org.jgrapht.graph.Pseudograph;
 import java.util.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfZeroImpedanceNetwork {
 

--- a/src/main/java/com/powsybl/openloadflow/network/LinePerUnitMode.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LinePerUnitMode.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum LinePerUnitMode {
     RATIO,

--- a/src/main/java/com/powsybl/openloadflow/network/LoadFlowModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LoadFlowModel.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum LoadFlowModel {
     AC,

--- a/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
+++ b/src/main/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelector.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class MostMeshedSlackBusSelector extends AbstractSlackBusSelector {
 

--- a/src/main/java/com/powsybl/openloadflow/network/NameSlackBusSelector.java
+++ b/src/main/java/com/powsybl/openloadflow/network/NameSlackBusSelector.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NameSlackBusSelector extends AbstractSlackBusSelector {
 

--- a/src/main/java/com/powsybl/openloadflow/network/NetworkSlackBusSelector.java
+++ b/src/main/java/com/powsybl/openloadflow/network/NetworkSlackBusSelector.java
@@ -19,7 +19,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class NetworkSlackBusSelector extends AbstractSlackBusSelector {
 

--- a/src/main/java/com/powsybl/openloadflow/network/NetworkState.java
+++ b/src/main/java/com/powsybl/openloadflow/network/NetworkState.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NetworkState {
 

--- a/src/main/java/com/powsybl/openloadflow/network/PiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModel.java
@@ -11,7 +11,7 @@ import org.apache.commons.lang3.Range;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface PiModel {
 

--- a/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 import java.util.function.ToDoubleFunction;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class PiModelArray implements PiModel {
 

--- a/src/main/java/com/powsybl/openloadflow/network/PlausibleValues.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PlausibleValues.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 /**
  * Network related plausible values.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class PlausibleValues {
 

--- a/src/main/java/com/powsybl/openloadflow/network/PowerShift.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PowerShift.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class PowerShift {
 

--- a/src/main/java/com/powsybl/openloadflow/network/PropertyBag.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PropertyBag.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface PropertyBag {
 

--- a/src/main/java/com/powsybl/openloadflow/network/ReactivePowerControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/ReactivePowerControl.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import java.util.Objects;
 
 /**
- * @author Bertrand Rix <bertrand.rix at artelys.com>
+ * @author Bertrand Rix {@literal <bertrand.rix at artelys.com>}
  */
 public class ReactivePowerControl extends Control {
 

--- a/src/main/java/com/powsybl/openloadflow/network/ReactivePowerDispatchMode.java
+++ b/src/main/java/com/powsybl/openloadflow/network/ReactivePowerDispatchMode.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum ReactivePowerDispatchMode {
     Q_EQUAL_PROPORTION,

--- a/src/main/java/com/powsybl/openloadflow/network/SelectedSlackBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/SelectedSlackBus.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SelectedSlackBus {
 

--- a/src/main/java/com/powsybl/openloadflow/network/ShuntVoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/ShuntVoltageControl.java
@@ -7,8 +7,8 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class ShuntVoltageControl extends DiscreteVoltageControl<LfShunt> {
 

--- a/src/main/java/com/powsybl/openloadflow/network/Side.java
+++ b/src/main/java/com/powsybl/openloadflow/network/Side.java
@@ -9,7 +9,7 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum Side {
     ONE(1),

--- a/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
+++ b/src/main/java/com/powsybl/openloadflow/network/SimplePiModel.java
@@ -12,7 +12,7 @@ import org.apache.commons.lang3.Range;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SimplePiModel implements PiModel {
 

--- a/src/main/java/com/powsybl/openloadflow/network/SlackBusSelectionMode.java
+++ b/src/main/java/com/powsybl/openloadflow/network/SlackBusSelectionMode.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum SlackBusSelectionMode {
     FIRST,

--- a/src/main/java/com/powsybl/openloadflow/network/SlackBusSelector.java
+++ b/src/main/java/com/powsybl/openloadflow/network/SlackBusSelector.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface SlackBusSelector {
 

--- a/src/main/java/com/powsybl/openloadflow/network/TransformerPhaseControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/TransformerPhaseControl.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class TransformerPhaseControl extends Control {
 

--- a/src/main/java/com/powsybl/openloadflow/network/TransformerVoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/TransformerVoltageControl.java
@@ -7,8 +7,8 @@
 package com.powsybl.openloadflow.network;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class TransformerVoltageControl extends DiscreteVoltageControl<LfBranch> {
 

--- a/src/main/java/com/powsybl/openloadflow/network/VoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/VoltageControl.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import java.util.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class VoltageControl<T extends LfElement> extends Control {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractImpedantLfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractImpedantLfBranch.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 import static com.powsybl.openloadflow.util.EvaluableConstants.NAN;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractImpedantLfBranch extends AbstractLfBranch {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractLfBranch extends AbstractElement implements LfBranch {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 import static com.powsybl.openloadflow.util.EvaluableConstants.NAN;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractLfBus extends AbstractElement implements LfBus {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractLfGenerator extends AbstractLfInjection implements LfGenerator {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfInjection.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfInjection.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network.impl;
 import com.powsybl.openloadflow.network.AbstractPropertyBag;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractLfInjection extends AbstractPropertyBag {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/ContingencyTripping.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/ContingencyTripping.java
@@ -13,7 +13,7 @@ import com.powsybl.math.graph.TraverseResult;
 import java.util.*;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class ContingencyTripping {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class HvdcConverterStations {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBatteryImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBatteryImpl.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class LfBatteryImpl extends AbstractLfGenerator {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfBranchImpl extends AbstractImpedantLfBranch {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfBusImpl extends AbstractLfBus {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfDanglingLineBranch extends AbstractImpedantLfBranch {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBus.java
@@ -14,7 +14,7 @@ import com.powsybl.openloadflow.network.LfNetworkStateUpdateParameters;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfDanglingLineBus extends AbstractLfBus {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineGenerator.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class LfDanglingLineGenerator extends AbstractLfGenerator {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class LfGeneratorImpl extends AbstractLfGenerator {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfHvdcImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfHvdcImpl.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 import static com.powsybl.openloadflow.util.EvaluableConstants.NAN;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class LfHvdcImpl extends AbstractElement implements LfHvdc {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
@@ -16,7 +16,7 @@ import com.powsybl.security.results.ThreeWindingsTransformerResult;
 import java.util.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class LfLegBranch extends AbstractImpedantLfBranch {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLoadImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLoadImpl.java
@@ -19,7 +19,7 @@ import java.util.*;
 import java.util.stream.Stream;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class LfLoadImpl extends AbstractLfInjection implements LfLoad {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkList.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkList.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfNetworkList implements AutoCloseable {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -36,7 +36,7 @@ import static com.powsybl.openloadflow.util.DebugUtil.DATE_TIME_FORMAT;
 import static com.powsybl.openloadflow.util.Markers.PERFORMANCE_MARKER;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoadingReport.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoadingReport.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.network.impl;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfNetworkLoadingReport {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfShuntImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfShuntImpl.java
@@ -18,8 +18,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class LfShuntImpl extends AbstractLfShunt {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfStarBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfStarBus.java
@@ -14,7 +14,7 @@ import com.powsybl.openloadflow.network.LfNetworkStateUpdateParameters;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfStarBus extends AbstractLfBus {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfStaticVarCompensatorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfStaticVarCompensatorImpl.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class LfStaticVarCompensatorImpl extends AbstractLfGenerator implements LfStaticVarCompensator {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfSwitch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfSwitch.java
@@ -19,7 +19,7 @@ import java.util.List;
 import static com.powsybl.openloadflow.util.EvaluableConstants.NAN;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfSwitch extends AbstractLfBranch {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfTieLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfTieLineBranch.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfTieLineBranch extends AbstractImpedantLfBranch {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfVscConverterStationImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfVscConverterStationImpl.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LfVscConverterStationImpl extends AbstractLfGenerator implements LfVscConverterStation {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
@@ -14,7 +14,7 @@ import com.powsybl.openloadflow.network.*;
 import java.util.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class Networks {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/NodeBreakerTraverser.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/NodeBreakerTraverser.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 public class NodeBreakerTraverser implements VoltageLevel.NodeBreakerView.TopologyTraverser {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/OlfBranchResult.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/OlfBranchResult.java
@@ -10,7 +10,7 @@ import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.security.results.BranchResult;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class OlfBranchResult extends AbstractExtension<BranchResult> {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/OlfThreeWindingsTransformerResult.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/OlfThreeWindingsTransformerResult.java
@@ -10,7 +10,7 @@ import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.security.results.ThreeWindingsTransformerResult;
 
 /**
- * @author Bertrand Rix <bertrand.rix at artelys.com>
+ * @author Bertrand Rix {@literal <bertrand.rix at artelys.com>}
  */
 public class OlfThreeWindingsTransformerResult extends AbstractExtension<ThreeWindingsTransformerResult> {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/PropagatedContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/PropagatedContingency.java
@@ -22,8 +22,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Gaël Macherel <gael.macherel@artelys.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Gaël Macherel {@literal <gael.macherel@artelys.com>}
  */
 public class PropagatedContingency {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/Ref.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/Ref.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.network.impl;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface Ref<T> {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/StrongRef.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/StrongRef.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network.impl;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class StrongRef<T> implements Ref<T> {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/Transformers.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/Transformers.java
@@ -14,8 +14,8 @@ import java.util.Objects;
 import java.util.OptionalInt;
 
 /**
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public final class Transformers {
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/WeakRef.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/WeakRef.java
@@ -10,7 +10,7 @@ import java.lang.ref.WeakReference;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class WeakRef<T> implements Ref<T> {
 

--- a/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class ActivePowerDistribution {
 

--- a/src/main/java/com/powsybl/openloadflow/network/util/GenerationActivePowerDistributionStep.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/GenerationActivePowerDistributionStep.java
@@ -19,8 +19,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Caio Luke <caio.luke at artelys.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Caio Luke {@literal <caio.luke at artelys.com>}
  */
 public class GenerationActivePowerDistributionStep implements ActivePowerDistribution.Step {
 

--- a/src/main/java/com/powsybl/openloadflow/network/util/LoadActivePowerDistributionStep.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/LoadActivePowerDistributionStep.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class LoadActivePowerDistributionStep implements ActivePowerDistribution.Step {
 

--- a/src/main/java/com/powsybl/openloadflow/network/util/ParticipatingElement.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ParticipatingElement.java
@@ -13,7 +13,7 @@ import com.powsybl.openloadflow.network.LfLoad;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ParticipatingElement {
 

--- a/src/main/java/com/powsybl/openloadflow/network/util/PreviousValueVoltageInitializer.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/PreviousValueVoltageInitializer.java
@@ -11,7 +11,7 @@ import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.network.LfNetwork;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class PreviousValueVoltageInitializer implements VoltageInitializer {
 

--- a/src/main/java/com/powsybl/openloadflow/network/util/UniformValueVoltageInitializer.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/UniformValueVoltageInitializer.java
@@ -10,7 +10,7 @@ import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.network.LfNetwork;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class UniformValueVoltageInitializer implements VoltageInitializer {
 

--- a/src/main/java/com/powsybl/openloadflow/network/util/VoltageInitializer.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/VoltageInitializer.java
@@ -10,7 +10,7 @@ import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.network.LfNetwork;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface VoltageInitializer {
 

--- a/src/main/java/com/powsybl/openloadflow/network/util/ZeroImpedanceFlows.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ZeroImpedanceFlows.java
@@ -14,8 +14,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @author Luma Zamarreño <zamarrenolm at aia.es>
- * @author José Antonio Marqués <marquesja at aia.es>
+ * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
+ * @author José Antonio Marqués {@literal <marquesja at aia.es>}
  */
 public class ZeroImpedanceFlows {
 

--- a/src/main/java/com/powsybl/openloadflow/sa/AbstractNetworkResult.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AbstractNetworkResult.java
@@ -20,7 +20,7 @@ import java.util.*;
 import java.util.function.Consumer;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractNetworkResult {
 

--- a/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
@@ -45,7 +45,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractSecurityAnalysis<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity,
                                                P extends AbstractLoadFlowParameters,

--- a/src/main/java/com/powsybl/openloadflow/sa/AcSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AcSecurityAnalysis.java
@@ -45,7 +45,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AcSecurityAnalysis extends AbstractSecurityAnalysis<AcVariableType, AcEquationType, AcLoadFlowParameters, AcLoadFlowContext> {
 

--- a/src/main/java/com/powsybl/openloadflow/sa/LimitViolationManager.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/LimitViolationManager.java
@@ -25,7 +25,7 @@ import java.util.function.*;
  * Limit violation manager. A reference limit violation manager could be specified to only report violations that
  * are more severe than reference one.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LimitViolationManager {
 

--- a/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisParameterJsonSerializer.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisParameterJsonSerializer.java
@@ -19,7 +19,7 @@ import com.powsybl.security.SecurityAnalysisParameters;
 import java.io.IOException;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class OpenSecurityAnalysisParameterJsonSerializer implements ExtensionJsonSerializer<SecurityAnalysisParameters, OpenSecurityAnalysisParameters> {
 

--- a/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisParameters.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class OpenSecurityAnalysisParameters extends AbstractExtension<SecurityAnalysisParameters> {
 

--- a/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProvider.java
@@ -35,7 +35,7 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 @AutoService(SecurityAnalysisProvider.class)
 public class OpenSecurityAnalysisProvider implements SecurityAnalysisProvider {

--- a/src/main/java/com/powsybl/openloadflow/sa/PostContingencyNetworkResult.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/PostContingencyNetworkResult.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class PostContingencyNetworkResult extends AbstractNetworkResult {
 

--- a/src/main/java/com/powsybl/openloadflow/sa/PreContingencyNetworkResult.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/PreContingencyNetworkResult.java
@@ -14,7 +14,7 @@ import com.powsybl.security.results.BranchResult;
 import java.util.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class PreContingencyNetworkResult extends AbstractNetworkResult {
 

--- a/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
@@ -39,8 +39,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Gael Macherel <gael.macherel at artelys.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Gael Macherel {@literal <gael.macherel at artelys.com>}
  */
 abstract class AbstractSensitivityAnalysis<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity> {
 

--- a/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
@@ -38,8 +38,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Gael Macherel <gael.macherel at artelys.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Gael Macherel {@literal <gael.macherel at artelys.com>}
  */
 public class AcSensitivityAnalysis extends AbstractSensitivityAnalysis<AcVariableType, AcEquationType> {
 

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -48,8 +48,8 @@ import java.util.stream.Collectors;
 import static com.powsybl.openloadflow.network.util.ParticipatingElement.normalizeParticipationFactors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Gaël Macherel <gael.macherel@artelys.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Gaël Macherel {@literal <gael.macherel@artelys.com>}
  */
 public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariableType, DcEquationType> {
 

--- a/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisParameterJsonSerializer.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisParameterJsonSerializer.java
@@ -19,7 +19,7 @@ import com.powsybl.sensitivity.SensitivityAnalysisParameters;
 import java.io.IOException;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class OpenSensitivityAnalysisParameterJsonSerializer implements ExtensionJsonSerializer<SensitivityAnalysisParameters, OpenSensitivityAnalysisParameters> {
 

--- a/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisParameters.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class OpenSensitivityAnalysisParameters extends AbstractExtension<SensitivityAnalysisParameters> {
 

--- a/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProvider.java
@@ -57,7 +57,7 @@ import java.util.function.Function;
 import static com.powsybl.openloadflow.util.DebugUtil.DATE_TIME_FORMAT;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(SensitivityAnalysisProvider.class)
 public class OpenSensitivityAnalysisProvider implements SensitivityAnalysisProvider {

--- a/src/main/java/com/powsybl/openloadflow/sensi/SensitivityFactoryJsonRecorder.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/SensitivityFactoryJsonRecorder.java
@@ -16,7 +16,7 @@ import java.nio.file.Path;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SensitivityFactoryJsonRecorder implements SensitivityFactorReader {
 

--- a/src/main/java/com/powsybl/openloadflow/util/ComplexPart.java
+++ b/src/main/java/com/powsybl/openloadflow/util/ComplexPart.java
@@ -9,7 +9,7 @@
 package com.powsybl.openloadflow.util;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at gmail.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at gmail.com>}
  */
 public enum ComplexPart {
     REAL,

--- a/src/main/java/com/powsybl/openloadflow/util/DebugUtil.java
+++ b/src/main/java/com/powsybl/openloadflow/util/DebugUtil.java
@@ -13,7 +13,7 @@ import java.nio.file.Path;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class DebugUtil {
 

--- a/src/main/java/com/powsybl/openloadflow/util/Evaluable.java
+++ b/src/main/java/com/powsybl/openloadflow/util/Evaluable.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.util;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface Evaluable {
 

--- a/src/main/java/com/powsybl/openloadflow/util/EvaluableConstants.java
+++ b/src/main/java/com/powsybl/openloadflow/util/EvaluableConstants.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.util;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class EvaluableConstants {
 

--- a/src/main/java/com/powsybl/openloadflow/util/Fortescue.java
+++ b/src/main/java/com/powsybl/openloadflow/util/Fortescue.java
@@ -12,7 +12,7 @@ import com.powsybl.math.matrix.DenseMatrix;
 import org.apache.commons.math3.geometry.euclidean.twod.Vector2D;
 
 /**
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 public final class Fortescue {
 

--- a/src/main/java/com/powsybl/openloadflow/util/Markers.java
+++ b/src/main/java/com/powsybl/openloadflow/util/Markers.java
@@ -10,7 +10,7 @@ import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class Markers {
 

--- a/src/main/java/com/powsybl/openloadflow/util/MatrixUtil.java
+++ b/src/main/java/com/powsybl/openloadflow/util/MatrixUtil.java
@@ -13,8 +13,8 @@ import com.powsybl.math.matrix.DenseMatrix;
 /**
  * TODO: move theses features to core.
  *
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at gmail.com>
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at gmail.com>}
  */
 public final class MatrixUtil {
 

--- a/src/main/java/com/powsybl/openloadflow/util/PerUnit.java
+++ b/src/main/java/com/powsybl/openloadflow/util/PerUnit.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.util;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class PerUnit {
 

--- a/src/main/java/com/powsybl/openloadflow/util/ProviderConstants.java
+++ b/src/main/java/com/powsybl/openloadflow/util/ProviderConstants.java
@@ -7,7 +7,7 @@
 package com.powsybl.openloadflow.util;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class ProviderConstants {
 

--- a/src/main/java/com/powsybl/openloadflow/util/Reports.java
+++ b/src/main/java/com/powsybl/openloadflow/util/Reports.java
@@ -15,7 +15,7 @@ import com.powsybl.openloadflow.OpenLoadFlowReportConstants;
 import java.util.Map;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class Reports {
 

--- a/src/test/java/com/powsybl/openloadflow/EquationsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/EquationsTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class EquationsTest {
 

--- a/src/test/java/com/powsybl/openloadflow/FullVoltageInitializerTest.java
+++ b/src/test/java/com/powsybl/openloadflow/FullVoltageInitializerTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import static com.powsybl.openloadflow.ac.VoltageMagnitudeInitializerTest.assertBusVoltage;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class FullVoltageInitializerTest {
 

--- a/src/test/java/com/powsybl/openloadflow/Ieee14Test.java
+++ b/src/test/java/com/powsybl/openloadflow/Ieee14Test.java
@@ -24,7 +24,7 @@ import static com.powsybl.openloadflow.util.LoadFlowAssert.assertVoltageEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class Ieee14Test {
 

--- a/src/test/java/com/powsybl/openloadflow/NonImpedantBranchTest.java
+++ b/src/test/java/com/powsybl/openloadflow/NonImpedantBranchTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class NonImpedantBranchTest extends AbstractLoadFlowNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/OpenLoadFlowParametersTest.java
+++ b/src/test/java/com/powsybl/openloadflow/OpenLoadFlowParametersTest.java
@@ -40,7 +40,7 @@ import static com.powsybl.openloadflow.util.LoadFlowAssert.assertVoltageEquals;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Jérémy Labous <jlabous at silicom.fr>
+ * @author Jérémy Labous {@literal <jlabous at silicom.fr>}
  */
 class OpenLoadFlowParametersTest {
 

--- a/src/test/java/com/powsybl/openloadflow/OpenLoadFlowProviderTest.java
+++ b/src/test/java/com/powsybl/openloadflow/OpenLoadFlowProviderTest.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class OpenLoadFlowProviderTest {
 

--- a/src/test/java/com/powsybl/openloadflow/OperationalLimitsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/OperationalLimitsTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 class OperationalLimitsTest extends AbstractLoadFlowNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/ZeroImpedanceFlowsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ZeroImpedanceFlowsTest.java
@@ -28,8 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Luma Zamarreño <zamarrenolm at aia.es>
- * @author José Antonio Marqués <marquesja at aia.es>
+ * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
+ * @author José Antonio Marqués {@literal <marquesja at aia.es>}
  */
 class ZeroImpedanceFlowsTest extends AbstractLoadFlowNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowBoundaryTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowBoundaryTest.java
@@ -23,7 +23,7 @@ import static com.powsybl.openloadflow.util.LoadFlowAssert.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class AcLoadFlowBoundaryTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
@@ -28,7 +28,7 @@ import static com.powsybl.openloadflow.util.LoadFlowAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class AcLoadFlowEurostagTutorialExample1Test {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowPhaseShifterTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowPhaseShifterTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class AcLoadFlowPhaseShifterTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowReportTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowReportTest.java
@@ -30,7 +30,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Bertrand Rix <bertrand.rix at artelys.com>
+ * @author Bertrand Rix {@literal <bertrand.rix at artelys.com>}
  */
 class AcLoadFlowReportTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowShuntTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowShuntTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *      l1    |
  *           shunt
  *
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 class AcLoadFlowShuntTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowSvcTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowSvcTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *      l1    |
  *           svc1
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class AcLoadFlowSvcTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTransformerControlTest.java
@@ -24,7 +24,7 @@ import static com.powsybl.openloadflow.util.LoadFlowAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 class AcLoadFlowTransformerControlTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTwoBusNetworkTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowTwoBusNetworkTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class AcLoadFlowTwoBusNetworkTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowWithCachingTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowWithCachingTest.java
@@ -33,7 +33,7 @@ import static com.powsybl.openloadflow.util.LoadFlowAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class AcLoadFlowWithCachingTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcloadFlowReactiveLimitsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcloadFlowReactiveLimitsTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class AcloadFlowReactiveLimitsTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AsymmetricalLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AsymmetricalLoadFlowTest.java
@@ -38,7 +38,7 @@ import static com.powsybl.openloadflow.util.LoadFlowAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Jean-Baptiste Heyberger <jbheyberger at gmail.com>
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  */
 public class AsymmetricalLoadFlowTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/CountriesToBalanceTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/CountriesToBalanceTest.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import static com.powsybl.openloadflow.util.LoadFlowAssert.assertActivePowerEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class CountriesToBalanceTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/DcValueVoltageInitializerTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DcValueVoltageInitializerTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * @author Damien Jeandemange <damien.jeandemange at artelys.com>
+ * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
  */
 class DcValueVoltageInitializerTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/DebugDirTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DebugDirTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class DebugDirTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
@@ -30,8 +30,8 @@ import static com.powsybl.openloadflow.util.LoadFlowAssert.assertReactivePowerEq
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Caio Luke <caio.luke at artelys.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Caio Luke {@literal <caio.luke at artelys.com>}
  */
 class DistributedSlackOnGenerationTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnLoadTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnLoadTest.java
@@ -29,7 +29,7 @@ import static com.powsybl.openloadflow.util.LoadFlowAssert.assertLoadFlowResults
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 class DistributedSlackOnLoadTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlLocalRescaleTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlLocalRescaleTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class GeneratorRemoteControlLocalRescaleTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
@@ -26,7 +26,7 @@ import static com.powsybl.openloadflow.util.LoadFlowAssert.assertVoltageEquals;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/GeneratorTargetVoltageInconsistencyTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/GeneratorTargetVoltageInconsistencyTest.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class GeneratorTargetVoltageInconsistencyTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/IllConditionedCaseTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/IllConditionedCaseTest.java
@@ -27,8 +27,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Damien Jeandemange <damien.jeandemange at artelys.com>
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class IllConditionedCaseTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/LinesWithDifferentNominalVoltagesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/LinesWithDifferentNominalVoltagesTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @see LinesWithDifferentNominalVoltagesNetworkFactory
  *
- * @author Damien Jeandemange <damien.jeandemange at artelys.com>
+ * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
  */
 class LinesWithDifferentNominalVoltagesTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/LoadModelTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/LoadModelTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class LoadModelTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class MultipleSlackBusesTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/NonImpedantBranchDisablingTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/NonImpedantBranchDisablingTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class NonImpedantBranchDisablingTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/NonImpedantBranchWithBreakerIssueTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/NonImpedantBranchWithBreakerIssueTest.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class NonImpedantBranchWithBreakerIssueTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
@@ -33,7 +33,7 @@ import static com.powsybl.openloadflow.util.LoadFlowAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class SecondaryVoltageControlTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/SwitchPqPvTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/SwitchPqPvTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *           |
  *           ld
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class SwitchPqPvTest extends AbstractLoadFlowNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/VoltageMagnitudeInitializerTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/VoltageMagnitudeInitializerTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class VoltageMagnitudeInitializerTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonParametersTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonParametersTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class NewtonRaphsonParametersTest {
 

--- a/src/test/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonStoppingCriteriaTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/nr/NewtonRaphsonStoppingCriteriaTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Alexandre Le Jean <alexandre.le-jean at artelys.com>
+ * @author Alexandre Le Jean {@literal <alexandre.le-jean at artelys.com>}
  */
 class NewtonRaphsonStoppingCriteriaTest {
 

--- a/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowEngineTest.java
+++ b/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowEngineTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class DcLoadFlowEngineTest {
 

--- a/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowMatrixTest.java
+++ b/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowMatrixTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class DcLoadFlowMatrixTest {
 

--- a/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 class DcLoadFlowTest {
 

--- a/src/test/java/com/powsybl/openloadflow/equations/EquationSystemIndexTest.java
+++ b/src/test/java/com/powsybl/openloadflow/equations/EquationSystemIndexTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class EquationSystemIndexTest {
 

--- a/src/test/java/com/powsybl/openloadflow/equations/EquationSystemTest.java
+++ b/src/test/java/com/powsybl/openloadflow/equations/EquationSystemTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class EquationSystemTest {
 

--- a/src/test/java/com/powsybl/openloadflow/equations/EquationTest.java
+++ b/src/test/java/com/powsybl/openloadflow/equations/EquationTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class EquationTest {
 

--- a/src/test/java/com/powsybl/openloadflow/equations/VariableTest.java
+++ b/src/test/java/com/powsybl/openloadflow/equations/VariableTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class VariableTest {
 

--- a/src/test/java/com/powsybl/openloadflow/graph/BridgesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/graph/BridgesTest.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class BridgesTest {
 

--- a/src/test/java/com/powsybl/openloadflow/graph/ConnectivityTest.java
+++ b/src/test/java/com/powsybl/openloadflow/graph/ConnectivityTest.java
@@ -16,7 +16,7 @@ import java.util.stream.IntStream;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class ConnectivityTest {
 

--- a/src/test/java/com/powsybl/openloadflow/graph/NetworkConnectivityTest.java
+++ b/src/test/java/com/powsybl/openloadflow/graph/NetworkConnectivityTest.java
@@ -22,8 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * @author Gaël Macherel <gael.macherel at artelys.com>
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Gaël Macherel {@literal <gael.macherel at artelys.com>}
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class NetworkConnectivityTest {
 

--- a/src/test/java/com/powsybl/openloadflow/network/AbstractLoadFlowNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/AbstractLoadFlowNetworkFactory.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.StaticVarCompensator.RegulationMode;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractLoadFlowNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/network/BoundaryFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/BoundaryFactory.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import com.powsybl.iidm.network.*;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class BoundaryFactory extends AbstractLoadFlowNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/network/BranchStateTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/BranchStateTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class BranchStateTest {
 

--- a/src/test/java/com/powsybl/openloadflow/network/BusBreakerNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/BusBreakerNetworkFactory.java
@@ -27,7 +27,7 @@ public final class BusBreakerNetworkFactory {
      *             LD
      * </pre>
      *
-     * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
      */
     public static Network create() {
         Network network = Network.create("test", "test");

--- a/src/test/java/com/powsybl/openloadflow/network/ConnectedComponentNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/ConnectedComponentNetworkFactory.java
@@ -11,7 +11,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
 
 /**
- * @author Gael Macherel <gael.macherel at artelys.com>
+ * @author Gael Macherel {@literal <gael.macherel at artelys.com>}
  */
 public class ConnectedComponentNetworkFactory extends AbstractLoadFlowNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/network/DistributedSlackNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/DistributedSlackNetworkFactory.java
@@ -12,7 +12,7 @@ import com.powsybl.iidm.network.extensions.ActivePowerControlAdder;
 /**
  * <p>4 bus test networks adapted to distributed slack bus:</p>
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DistributedSlackNetworkFactory extends AbstractLoadFlowNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/network/EurostagFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/EurostagFactory.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.Generator;
 import com.powsybl.iidm.network.Network;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class EurostagFactory extends AbstractLoadFlowNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/network/FirstSlackBusSelectorTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/FirstSlackBusSelectorTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
- * @author Etienne Lesot <etienne.lesot@rte-france.com>
+ * @author Etienne Lesot {@literal <etienne.lesot@rte-france.com>}
  */
 class FirstSlackBusSelectorTest {
     @Test

--- a/src/test/java/com/powsybl/openloadflow/network/FourBusNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/FourBusNetworkFactory.java
@@ -26,7 +26,7 @@ import com.powsybl.iidm.network.TwoWindingsTransformer;
  *      1pu                 -4pu
  *</pre>
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class FourBusNetworkFactory extends AbstractLoadFlowNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/network/HvdcNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/HvdcNetworkFactory.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import com.powsybl.iidm.network.*;
 
 /**
- * @author Gaël Macherel <gael.macherel@artelys.com>
+ * @author Gaël Macherel {@literal <gael.macherel@artelys.com>}
  */
 public class HvdcNetworkFactory extends AbstractLoadFlowNetworkFactory {
 
@@ -22,7 +22,7 @@ public class HvdcNetworkFactory extends AbstractLoadFlowNetworkFactory {
      * l12          hvdc23
      * </pre>
      *
-     * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
      */
     public static Network createVsc() {
         Network network = Network.create("vsc", "test");
@@ -137,7 +137,7 @@ public class HvdcNetworkFactory extends AbstractLoadFlowNetworkFactory {
      *                              g3
      * </pre>
      *
-     * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
      */
     public static Network createLcc() {
         Network network = Network.create("lcc", "test");
@@ -259,7 +259,7 @@ public class HvdcNetworkFactory extends AbstractLoadFlowNetworkFactory {
      *                                                  g3
      * </pre>
      *
-     * @author Gael Macherel <gael.macherel at artelys.com>
+ * @author Gael Macherel {@literal <gael.macherel at artelys.com>}
      */
     public static Network createLccWithBiggerComponents() {
         Network network = createLcc();

--- a/src/test/java/com/powsybl/openloadflow/network/LargestGeneratorSlackBusSelectorTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/LargestGeneratorSlackBusSelectorTest.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class LargestGeneratorSlackBusSelectorTest {
 

--- a/src/test/java/com/powsybl/openloadflow/network/LfBusNumBugTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/LfBusNumBugTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class LfBusNumBugTest {
 

--- a/src/test/java/com/powsybl/openloadflow/network/LfNetworkLoaderPostProcessorTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/LfNetworkLoaderPostProcessorTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class LfNetworkLoaderPostProcessorTest {
 

--- a/src/test/java/com/powsybl/openloadflow/network/LfNetworkTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/LfNetworkTest.java
@@ -36,7 +36,7 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class LfNetworkTest extends AbstractConverterTest {
 

--- a/src/test/java/com/powsybl/openloadflow/network/LfStandbyAutomatonShuntTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/LfStandbyAutomatonShuntTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class LfStandbyAutomatonShuntTest {
 

--- a/src/test/java/com/powsybl/openloadflow/network/LinesWithDifferentNominalVoltagesNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/LinesWithDifferentNominalVoltagesNetworkFactory.java
@@ -36,7 +36,7 @@ import com.powsybl.iidm.network.extensions.ActivePowerControlAdder;
  *
  * </pre>
  *
- * @author Damien Jeandemange <damien.jeandemange at artelys.com>
+ * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
  */
 public class LinesWithDifferentNominalVoltagesNetworkFactory extends AbstractLoadFlowNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelectorTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/MostMeshedSlackBusSelectorTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class MostMeshedSlackBusSelectorTest {
 

--- a/src/test/java/com/powsybl/openloadflow/network/NameSlackBusSelectorTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/NameSlackBusSelectorTest.java
@@ -17,7 +17,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class NameSlackBusSelectorTest {
 

--- a/src/test/java/com/powsybl/openloadflow/network/NetworkSlackBusSelectorTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/NetworkSlackBusSelectorTest.java
@@ -19,7 +19,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 class NetworkSlackBusSelectorTest {
 

--- a/src/test/java/com/powsybl/openloadflow/network/NodeBreakerNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/NodeBreakerNetworkFactory.java
@@ -51,7 +51,7 @@ public final class NodeBreakerNetworkFactory {
      *         |
      *         LD
      *
-     * @author Gael Macharel <gael.macherel at artelys.com>
+ * @author Gael Macharel {@literal <gael.macherel at artelys.com>}
      */
     public static Network create() {
         Network network = Network.create("test", "test");
@@ -230,7 +230,7 @@ public final class NodeBreakerNetworkFactory {
      *                     LD (600MW)
      *</pre>
      *
-     * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
      */
     public static Network create3Bars() {
         Network network = Network.create("test", "test");
@@ -293,7 +293,7 @@ public final class NodeBreakerNetworkFactory {
      *                           LD (5)
      *</pre>
      *
-     * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
      */
     public static Network create3barsAndJustOneVoltageLevel() {
         Network network = Network.create("test", "test");

--- a/src/test/java/com/powsybl/openloadflow/network/OriginalIdsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/OriginalIdsTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class OriginalIdsTest {
 

--- a/src/test/java/com/powsybl/openloadflow/network/PerUnitPrecisionLossTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/PerUnitPrecisionLossTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class PerUnitPrecisionLossTest {
 

--- a/src/test/java/com/powsybl/openloadflow/network/PhaseControlFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/PhaseControlFactory.java
@@ -11,7 +11,7 @@ import com.powsybl.iidm.network.test.PhaseShifterTestCaseFactory;
 import org.joda.time.DateTime;
 
 /**
- * @author Anne Tilloy <anne.tilloy@rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy@rte-france.com>}
  */
 public class PhaseControlFactory extends AbstractLoadFlowNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/network/PiModelArrayTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/PiModelArrayTest.java
@@ -19,7 +19,7 @@ import static com.powsybl.openloadflow.network.PiModelArray.FirstTapPositionAbov
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class PiModelArrayTest {
 

--- a/src/test/java/com/powsybl/openloadflow/network/PropertyTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/PropertyTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class PropertyTest {
 

--- a/src/test/java/com/powsybl/openloadflow/network/ReactivePowerControlNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/ReactivePowerControlNetworkFactory.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.RemoteReactivePowerControlAdder;
 
 /**
- * @author Caio Luke <caio.luke at artelys.com>
+ * @author Caio Luke {@literal <caio.luke at artelys.com>}
  */
 public class ReactivePowerControlNetworkFactory extends AbstractLoadFlowNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/network/ShuntNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/ShuntNetworkFactory.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import com.powsybl.iidm.network.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class ShuntNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/network/SimplePiModelTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/SimplePiModelTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class SimplePiModelTest {
 

--- a/src/test/java/com/powsybl/openloadflow/network/SwitchLoopIssueNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/SwitchLoopIssueNetworkFactory.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import com.powsybl.iidm.network.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class SwitchLoopIssueNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/network/T3wtFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/T3wtFactory.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import com.powsybl.iidm.network.*;
 
 /**
- * @author Gael Macherel <gael.macherel at artelys.com>
+ * @author Gael Macherel {@literal <gael.macherel at artelys.com>}
  */
 public class T3wtFactory extends AbstractLoadFlowNetworkFactory {
 
@@ -25,7 +25,7 @@ public class T3wtFactory extends AbstractLoadFlowNetworkFactory {
      *         |
      *         sc3
      *
-     * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
      */
     public static Network create() {
         Network network = Network.create("vsc", "test");

--- a/src/test/java/com/powsybl/openloadflow/network/TwoBusNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/TwoBusNetworkFactory.java
@@ -23,7 +23,7 @@ import com.powsybl.iidm.network.Network;
  *      200 MW, 100 MVar
  *</pre>
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class TwoBusNetworkFactory extends AbstractLoadFlowNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
@@ -9,7 +9,7 @@ package com.powsybl.openloadflow.network;
 import com.powsybl.iidm.network.*;
 
 /**
- * @author Anne Tilloy <anne.tilloy@rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy@rte-france.com>}
  */
 public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImplTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImplTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class LfNetworkLoaderImplTest extends AbstractLoadFlowNetworkFactory {
 

--- a/src/test/java/com/powsybl/openloadflow/network/impl/LfSwitchTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/impl/LfSwitchTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 class LfSwitchTest {
 

--- a/src/test/java/com/powsybl/openloadflow/sa/AbstractOpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/AbstractOpenSecurityAnalysisTest.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractOpenSecurityAnalysisTest {
 

--- a/src/test/java/com/powsybl/openloadflow/sa/LfActionTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/LfActionTest.java
@@ -34,8 +34,8 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
- * @author Jean-Luc Bouchot <jlbouchot at gmail.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
+ * @author Jean-Luc Bouchot {@literal <jlbouchot at gmail.com>}
  */
 class LfActionTest extends AbstractConverterTest {
 

--- a/src/test/java/com/powsybl/openloadflow/sa/LfContingencyTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/LfContingencyTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class LfContingencyTest extends AbstractConverterTest {
 

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisGraphTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisGraphTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class OpenSecurityAnalysisGraphTest {
 

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProviderTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProviderTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class OpenSecurityAnalysisProviderTest extends AbstractConverterTest {
 

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -44,7 +44,7 @@ import static java.util.Collections.emptySet;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
 

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
@@ -45,8 +45,8 @@ import static com.powsybl.openloadflow.util.LoadFlowAssert.assertReportEquals;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTest {
 

--- a/src/test/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysisTest.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractSensitivityAnalysisTest extends AbstractConverterTest {
 

--- a/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisContingenciesTest.java
@@ -34,7 +34,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class AcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysisTest {
 

--- a/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisReportTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisReportTest.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 import static com.powsybl.openloadflow.util.LoadFlowAssert.assertReportEquals;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class AcSensitivityAnalysisReportTest extends AbstractSensitivityAnalysisTest {
 

--- a/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisTest.java
@@ -33,7 +33,7 @@ import static com.powsybl.openloadflow.util.LoadFlowAssert.assertReactivePowerEq
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class AcSensitivityAnalysisTest extends AbstractSensitivityAnalysisTest {
 

--- a/src/test/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysisContingenciesTest.java
@@ -42,7 +42,7 @@ import static com.powsybl.openloadflow.util.LoadFlowAssert.assertActivePowerEqua
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Gael Macherel <gael.macherel at artelys.com>
+ * @author Gael Macherel {@literal <gael.macherel at artelys.com>}
  */
 class DcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysisTest {
 

--- a/src/test/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysisTest.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class DcSensitivityAnalysisTest extends AbstractSensitivityAnalysisTest {
 

--- a/src/test/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisParametersTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisParametersTest.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import java.nio.file.FileSystem;
 
 /**
- * @author Etienne Lesot <etienne.lesot at rte-france.com>
+ * @author Etienne Lesot {@literal <etienne.lesot at rte-france.com>}
  */
 class OpenSensitivityAnalysisParametersTest {
 

--- a/src/test/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProviderTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProviderTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class OpenSensitivityAnalysisProviderTest extends AbstractSensitivityAnalysisTest {
 

--- a/src/test/java/com/powsybl/openloadflow/util/LoadFlowAssert.java
+++ b/src/test/java/com/powsybl/openloadflow/util/LoadFlowAssert.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class LoadFlowAssert {
 

--- a/src/test/java/com/powsybl/openloadflow/util/LoadFlowResultBuilder.java
+++ b/src/test/java/com/powsybl/openloadflow/util/LoadFlowResultBuilder.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * @author Fabien Rigaux <fabien.rigaux@free.fr>
+ * @author Fabien Rigaux {@literal <fabien.rigaux@free.fr>}
  */
 public class LoadFlowResultBuilder {
     private Map<String, String> metrics = new HashMap<>();

--- a/src/test/java/com/powsybl/openloadflow/util/sa/ContingencyTrippingTest.java
+++ b/src/test/java/com/powsybl/openloadflow/util/sa/ContingencyTrippingTest.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
 class ContingencyTrippingTest {
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem?**
No, but similar to https://github.com/powsybl/powsybl-core/pull/2753

**What kind of change does this PR introduce?**
Bug fix for javadoc generation

**What is the current behavior?**
Errors related to the author's email address formatting occur when generating the javadoc.
Email addresses were written as `@author Name Surname <email>`

**What is the new behavior (if this is a feature change)?**
No more errors related to that when generating the javadoc.
Email addresses are written as `@author Name Surname {@literal <email> }`