### PR TITLE
Fix sharing of reactive power with for multiple generators with ReactivePowerControl

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/ReactivePowerDispatchMode.java
+++ b/src/main/java/com/powsybl/openloadflow/network/ReactivePowerDispatchMode.java
@@ -11,5 +11,6 @@ package com.powsybl.openloadflow.network;
  */
 public enum ReactivePowerDispatchMode {
     Q_EQUAL_PROPORTION,
-    K_EQUAL_PROPORTION
+    K_EQUAL_PROPORTION,
+    REACTIVE_KEYS,
 }

--- a/src/main/java/com/powsybl/openloadflow/network/ReactivePowerDispatchMode.java
+++ b/src/main/java/com/powsybl/openloadflow/network/ReactivePowerDispatchMode.java
@@ -11,6 +11,5 @@ package com.powsybl.openloadflow.network;
  */
 public enum ReactivePowerDispatchMode {
     Q_EQUAL_PROPORTION,
-    K_EQUAL_PROPORTION,
-    REACTIVE_KEYS,
+    K_EQUAL_PROPORTION
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -518,10 +518,13 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     }
 
     private static ToDoubleFunction<String> splitDispatchQWithReactiveKeys(List<LfGenerator> generatorsWithControl, double qToDispatch) {
-        double sumQkeys = 0.0;
+        double sumQkeys = 0;
         for (LfGenerator generator : generatorsWithControl) {
             double qKey = generator.getRemoteControlReactiveKey().orElseThrow();
             sumQkeys += qKey;
+        }
+        if (sumQkeys == 0) { // to avoid division by zero
+            sumQkeys = 1;
         }
 
         Map<String, Double> qToDispatchByGeneratorId = new HashMap<>(generatorsWithControl.size());

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -542,6 +542,9 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
             double maxRangeQ = generator.getRangeQ(LfGenerator.ReactiveRangeMode.MAX);
             sumMaxRanges += maxRangeQ;
         }
+        if (sumMaxRanges == 0) { // to avoid division by zero
+            sumMaxRanges = 1;
+        }
 
         Map<String, Double> qToDispatchByGeneratorId = new HashMap<>(generatorsWithControl.size());
         for (LfGenerator generator : generatorsWithControl) {

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowEurostagTutorialExample1Test.java
@@ -421,7 +421,8 @@ class AcLoadFlowEurostagTutorialExample1Test {
                 .setMinP(-9999.99D).setMaxP(9999.99D)
                 .setVoltageRegulatorOn(true).setTargetV(24.5D)
                 .setTargetP(607.0D).setTargetQ(301.0D).add();
-        network.getGenerator("GEN1").newMinMaxReactiveLimits().setMinQ(0).setMaxQ(160).add();
+        // GEN1 reactive limits are not plausible => fallback into split Q equally
+        network.getGenerator("GEN1").newMinMaxReactiveLimits().setMinQ(-10000).setMaxQ(10000).add();
         LoadFlowParameters parameters = new LoadFlowParameters().setUseReactiveLimits(true)
                 .setDistributedSlack(false)
                 .setVoltageInitMode(LoadFlowParameters.VoltageInitMode.DC_VALUES);

--- a/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
@@ -559,44 +559,73 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
     }
 
     @Test
-    void testSharedGeneratorRemoteReactivePowerControl5() {
+    void testSharedGeneratorRemoteReactivePowerControlReactiveKeys() {
         // generator g1 and g1Bis regulate reactive power on line 4->3
         // they are on the same bus
-        Network network1 = FourBusNetworkFactory.createWithReactiveControl2GeneratorsOnSameBus();
-        Generator g1 = network1.getGenerator("g1");
-        Generator g1Bis = network1.getGenerator("g1Bis");
-        Line l34 = network1.getLine("l34");
+        Network network = FourBusNetworkFactory.createWithReactiveControl2GeneratorsOnSameBus();
+        Generator g1 = network.getGenerator("g1");
+        Generator g1Bis = network.getGenerator("g1Bis");
+        Line l34 = network.getLine("l34");
 
         // Q should be split 1 : 4 for g1 and g1Bis respectively
         g1.newExtension(CoordinatedReactiveControlAdder.class).withQPercent(80).add();
         g1Bis.newExtension(CoordinatedReactiveControlAdder.class).withQPercent(20).add();
 
-        parameters.getExtension(OpenLoadFlowParameters.class).setReactivePowerRemoteControl(true);
-        LoadFlowResult result1 = loadFlowRunner.run(network1, parameters);
-        assertTrue(result1.isFullyConverged());
+        parameters.getExtension(OpenLoadFlowParameters.class).setReactivePowerRemoteControl(true)
+                .setReactivePowerDispatchMode(ReactivePowerDispatchMode.REACTIVE_KEYS);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isFullyConverged());
         assertReactivePowerEquals(2, l34.getTerminal(TwoSides.TWO));
         assertEquals(g1.getTerminal().getQ(), 4 * g1Bis.getTerminal().getQ(), DELTA_POWER);
+        assertEquals(5.8386, g1.getTerminal().getQ() + g1Bis.getTerminal().getQ(), DELTA_POWER);
     }
 
     @Test
-    void testSharedGeneratorRemoteReactivePowerControl6() {
+    void testSharedGeneratorRemoteReactivePowerControlReactiveKeysFallbackMaxRange() {
         // generator g1 and g1Bis regulate reactive power on line 4->3
         // they are on the same bus
-        Network network1 = FourBusNetworkFactory.createWithReactiveControl2GeneratorsOnSameBus();
-        Generator g1 = network1.getGenerator("g1");
-        Generator g1Bis = network1.getGenerator("g1Bis");
-        Line l34 = network1.getLine("l34");
+        Network network = FourBusNetworkFactory.createWithReactiveControl2GeneratorsOnSameBus();
+        Generator g1 = network.getGenerator("g1");
+        Generator g1Bis = network.getGenerator("g1Bis");
+        Line l34 = network.getLine("l34");
 
         // no reactive keys set => fallback
         // Q should be split 1 : 2 for g1 and g1Bis respectively
-        g1.newMinMaxReactiveLimits().setMinQ(-20).setMaxQ(20);
-        g1Bis.newMinMaxReactiveLimits().setMinQ(-10).setMaxQ(10);
+        g1.newMinMaxReactiveLimits().setMinQ(-20).setMaxQ(20).add();
+        g1Bis.newMinMaxReactiveLimits().setMinQ(-10).setMaxQ(10).add();
 
-        parameters.getExtension(OpenLoadFlowParameters.class).setReactivePowerRemoteControl(true);
-        LoadFlowResult result1 = loadFlowRunner.run(network1, parameters);
-        assertTrue(result1.isFullyConverged());
+        parameters.getExtension(OpenLoadFlowParameters.class).setReactivePowerRemoteControl(true)
+                .setReactivePowerDispatchMode(ReactivePowerDispatchMode.REACTIVE_KEYS);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isFullyConverged());
         assertReactivePowerEquals(2, l34.getTerminal(TwoSides.TWO));
         assertEquals(g1.getTerminal().getQ(), 2 * g1Bis.getTerminal().getQ(), DELTA_POWER);
+        assertEquals(5.8386, g1.getTerminal().getQ() + g1Bis.getTerminal().getQ(), DELTA_POWER);
+    }
+
+    @Test
+    void testSharedGeneratorRemoteReactivePowerControlReactiveKeysFallbackEquallyDistributed() {
+        // generator g1 and g1Bis regulate reactive power on line 4->3
+        // they are on the same bus
+        Network network = FourBusNetworkFactory.createWithReactiveControl2GeneratorsOnSameBus();
+        Generator g1 = network.getGenerator("g1");
+        Generator g1Bis = network.getGenerator("g1Bis");
+        Line l34 = network.getLine("l34");
+
+        // no reactive keys set => fallback max range
+        // not valid max ranges => fallback equally distributed
+        // Q should be equally split between g1 and g1Bis
+
+        parameters.getExtension(OpenLoadFlowParameters.class).setReactivePowerRemoteControl(true)
+                .setReactivePowerDispatchMode(ReactivePowerDispatchMode.REACTIVE_KEYS);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isFullyConverged());
+        assertReactivePowerEquals(2, l34.getTerminal(TwoSides.TWO));
+        assertEquals(g1.getTerminal().getQ(), g1Bis.getTerminal().getQ(), DELTA_POWER);
+        assertEquals(5.8386, g1.getTerminal().getQ() + g1Bis.getTerminal().getQ(), DELTA_POWER);
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
@@ -572,7 +572,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
         g1Bis.newExtension(CoordinatedReactiveControlAdder.class).withQPercent(20).add();
 
         parameters.getExtension(OpenLoadFlowParameters.class).setReactivePowerRemoteControl(true)
-                .setReactivePowerDispatchMode(ReactivePowerDispatchMode.REACTIVE_KEYS);
+                .setReactivePowerDispatchMode(ReactivePowerDispatchMode.Q_EQUAL_PROPORTION);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
@@ -596,7 +596,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
         g1Bis.newMinMaxReactiveLimits().setMinQ(-10).setMaxQ(10).add();
 
         parameters.getExtension(OpenLoadFlowParameters.class).setReactivePowerRemoteControl(true)
-                .setReactivePowerDispatchMode(ReactivePowerDispatchMode.REACTIVE_KEYS);
+                .setReactivePowerDispatchMode(ReactivePowerDispatchMode.Q_EQUAL_PROPORTION);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
@@ -619,7 +619,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
         // Q should be equally split between g1 and g1Bis
 
         parameters.getExtension(OpenLoadFlowParameters.class).setReactivePowerRemoteControl(true)
-                .setReactivePowerDispatchMode(ReactivePowerDispatchMode.REACTIVE_KEYS);
+                .setReactivePowerDispatchMode(ReactivePowerDispatchMode.Q_EQUAL_PROPORTION);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());

--- a/src/test/java/com/powsybl/openloadflow/network/impl/LfBusImplTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/impl/LfBusImplTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static com.powsybl.openloadflow.util.LoadFlowAssert.DELTA_POWER;
@@ -173,7 +172,10 @@ class LfBusImplTest {
 
     @Test
     void dispatchQForMaxTest() {
-        List<LfGenerator> generators = createLfGeneratorsWithInitQ(Arrays.asList(0d, 0d, 0d));
+        Network network = FourSubstationsNodeBreakerFactory.create();
+        // GH1 reactive limits are not plausible => fallback into split Q equally
+        network.getGenerator("GH1").newMinMaxReactiveLimits().setMinQ(-10000).setMaxQ(10000).add();
+        List<LfGenerator> generators = createLfGeneratorsWithInitQ(network, List.of(0d, 0d, 0d));
         LfGenerator generatorToRemove = generators.get(1);
         double qToDispatch = 21;
         double residueQ = AbstractLfBus.dispatchQ(generators, true, ReactivePowerDispatchMode.Q_EQUAL_PROPORTION, qToDispatch);
@@ -187,14 +189,17 @@ class LfBusImplTest {
 
     @Test
     void dispatchQTestWithInitialQForMax() {
-        List<LfGenerator> generators = createLfGeneratorsWithInitQ(Arrays.asList(1.5d, 1d, 3d));
+        Network network = FourSubstationsNodeBreakerFactory.create();
+        // GH1 reactive limits are not plausible => fallback into split Q equally
+        network.getGenerator("GH1").newMinMaxReactiveLimits().setMinQ(-10000).setMaxQ(10000).add();
+        List<LfGenerator> generators = createLfGeneratorsWithInitQ(network, List.of(1.5d, 1d, 3d));
         double qInitial = generators.get(0).getCalculatedQ() + generators.get(1).getCalculatedQ() + generators.get(2).getCalculatedQ();
         LfGenerator generatorToRemove1 = generators.get(1);
         LfGenerator generatorToRemove2 = generators.get(2);
         double qToDispatch = 20;
         double residueQ = AbstractLfBus.dispatchQ(generators, true, ReactivePowerDispatchMode.Q_EQUAL_PROPORTION, qToDispatch);
-        double totalCalculatedQ = generators.get(0).getCalculatedQ() + generatorToRemove1.getCalculatedQ() + generatorToRemove2.getCalculatedQ();
         assertEquals(1, generators.size());
+        double totalCalculatedQ = generators.get(0).getCalculatedQ() + generatorToRemove1.getCalculatedQ() + generatorToRemove2.getCalculatedQ();
         assertEquals(qToDispatch + qInitial - totalCalculatedQ, residueQ, 0.0001);
         assertEquals(8.17, generators.get(0).getCalculatedQ(), 0.01);
         assertEquals(generatorToRemove1.getMaxQ(), generatorToRemove1.getCalculatedQ(), 0.01);
@@ -203,7 +208,10 @@ class LfBusImplTest {
 
     @Test
     void dispatchQForMinTest() {
-        List<LfGenerator> generators = createLfGeneratorsWithInitQ(Arrays.asList(0d, 0d, 0d));
+        Network network = FourSubstationsNodeBreakerFactory.create();
+        // GH1 reactive limits are not plausible => fallback into split Q equally
+        network.getGenerator("GH1").newMinMaxReactiveLimits().setMinQ(-10000).setMaxQ(10000).add();
+        List<LfGenerator> generators = createLfGeneratorsWithInitQ(network, List.of(0d, 0d, 0d));
         LfGenerator generatorToRemove2 = generators.get(1);
         LfGenerator generatorToRemove3 = generators.get(2);
         double qToDispatch = -21;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Reactive power is always equally split between generators on a bus controlling the reactive power on a branch. Thus, ignoring the reactive keys. 


**What is the new behavior (if this is a feature change)?**
The reactive keys will not only work for splitting the reactive power between different buses but also for different generators on the same bus.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
