### PR TITLE
Fix PerEquationTypeStoppingCriteria

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
@@ -242,7 +242,7 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
         new Parameter(REACTIVE_POWER_REMOTE_CONTROL_PARAM_NAME, ParameterType.BOOLEAN, "SVC remote reactive power control", REACTIVE_POWER_REMOTE_CONTROL_DEFAULT_VALUE),
         new Parameter(MAX_NEWTON_RAPHSON_ITERATIONS_PARAM_NAME, ParameterType.INTEGER, "Max iterations per Newton-Raphson", NewtonRaphsonParameters.DEFAULT_MAX_ITERATIONS),
         new Parameter(MAX_OUTER_LOOP_ITERATIONS_PARAM_NAME, ParameterType.INTEGER, "Max outer loop iterations", AbstractLoadFlowParameters.DEFAULT_MAX_OUTER_LOOP_ITERATIONS),
-        new Parameter(NEWTON_RAPHSON_CONV_EPS_PER_EQ_PARAM_NAME, ParameterType.DOUBLE, "Newton-Raphson convergence epsilon per equation", DefaultNewtonRaphsonStoppingCriteria.DEFAULT_CONV_EPS_PER_EQ),
+        new Parameter(NEWTON_RAPHSON_CONV_EPS_PER_EQ_PARAM_NAME, ParameterType.DOUBLE, "Newton-Raphson convergence epsilon per equation", NewtonRaphsonStoppingCriteria.DEFAULT_CONV_EPS_PER_EQ),
         new Parameter(VOLTAGE_INIT_MODE_OVERRIDE_PARAM_NAME, ParameterType.STRING, "Voltage init mode override", VOLTAGE_INIT_MODE_OVERRIDE_DEFAULT_VALUE.name(), getEnumPossibleValues(VoltageInitModeOverride.class)),
         new Parameter(TRANSFORMER_VOLTAGE_CONTROL_MODE_PARAM_NAME, ParameterType.STRING, "Transformer voltage control mode", TRANSFORMER_VOLTAGE_CONTROL_MODE_DEFAULT_VALUE.name(), getEnumPossibleValues(TransformerVoltageControlMode.class)),
         new Parameter(SHUNT_VOLTAGE_CONTROL_MODE_PARAM_NAME, ParameterType.STRING, "Shunt voltage control mode", SHUNT_VOLTAGE_CONTROL_MODE_DEFAULT_VALUE.name(), getEnumPossibleValues(ShuntVoltageControlMode.class)),
@@ -361,7 +361,7 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
 
     private int maxOuterLoopIterations = AbstractLoadFlowParameters.DEFAULT_MAX_OUTER_LOOP_ITERATIONS;
 
-    private double newtonRaphsonConvEpsPerEq = DefaultNewtonRaphsonStoppingCriteria.DEFAULT_CONV_EPS_PER_EQ;
+    private double newtonRaphsonConvEpsPerEq = NewtonRaphsonStoppingCriteria.DEFAULT_CONV_EPS_PER_EQ;
 
     private VoltageInitModeOverride voltageInitModeOverride = VOLTAGE_INIT_MODE_OVERRIDE_DEFAULT_VALUE;
 
@@ -1081,7 +1081,7 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
                 .setReactivePowerRemoteControl(config.getBooleanProperty(REACTIVE_POWER_REMOTE_CONTROL_PARAM_NAME, REACTIVE_POWER_REMOTE_CONTROL_DEFAULT_VALUE))
                 .setMaxNewtonRaphsonIterations(config.getIntProperty(MAX_NEWTON_RAPHSON_ITERATIONS_PARAM_NAME, NewtonRaphsonParameters.DEFAULT_MAX_ITERATIONS))
                 .setMaxOuterLoopIterations(config.getIntProperty(MAX_OUTER_LOOP_ITERATIONS_PARAM_NAME, AbstractLoadFlowParameters.DEFAULT_MAX_OUTER_LOOP_ITERATIONS))
-                .setNewtonRaphsonConvEpsPerEq(config.getDoubleProperty(NEWTON_RAPHSON_CONV_EPS_PER_EQ_PARAM_NAME, DefaultNewtonRaphsonStoppingCriteria.DEFAULT_CONV_EPS_PER_EQ))
+                .setNewtonRaphsonConvEpsPerEq(config.getDoubleProperty(NEWTON_RAPHSON_CONV_EPS_PER_EQ_PARAM_NAME, NewtonRaphsonStoppingCriteria.DEFAULT_CONV_EPS_PER_EQ))
                 .setVoltageInitModeOverride(config.getEnumProperty(VOLTAGE_INIT_MODE_OVERRIDE_PARAM_NAME, VoltageInitModeOverride.class, VOLTAGE_INIT_MODE_OVERRIDE_DEFAULT_VALUE))
                 .setTransformerVoltageControlMode(config.getEnumProperty(TRANSFORMER_VOLTAGE_CONTROL_MODE_PARAM_NAME, TransformerVoltageControlMode.class, TRANSFORMER_VOLTAGE_CONTROL_MODE_DEFAULT_VALUE))
                 .setShuntVoltageControlMode(config.getEnumProperty(SHUNT_VOLTAGE_CONTROL_MODE_PARAM_NAME, ShuntVoltageControlMode.class, SHUNT_VOLTAGE_CONTROL_MODE_DEFAULT_VALUE))
@@ -1458,17 +1458,15 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
     }
 
     private static NewtonRaphsonStoppingCriteria createNewtonRaphsonStoppingCriteria(OpenLoadFlowParameters parametersExt) {
-        switch (parametersExt.getNewtonRaphsonStoppingCriteriaType()) {
-            case UNIFORM_CRITERIA:
-                return new DefaultNewtonRaphsonStoppingCriteria(parametersExt.getNewtonRaphsonConvEpsPerEq());
-            case PER_EQUATION_TYPE_CRITERIA:
-                return new PerEquationTypeStoppingCriteria(parametersExt.getMaxActivePowerMismatch(),
-                        parametersExt.getMaxReactivePowerMismatch(), parametersExt.getMaxVoltageMismatch(),
-                        parametersExt.getMaxAngleMismatch(), parametersExt.getMaxRatioMismatch(),
-                        parametersExt.getMaxSusceptanceMismatch());
-            default:
-                throw new PowsyblException("Unknown Newton Raphson stopping criteria type: " + parametersExt.getNewtonRaphsonStoppingCriteriaType());
-        }
+        return switch (parametersExt.getNewtonRaphsonStoppingCriteriaType()) {
+            case UNIFORM_CRITERIA ->
+                    new DefaultNewtonRaphsonStoppingCriteria(parametersExt.getNewtonRaphsonConvEpsPerEq());
+            case PER_EQUATION_TYPE_CRITERIA ->
+                    new PerEquationTypeStoppingCriteria(parametersExt.getNewtonRaphsonConvEpsPerEq(), parametersExt.getMaxActivePowerMismatch(),
+                            parametersExt.getMaxReactivePowerMismatch(), parametersExt.getMaxVoltageMismatch(),
+                            parametersExt.getMaxAngleMismatch(), parametersExt.getMaxRatioMismatch(),
+                            parametersExt.getMaxSusceptanceMismatch());
+        };
     }
 
     static List<AcOuterLoop> createOuterLoops(LoadFlowParameters parameters, OpenLoadFlowParameters parametersExt) {

--- a/src/main/java/com/powsybl/openloadflow/ac/solver/DefaultNewtonRaphsonStoppingCriteria.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/solver/DefaultNewtonRaphsonStoppingCriteria.java
@@ -17,15 +17,10 @@ import net.jafama.FastMath;
  */
 public class DefaultNewtonRaphsonStoppingCriteria implements NewtonRaphsonStoppingCriteria {
 
-    /**
-     * Convergence epsilon per equation: 10^-4 in p.u => 10^-2 in Kv, Mw or MVar
-     */
-    public static final double DEFAULT_CONV_EPS_PER_EQ = Math.pow(10, -4);
-
     private final double convEpsPerEq;
 
     public DefaultNewtonRaphsonStoppingCriteria() {
-        this(DEFAULT_CONV_EPS_PER_EQ);
+        this(NewtonRaphsonStoppingCriteria.DEFAULT_CONV_EPS_PER_EQ);
     }
 
     public DefaultNewtonRaphsonStoppingCriteria(double convEpsPerEq) {

--- a/src/main/java/com/powsybl/openloadflow/ac/solver/NewtonRaphsonStoppingCriteria.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/solver/NewtonRaphsonStoppingCriteria.java
@@ -15,6 +15,11 @@ import com.powsybl.openloadflow.equations.EquationSystem;
  */
 public interface NewtonRaphsonStoppingCriteria {
 
+    /**
+     * Convergence epsilon per equation: 10^-4 in p.u => 10^-2 in Kv, Mw or MVar
+     */
+    double DEFAULT_CONV_EPS_PER_EQ = Math.pow(10, -4);
+
     class TestResult {
 
         private final boolean stop;

--- a/src/main/java/com/powsybl/openloadflow/ac/solver/PerEquationTypeStoppingCriteria.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/solver/PerEquationTypeStoppingCriteria.java
@@ -52,48 +52,38 @@ public class PerEquationTypeStoppingCriteria implements NewtonRaphsonStoppingCri
             var type = eq.getType();
             var idx = eq.getColumn();
             switch (type) {
-                case BRANCH_TARGET_P,
-                     BUS_TARGET_P,
-                     DUMMY_TARGET_P:
+                case BRANCH_TARGET_P, BUS_TARGET_P, DUMMY_TARGET_P, BUS_DISTR_SLACK_P -> {
                     if (Math.abs(fx[idx]) * PerUnit.SB >= maxActivePowerMismatch) {
                         return false;
                     }
-                    break;
-                case BRANCH_TARGET_Q,
-                     BUS_TARGET_Q,
-                     DISTR_Q,
-                     DUMMY_TARGET_Q:
+                }
+                case BRANCH_TARGET_Q, BUS_TARGET_Q, DISTR_Q, DUMMY_TARGET_Q -> {
                     if (Math.abs(fx[idx]) * PerUnit.SB >= maxReactivePowerMismatch) {
                         return false;
                     }
-                    break;
-                case BUS_TARGET_V,
-                     ZERO_V:
+                }
+                case BUS_TARGET_V, ZERO_V -> {
                     if (Math.abs(fx[idx]) >= maxVoltageMismatch) {
                         return false;
                     }
-                    break;
-                case BRANCH_TARGET_RHO1,
-                     DISTR_RHO:
+                }
+                case BRANCH_TARGET_RHO1, DISTR_RHO -> {
                     if (Math.abs(fx[idx]) >= maxDefaultRatioMismatch) {
                         return false;
                     }
-                    break;
-                case DISTR_SHUNT_B,
-                     SHUNT_TARGET_B:
+                }
+                case DISTR_SHUNT_B, SHUNT_TARGET_B -> {
                     if (Math.abs(fx[idx]) >= maxDefaultSusceptanceMismatch) {
                         return false;
                     }
-                    break;
-                case BUS_TARGET_PHI,
-                     ZERO_PHI,
-                     BRANCH_TARGET_ALPHA1:
+                }
+                case BUS_TARGET_PHI, ZERO_PHI, BRANCH_TARGET_ALPHA1 -> {
                     if (Math.abs(fx[idx]) >= maxDefaultAngleMismatch) {
                         return false;
                     }
-                    break;
-                default:
-                    throw new PowsyblException("Unknown equation term");
+                }
+                // FIXME what about BUS_TARGET_IX_ZERO, BUS_TARGET_IY_ZERO, BUS_TARGET_IX_NEGATIVE, BUS_TARGET_IY_NEGATIVE ?
+                default -> throw new PowsyblException("Unknown equation term");
             }
         }
         return true;

--- a/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
@@ -14,12 +14,18 @@ import com.powsybl.loadflow.LoadFlowResult;
 import com.powsybl.math.matrix.DenseMatrixFactory;
 import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.OpenLoadFlowProvider;
+import com.powsybl.openloadflow.ac.solver.NewtonRaphsonStoppingCriteriaType;
 import com.powsybl.openloadflow.network.EurostagFactory;
 import com.powsybl.openloadflow.util.LoadFlowAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -48,8 +54,14 @@ class MultipleSlackBusesTest {
                 .setMaxSlackBusCount(2);
     }
 
-    @Test
-    void multiSlackTest() {
+    static Stream<Arguments> allStoppingCriteriaTypes() {
+        return Arrays.stream(NewtonRaphsonStoppingCriteriaType.values()).map(Arguments::of);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("allStoppingCriteriaTypes")
+    void multiSlackTest(NewtonRaphsonStoppingCriteriaType stoppingCriteria) {
+        parametersExt.setNewtonRaphsonStoppingCriteriaType(stoppingCriteria);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
         LoadFlowResult.ComponentResult componentResult = result.getComponentResults().get(0);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
BugFix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
AC NR loadflow PowsyblException "Unknown equation term" when using 1/ multiple slack buses with 2/ PerEquationTypeStoppingCriteria

cause: missing BUS_DISTR_SLACK_P in PerEquationTypeStoppingCriteria


**What is the new behavior (if this is a feature change)?**
bugfix:
- BUS_DISTR_SLACK_P correctly taken into account using maxActivePowerMismatch threshold
- any other equation term use newtonRaphsonConvEpsPerEq threshold

**Does this PR introduce a breaking change or deprecate an API?**
No
