### PR TITLE
Fix update reactive keys for voltage control

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/LfContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfContingency.java
@@ -152,6 +152,7 @@ public class LfContingency {
             generator.setDisabled(true);
             if (generator.getGeneratorControlType() != LfGenerator.GeneratorControlType.OFF) {
                 generator.setGeneratorControlType(LfGenerator.GeneratorControlType.OFF);
+                bus.getGeneratorVoltageControl().ifPresent(vc -> vc.updateReactiveKeys());
             } else {
                 bus.setGenerationTargetQ(bus.getGenerationTargetQ() - generator.getTargetQ());
             }

--- a/src/test/java/com/powsybl/openloadflow/network/FourBusNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/FourBusNetworkFactory.java
@@ -98,14 +98,9 @@ public class FourBusNetworkFactory extends AbstractLoadFlowNetworkFactory {
     public static Network createWith2GenControllersOnSameBus() {
         Network network = create();
         Bus b1 = network.getBusBreakerView().getBus("b1");
-
         network.getLoad("d3").setQ0(1);
-
-        createGenerator(b1, "g1Bis", 2);
-
         Generator g1 = network.getGenerator("g1");
-        Generator g1Bis = network.getGenerator("g1Bis");
-
+        Generator g1Bis = createGenerator(b1, "g1Bis", 2);
         g1.setTargetQ(0).setVoltageRegulatorOn(false);
         g1Bis.setTargetQ(0).setVoltageRegulatorOn(false);
         return network;

--- a/src/test/java/com/powsybl/openloadflow/network/FourBusNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/FourBusNetworkFactory.java
@@ -7,6 +7,7 @@
 package com.powsybl.openloadflow.network;
 
 import com.powsybl.iidm.network.Bus;
+import com.powsybl.iidm.network.Generator;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
 
@@ -91,6 +92,29 @@ public class FourBusNetworkFactory extends AbstractLoadFlowNetworkFactory {
         Network network = create();
         Bus b2 = network.getBusBreakerView().getBus("b2");
         createGenerator(b2, "g5", 0.5);
+        return network;
+    }
+
+    public static Network createWith2ReactiveControllersOnSameBus() {
+        Network network = create();
+        Bus b1 = network.getBusBreakerView().getBus("b1");
+
+        network.getLoad("d3").setQ0(1);
+
+        createGenerator(b1, "g1Bis", 2);
+
+        Generator g1 = network.getGenerator("g1");
+        Generator g1Bis = network.getGenerator("g1Bis");
+
+        g1.setTargetQ(0).setVoltageRegulatorOn(false);
+        g1Bis.setTargetQ(0).setVoltageRegulatorOn(false);
+        return network;
+    }
+
+    public static Network createWith2ReactiveControllersOnSameBusAnd1Extra() {
+        Network network = createWith2ReactiveControllersOnSameBus();
+        Generator g4 = network.getGenerator("g4");
+        g4.setTargetQ(0).setVoltageRegulatorOn(false);
         return network;
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/network/FourBusNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/FourBusNetworkFactory.java
@@ -7,7 +7,6 @@
 package com.powsybl.openloadflow.network;
 
 import com.powsybl.iidm.network.Bus;
-import com.powsybl.iidm.network.Generator;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
 
@@ -95,21 +94,11 @@ public class FourBusNetworkFactory extends AbstractLoadFlowNetworkFactory {
         return network;
     }
 
-    public static Network createWith2GenControllersOnSameBus() {
+    public static Network createWith2GeneratorsAtBus1() {
         Network network = create();
         Bus b1 = network.getBusBreakerView().getBus("b1");
+        createGenerator(b1, "g1Bis", 2);
         network.getLoad("d3").setQ0(1);
-        Generator g1 = network.getGenerator("g1");
-        Generator g1Bis = createGenerator(b1, "g1Bis", 2);
-        g1.setTargetQ(0).setVoltageRegulatorOn(false);
-        g1Bis.setTargetQ(0).setVoltageRegulatorOn(false);
-        return network;
-    }
-
-    public static Network createWith2GenControllersOnSameBusAnd1Extra() {
-        Network network = createWith2GenControllersOnSameBus();
-        Generator g4 = network.getGenerator("g4");
-        g4.setTargetQ(0).setVoltageRegulatorOn(false);
         return network;
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/network/FourBusNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/FourBusNetworkFactory.java
@@ -95,7 +95,7 @@ public class FourBusNetworkFactory extends AbstractLoadFlowNetworkFactory {
         return network;
     }
 
-    public static Network createWith2ReactiveControllersOnSameBus() {
+    public static Network createWith2GenControllersOnSameBus() {
         Network network = create();
         Bus b1 = network.getBusBreakerView().getBus("b1");
 
@@ -111,8 +111,8 @@ public class FourBusNetworkFactory extends AbstractLoadFlowNetworkFactory {
         return network;
     }
 
-    public static Network createWith2ReactiveControllersOnSameBusAnd1Extra() {
-        Network network = createWith2ReactiveControllersOnSameBus();
+    public static Network createWith2GenControllersOnSameBusAnd1Extra() {
+        Network network = createWith2GenControllersOnSameBus();
         Generator g4 = network.getGenerator("g4");
         g4.setTargetQ(0).setVoltageRegulatorOn(false);
         return network;

--- a/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
@@ -1394,16 +1394,13 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
         Terminal regTerminal = network.getLine("l34").getTerminal2();
         g1.setMaxP(10)
                 .setRegulatingTerminal(regTerminal)
-                .setTargetV(1.2)
-                .setVoltageRegulatorOn(true);
+                .setTargetV(1.2);
         g1Bis.setMaxP(10)
                 .setRegulatingTerminal(regTerminal)
-                .setTargetV(1.2)
-                .setVoltageRegulatorOn(true);
+                .setTargetV(1.2);
         g4.setMaxP(10)
                 .setRegulatingTerminal(regTerminal)
-                .setTargetV(1.2)
-                .setVoltageRegulatorOn(true);
+                .setTargetV(1.2);
         return network;
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
@@ -1385,27 +1385,23 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
     }
 
     public static Network createWithSharedRemoteControl2GensOnSameBusAnd1Extra() {
-        Network network = FourBusNetworkFactory.createWith2ReactiveControllersOnSameBusAnd1Extra();
+        Network network = FourBusNetworkFactory.createWith2GenControllersOnSameBusAnd1Extra();
         Generator g1 = network.getGenerator("g1");
-        g1.setMaxP(10);
         Generator g1Bis = network.getGenerator("g1Bis");
-        g1Bis.setMaxP(10);
         Generator g4 = network.getGenerator("g4");
-        g4.setMaxP(20);
         Terminal regTerminal = network.getLine("l34").getTerminal2();
-
-        g1.setRegulatingTerminal(regTerminal);
-        g1.setTargetV(1.6);
-        g1.setVoltageRegulatorOn(true);
-
-        g1Bis.setRegulatingTerminal(regTerminal);
-        g1Bis.setTargetV(1.6);
-        g1Bis.setVoltageRegulatorOn(true);
-
-        g4.setRegulatingTerminal(regTerminal);
-        g4.setTargetV(1.6);
-        g4.setVoltageRegulatorOn(true);
-
+        g1.setMaxP(10)
+                .setRegulatingTerminal(regTerminal)
+                .setTargetV(1.2)
+                .setVoltageRegulatorOn(true);
+        g1Bis.setMaxP(10)
+                .setRegulatingTerminal(regTerminal)
+                .setTargetV(1.2)
+                .setVoltageRegulatorOn(true);
+        g4.setMaxP(10)
+                .setRegulatingTerminal(regTerminal)
+                .setTargetV(1.2)
+                .setVoltageRegulatorOn(true);
         return network;
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
@@ -1384,8 +1384,10 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
         return network;
     }
 
-    public static Network createWithSharedRemoteControl2GensOnSameBusAnd1Extra() {
-        Network network = FourBusNetworkFactory.createWith2GenControllersOnSameBusAnd1Extra();
+    public static Network createFourBusNetworkWithSharedVoltageControl() {
+        // Four bus network with g1 and g1Bis at b1, g4 at b4
+        // Shared voltage control at b4
+        Network network = FourBusNetworkFactory.createWith2GeneratorsAtBus1();
         Generator g1 = network.getGenerator("g1");
         Generator g1Bis = network.getGenerator("g1Bis");
         Generator g4 = network.getGenerator("g4");

--- a/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
@@ -1383,4 +1383,29 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
 
         return network;
     }
+
+    public static Network createWithSharedRemoteControl2GensOnSameBusAnd1Extra() {
+        Network network = FourBusNetworkFactory.createWith2ReactiveControllersOnSameBusAnd1Extra();
+        Generator g1 = network.getGenerator("g1");
+        g1.setMaxP(10);
+        Generator g1Bis = network.getGenerator("g1Bis");
+        g1Bis.setMaxP(10);
+        Generator g4 = network.getGenerator("g4");
+        g4.setMaxP(20);
+        Terminal regTerminal = network.getLine("l34").getTerminal2();
+
+        g1.setRegulatingTerminal(regTerminal);
+        g1.setTargetV(1.6);
+        g1.setVoltageRegulatorOn(true);
+
+        g1Bis.setRegulatingTerminal(regTerminal);
+        g1Bis.setTargetV(1.6);
+        g1Bis.setVoltageRegulatorOn(true);
+
+        g4.setRegulatingTerminal(regTerminal);
+        g4.setTargetV(1.6);
+        g4.setVoltageRegulatorOn(true);
+
+        return network;
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Reactive keys for voltage control are not being updated correctly in SA after a generator is lost


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
