### PR TITLE
Generator remote reactive power control on non impedant branches

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -536,7 +536,8 @@ public class LfNetwork extends AbstractPropertyBag implements PropertyBag {
         } else {
             // zero impedance phase shifter controller or controlled branch is not supported
             branches.stream()
-                    .filter(b -> b.isPhaseController() || b.isPhaseControlled())
+                    .filter(b -> b.isPhaseController() || b.isPhaseControlled()
+                            || b.getGeneratorReactivePowerControl().isPresent())
                     .forEach(branch -> branch.setMinZ(lowImpedanceThreshold));
         }
     }

--- a/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
@@ -396,6 +396,32 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
     }
 
     @Test
+    void testGeneratorRemoteReactivePowerControlOnNonImpdantBranch() {
+        // create a basic 4-buses network
+        Network network = FourBusNetworkFactory.createBaseNetwork();
+        Generator g4 = network.getGenerator("g4");
+        Line l34 = network.getLine("l34");
+        l34.setR(0).setX(0);
+
+        double targetQ = 1.0;
+
+        // disable voltage control on g4
+        g4.setTargetQ(0).setVoltageRegulatorOn(false);
+
+        // first test: generator g4 regulates reactive power on line 4->3 (on side of g4)
+        g4.newExtension(RemoteReactivePowerControlAdder.class)
+            .withTargetQ(targetQ)
+            .withRegulatingTerminal(l34.getTerminal(TwoSides.TWO))
+            .withEnabled(true).add();
+
+        parameters.getExtension(OpenLoadFlowParameters.class).setReactivePowerRemoteControl(true);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isFullyConverged());
+        assertReactivePowerEquals(targetQ, l34.getTerminal(TwoSides.TWO));
+    }
+
+    @Test
     void testDiscardedGeneratorRemoteReactivePowerControls() {
         // create a basic 4-buses network
         Network network = FourBusNetworkFactory.createBaseNetwork();

--- a/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
@@ -396,7 +396,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
     }
 
     @Test
-    void testGeneratorRemoteReactivePowerControlOnNonImpdantBranch() {
+    void testGeneratorRemoteReactivePowerControlOnZeroImpedanceBranch() {
         // create a basic 4-buses network
         Network network = FourBusNetworkFactory.createBaseNetwork();
         Generator g4 = network.getGenerator("g4");
@@ -408,14 +408,15 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
         // disable voltage control on g4
         g4.setTargetQ(0).setVoltageRegulatorOn(false);
 
-        // first test: generator g4 regulates reactive power on line 4->3 (on side of g4)
+        // generator g4 regulates reactive power on line 4->3 (on side of g4)
+        // which is zero impedant
         g4.newExtension(RemoteReactivePowerControlAdder.class)
             .withTargetQ(targetQ)
             .withRegulatingTerminal(l34.getTerminal(TwoSides.TWO))
             .withEnabled(true).add();
 
-        parameters.getExtension(OpenLoadFlowParameters.class).setReactivePowerRemoteControl(true);
-
+        parameters.getExtension(OpenLoadFlowParameters.class)
+                .setReactivePowerRemoteControl(true);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
         assertReactivePowerEquals(targetQ, l34.getTerminal(TwoSides.TWO));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->
Remote reactive power target of generators is not held on zero impedance branches.


**What is the new behavior (if this is a feature change)?**
Target is now held even if branch has null impedance


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
