### PR TITLE
Fix shunt b and g reinit notification

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfShuntImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfShuntImpl.java
@@ -265,7 +265,7 @@ public class LfShuntImpl extends AbstractLfShunt {
             throw new PowsyblException("Cannot re-init a shunt compensator with voltage control capabilities");
         }
         List<ShuntCompensator> shuntCompensators = shuntCompensatorsRefs.stream().map(Ref::get).collect(Collectors.toList());
-        b = computeB(shuntCompensators, zb);
-        g = computeG(shuntCompensators, zb);
+        setB(computeB(shuntCompensators, zb));
+        setG(computeG(shuntCompensators, zb));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When b and g of a shunt is reinit from IIDM values, network notification are not sent.


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
