### PR TITLE
Support paired dangling lines ids in state monitors

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
@@ -241,9 +241,7 @@ public interface LfBranch extends LfElement {
 
     boolean isTransformerReactivePowerControlled();
 
-    default BranchResult createBranchResult(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension) {
-        return null;
-    }
+    List<BranchResult> createBranchResult(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension);
 
     double computeApparentPower1();
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
@@ -241,7 +241,9 @@ public interface LfBranch extends LfElement {
 
     boolean isTransformerReactivePowerControlled();
 
-    BranchResult createBranchResult(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension);
+    default BranchResult createBranchResult(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension) {
+        return null;
+    }
 
     double computeApparentPower1();
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
@@ -208,7 +208,7 @@ public class LfBranchImpl extends AbstractImpedantLfBranch {
     }
 
     @Override
-    public BranchResult createBranchResult(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension) {
+    public List<BranchResult> createBranchResult(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension) {
         var branch = getBranch();
         double flowTransfer = Double.NaN;
         if (!Double.isNaN(preContingencyBranchP1) && !Double.isNaN(preContingencyBranchOfContingencyP1)) {
@@ -225,7 +225,7 @@ public class LfBranchImpl extends AbstractImpedantLfBranch {
                     Math.toDegrees(getAngle1()),
                     Math.toDegrees(getAngle2())));
         }
-        return branchResult;
+        return List.of(branchResult);
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
@@ -65,12 +65,12 @@ public class LfDanglingLineBranch extends AbstractImpedantLfBranch {
     }
 
     @Override
-    public BranchResult createBranchResult(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension) {
+    public List<BranchResult> createBranchResult(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension) {
         // in a security analysis, we don't have any way to monitor the flows at boundary side. So in the branch result,
         // we follow the convention side 1 for network side and side 2 for boundary side.
         double currentScale = PerUnit.ib(getDanglingLine().getTerminal().getVoltageLevel().getNominalV());
-        return new BranchResult(getId(), p1.eval() * PerUnit.SB, q1.eval() * PerUnit.SB, currentScale * i1.eval(),
-                p2.eval() * PerUnit.SB, q2.eval() * PerUnit.SB, currentScale * i2.eval(), Double.NaN);
+        return List.of(new BranchResult(getId(), p1.eval() * PerUnit.SB, q1.eval() * PerUnit.SB, currentScale * i1.eval(),
+                p2.eval() * PerUnit.SB, q2.eval() * PerUnit.SB, currentScale * i2.eval(), Double.NaN));
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
@@ -149,7 +149,7 @@ public final class LfLegBranch extends AbstractImpedantLfBranch {
     }
 
     @Override
-    public BranchResult createBranchResult(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension) {
+    public List<BranchResult> createBranchResult(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension) {
         throw new PowsyblException("Unsupported type of branch for branch result: " + getId());
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfSwitch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfSwitch.java
@@ -351,7 +351,7 @@ public class LfSwitch extends AbstractLfBranch {
     }
 
     @Override
-    public BranchResult createBranchResult(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension) {
+    public List<BranchResult> createBranchResult(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension) {
         throw new PowsyblException("Unsupported type of branch for branch result: " + getSwitch().getId());
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfTieLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfTieLineBranch.java
@@ -59,32 +59,38 @@ public class LfTieLineBranch extends AbstractImpedantLfBranch {
         return BranchType.TIE_LINE;
     }
 
-    private DanglingLine getHalf1() {
+    public DanglingLine getHalf1() {
         return danglingLine1Ref.get();
     }
 
-    private DanglingLine getHalf2() {
+    public DanglingLine getHalf2() {
         return danglingLine2Ref.get();
     }
 
-    @Override
-    public BranchResult createBranchResult(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension) {
+    public List<BranchResult> createAllBranchResults(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension) {
         double flowTransfer = Double.NaN;
         if (!Double.isNaN(preContingencyBranchP1) && !Double.isNaN(preContingencyBranchOfContingencyP1)) {
             flowTransfer = (p1.eval() * PerUnit.SB - preContingencyBranchP1) / preContingencyBranchOfContingencyP1;
         }
-        double currentScale1 = PerUnit.ib(getHalf1().getTerminal().getVoltageLevel().getNominalV());
-        double currentScale2 = PerUnit.ib(getHalf2().getTerminal().getVoltageLevel().getNominalV());
+        double nominalV1 = getHalf1().getTerminal().getVoltageLevel().getNominalV();
+        double nominalV2 = getHalf2().getTerminal().getVoltageLevel().getNominalV();
+        double currentScale1 = PerUnit.ib(nominalV1);
+        double currentScale2 = PerUnit.ib(nominalV2);
         var branchResult = new BranchResult(getId(), p1.eval() * PerUnit.SB, q1.eval() * PerUnit.SB, currentScale1 * i1.eval(),
-                                            p2.eval() * PerUnit.SB, q2.eval() * PerUnit.SB, currentScale2 * i2.eval(), flowTransfer);
+                p2.eval() * PerUnit.SB, q2.eval() * PerUnit.SB, currentScale2 * i2.eval(), flowTransfer);
+        var half1Result = new BranchResult(getHalf1().getId(), p1.eval() * PerUnit.SB, q1.eval() * PerUnit.SB, currentScale1 * i1.eval(),
+                Double.NaN, Double.NaN, Double.NaN, flowTransfer);
+        var half2Result = new BranchResult(getHalf2().getId(), Double.NaN, Double.NaN, Double.NaN,
+                p2.eval() * PerUnit.SB, q2.eval() * PerUnit.SB, currentScale2 * i2.eval(), Double.NaN);
         if (createExtension) {
             branchResult.addExtension(OlfBranchResult.class, new OlfBranchResult(piModel.getR1(), piModel.getContinuousR1(),
-                    getV1() * getHalf1().getTerminal().getVoltageLevel().getNominalV(),
-                    getV2() * getHalf2().getTerminal().getVoltageLevel().getNominalV(),
-                    Math.toDegrees(getAngle1()),
-                    Math.toDegrees(getAngle2())));
+                    getV1() * nominalV1, getV2() * nominalV2, Math.toDegrees(getAngle1()), Math.toDegrees(getAngle2())));
+            half1Result.addExtension(OlfBranchResult.class, new OlfBranchResult(piModel.getR1(), piModel.getContinuousR1(),
+                    getV1() * nominalV1, Double.NaN, Math.toDegrees(getAngle1()), Double.NaN));
+            half2Result.addExtension(OlfBranchResult.class, new OlfBranchResult(piModel.getR1(), piModel.getContinuousR1(),
+                    Double.NaN, getV2() * nominalV2, Double.NaN, Math.toDegrees(getAngle2())));
         }
-        return branchResult;
+        return List.of(branchResult, half1Result, half2Result);
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfTieLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfTieLineBranch.java
@@ -55,6 +55,11 @@ public class LfTieLineBranch extends AbstractImpedantLfBranch {
     }
 
     @Override
+    public List<String> getOriginalIds() {
+        return List.of(id, danglingLine1Ref.get().getId(), danglingLine2Ref.get().getId());
+    }
+
+    @Override
     public BranchType getBranchType() {
         return BranchType.TIE_LINE;
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfTieLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfTieLineBranch.java
@@ -67,7 +67,8 @@ public class LfTieLineBranch extends AbstractImpedantLfBranch {
         return danglingLine2Ref.get();
     }
 
-    public List<BranchResult> createAllBranchResults(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension) {
+    @Override
+    public List<BranchResult> createBranchResult(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1, boolean createExtension) {
         double flowTransfer = Double.NaN;
         if (!Double.isNaN(preContingencyBranchP1) && !Double.isNaN(preContingencyBranchOfContingencyP1)) {
             flowTransfer = (p1.eval() * PerUnit.SB - preContingencyBranchP1) / preContingencyBranchOfContingencyP1;
@@ -80,8 +81,8 @@ public class LfTieLineBranch extends AbstractImpedantLfBranch {
                 p2.eval() * PerUnit.SB, q2.eval() * PerUnit.SB, currentScale2 * i2.eval(), flowTransfer);
         var half1Result = new BranchResult(getHalf1().getId(), p1.eval() * PerUnit.SB, q1.eval() * PerUnit.SB, currentScale1 * i1.eval(),
                 Double.NaN, Double.NaN, Double.NaN, flowTransfer);
-        var half2Result = new BranchResult(getHalf2().getId(), Double.NaN, Double.NaN, Double.NaN,
-                p2.eval() * PerUnit.SB, q2.eval() * PerUnit.SB, currentScale2 * i2.eval(), Double.NaN);
+        var half2Result = new BranchResult(getHalf2().getId(), p2.eval() * PerUnit.SB, q2.eval() * PerUnit.SB, currentScale2 * i2.eval(),
+                Double.NaN, Double.NaN, Double.NaN, flowTransfer);
         if (createExtension) {
             branchResult.addExtension(OlfBranchResult.class, new OlfBranchResult(piModel.getR1(), piModel.getContinuousR1(),
                     getV1() * nominalV1, getV2() * nominalV2, Math.toDegrees(getAngle1()), Math.toDegrees(getAngle2())));

--- a/src/main/java/com/powsybl/openloadflow/sa/AbstractNetworkResult.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AbstractNetworkResult.java
@@ -10,14 +10,15 @@ import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.LfNetwork;
 import com.powsybl.openloadflow.network.impl.LfLegBranch;
 import com.powsybl.openloadflow.network.impl.LfStarBus;
-import com.powsybl.openloadflow.network.impl.LfTieLineBranch;
 import com.powsybl.security.monitor.StateMonitor;
 import com.powsybl.security.monitor.StateMonitorIndex;
 import com.powsybl.security.results.BranchResult;
 import com.powsybl.security.results.BusResult;
 import com.powsybl.security.results.ThreeWindingsTransformerResult;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
@@ -45,16 +46,14 @@ public abstract class AbstractNetworkResult {
         Objects.requireNonNull(monitor);
         if (!monitor.getBranchIds().isEmpty()) {
             network.getBranches().stream()
-                    .filter(lfBranch -> monitor.getBranchIds().contains(lfBranch.getId()))
                     .filter(lfBranch -> !lfBranch.isDisabled())
-                    .forEach(branchConsumer);
-            // user can ask for underlying dangling ids instead of tie line id.
-            network.getBranches().stream()
-                    .filter(lfBranch -> !lfBranch.isDisabled())
-                    .filter(lfBranch -> lfBranch instanceof LfTieLineBranch)
-                    .map(LfTieLineBranch.class::cast)
-                    .filter(tl -> monitor.getBranchIds().contains(tl.getHalf1().getId()) || monitor.getBranchIds().contains(tl.getHalf2().getId()))
-                    .forEach(branchConsumer);
+                    .forEach(lfBranch -> {
+                        for (String originalId : lfBranch.getOriginalIds()) {
+                            if (monitor.getBranchIds().contains(originalId)) {
+                                branchConsumer.accept(lfBranch);
+                            }
+                        }
+                    });
         }
 
         if (!monitor.getVoltageLevelIds().isEmpty()) {

--- a/src/main/java/com/powsybl/openloadflow/sa/AbstractNetworkResult.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AbstractNetworkResult.java
@@ -10,6 +10,7 @@ import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.LfNetwork;
 import com.powsybl.openloadflow.network.impl.LfLegBranch;
 import com.powsybl.openloadflow.network.impl.LfStarBus;
+import com.powsybl.openloadflow.network.impl.LfTieLineBranch;
 import com.powsybl.security.monitor.StateMonitor;
 import com.powsybl.security.monitor.StateMonitorIndex;
 import com.powsybl.security.results.BranchResult;
@@ -46,6 +47,13 @@ public abstract class AbstractNetworkResult {
             network.getBranches().stream()
                     .filter(lfBranch -> monitor.getBranchIds().contains(lfBranch.getId()))
                     .filter(lfBranch -> !lfBranch.isDisabled())
+                    .forEach(branchConsumer);
+            // user can ask for underlying dangling ids instead of tie line id.
+            network.getBranches().stream()
+                    .filter(lfBranch -> !lfBranch.isDisabled())
+                    .filter(lfBranch -> lfBranch instanceof LfTieLineBranch)
+                    .map(LfTieLineBranch.class::cast)
+                    .filter(tl -> monitor.getBranchIds().contains(tl.getHalf1().getId()) || monitor.getBranchIds().contains(tl.getHalf2().getId()))
                     .forEach(branchConsumer);
         }
 

--- a/src/main/java/com/powsybl/openloadflow/sa/PostContingencyNetworkResult.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/PostContingencyNetworkResult.java
@@ -10,6 +10,7 @@ import com.powsybl.contingency.Contingency;
 import com.powsybl.contingency.ContingencyElement;
 import com.powsybl.contingency.ContingencyElementType;
 import com.powsybl.openloadflow.network.LfNetwork;
+import com.powsybl.openloadflow.network.impl.LfTieLineBranch;
 import com.powsybl.security.monitor.StateMonitor;
 import com.powsybl.security.monitor.StateMonitorIndex;
 import com.powsybl.security.results.BranchResult;
@@ -59,7 +60,13 @@ public class PostContingencyNetworkResult extends AbstractNetworkResult {
                     }
                 }
             }
-            branchResults.add(branch.createBranchResult(preContingencyBranchP1, preContingencyBranchOfContingencyP1, createResultExtension));
+            if (branch instanceof LfTieLineBranch) {
+                LfTieLineBranch lfTieLineBranch = (LfTieLineBranch) branch;
+                List<BranchResult> tieLineResults = lfTieLineBranch.createAllBranchResults(preContingencyBranchP1, preContingencyBranchOfContingencyP1, createResultExtension);
+                branchResults.addAll(tieLineResults);
+            } else {
+                branchResults.add(branch.createBranchResult(preContingencyBranchP1, preContingencyBranchOfContingencyP1, createResultExtension));
+            }
         });
     }
 

--- a/src/main/java/com/powsybl/openloadflow/sa/PostContingencyNetworkResult.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/PostContingencyNetworkResult.java
@@ -10,7 +10,6 @@ import com.powsybl.contingency.Contingency;
 import com.powsybl.contingency.ContingencyElement;
 import com.powsybl.contingency.ContingencyElementType;
 import com.powsybl.openloadflow.network.LfNetwork;
-import com.powsybl.openloadflow.network.impl.LfTieLineBranch;
 import com.powsybl.security.monitor.StateMonitor;
 import com.powsybl.security.monitor.StateMonitorIndex;
 import com.powsybl.security.results.BranchResult;
@@ -60,13 +59,7 @@ public class PostContingencyNetworkResult extends AbstractNetworkResult {
                     }
                 }
             }
-            if (branch instanceof LfTieLineBranch) {
-                LfTieLineBranch lfTieLineBranch = (LfTieLineBranch) branch;
-                List<BranchResult> tieLineResults = lfTieLineBranch.createAllBranchResults(preContingencyBranchP1, preContingencyBranchOfContingencyP1, createResultExtension);
-                branchResults.addAll(tieLineResults);
-            } else {
-                branchResults.add(branch.createBranchResult(preContingencyBranchP1, preContingencyBranchOfContingencyP1, createResultExtension));
-            }
+            branchResults.addAll(branch.createBranchResult(preContingencyBranchP1, preContingencyBranchOfContingencyP1, createResultExtension));
         });
     }
 

--- a/src/main/java/com/powsybl/openloadflow/sa/PreContingencyNetworkResult.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/PreContingencyNetworkResult.java
@@ -33,15 +33,14 @@ public class PreContingencyNetworkResult extends AbstractNetworkResult {
 
     private void addResults(StateMonitor monitor) {
         addResults(monitor, branch -> {
-            if (branch instanceof LfTieLineBranch) {
+            List<BranchResult> branchResult = branch.createBranchResult(Double.NaN, Double.NaN, createResultExtension);
+            if (branchResult.size() == 1) {
+                branchResults.put(branch.getId(), branchResult.get(0));
+            } else if (branch instanceof LfTieLineBranch) {
                 LfTieLineBranch lfTieLineBranch = (LfTieLineBranch) branch;
-                List<BranchResult> tieLineResults = lfTieLineBranch.createAllBranchResults(Double.NaN, Double.NaN, createResultExtension);
-                branchResults.put(lfTieLineBranch.getId(), tieLineResults.get(0));
-                branchResults.put(lfTieLineBranch.getHalf1().getId(), tieLineResults.get(1));
-                branchResults.put(lfTieLineBranch.getHalf2().getId(), tieLineResults.get(2));
-            } else {
-                var branchResult = branch.createBranchResult(Double.NaN, Double.NaN, createResultExtension);
-                branchResults.put(branch.getId(), branchResult);
+                branchResults.put(lfTieLineBranch.getId(), branchResult.get(0));
+                branchResults.put(lfTieLineBranch.getHalf1().getId(), branchResult.get(1));
+                branchResults.put(lfTieLineBranch.getHalf2().getId(), branchResult.get(2));
             }
         });
     }

--- a/src/main/java/com/powsybl/openloadflow/sa/PreContingencyNetworkResult.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/PreContingencyNetworkResult.java
@@ -7,7 +7,6 @@
 package com.powsybl.openloadflow.sa;
 
 import com.powsybl.openloadflow.network.LfNetwork;
-import com.powsybl.openloadflow.network.impl.LfTieLineBranch;
 import com.powsybl.security.monitor.StateMonitor;
 import com.powsybl.security.monitor.StateMonitorIndex;
 import com.powsybl.security.results.BranchResult;
@@ -33,15 +32,8 @@ public class PreContingencyNetworkResult extends AbstractNetworkResult {
 
     private void addResults(StateMonitor monitor) {
         addResults(monitor, branch -> {
-            List<BranchResult> branchResult = branch.createBranchResult(Double.NaN, Double.NaN, createResultExtension);
-            if (branchResult.size() == 1) {
-                branchResults.put(branch.getId(), branchResult.get(0));
-            } else if (branch instanceof LfTieLineBranch) {
-                LfTieLineBranch lfTieLineBranch = (LfTieLineBranch) branch;
-                branchResults.put(lfTieLineBranch.getId(), branchResult.get(0));
-                branchResults.put(lfTieLineBranch.getHalf1().getId(), branchResult.get(1));
-                branchResults.put(lfTieLineBranch.getHalf2().getId(), branchResult.get(2));
-            }
+            branch.createBranchResult(Double.NaN, Double.NaN, createResultExtension)
+                    .forEach(branchResult -> branchResults.put(branchResult.getBranchId(), branchResult));
         });
     }
 

--- a/src/main/java/com/powsybl/openloadflow/sa/PreContingencyNetworkResult.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/PreContingencyNetworkResult.java
@@ -7,6 +7,7 @@
 package com.powsybl.openloadflow.sa;
 
 import com.powsybl.openloadflow.network.LfNetwork;
+import com.powsybl.openloadflow.network.impl.LfTieLineBranch;
 import com.powsybl.security.monitor.StateMonitor;
 import com.powsybl.security.monitor.StateMonitorIndex;
 import com.powsybl.security.results.BranchResult;
@@ -32,8 +33,16 @@ public class PreContingencyNetworkResult extends AbstractNetworkResult {
 
     private void addResults(StateMonitor monitor) {
         addResults(monitor, branch -> {
-            var branchResult = branch.createBranchResult(Double.NaN, Double.NaN, createResultExtension);
-            branchResults.put(branch.getId(), branchResult);
+            if (branch instanceof LfTieLineBranch) {
+                LfTieLineBranch lfTieLineBranch = (LfTieLineBranch) branch;
+                List<BranchResult> tieLineResults = lfTieLineBranch.createAllBranchResults(Double.NaN, Double.NaN, createResultExtension);
+                branchResults.put(lfTieLineBranch.getId(), tieLineResults.get(0));
+                branchResults.put(lfTieLineBranch.getHalf1().getId(), tieLineResults.get(1));
+                branchResults.put(lfTieLineBranch.getHalf2().getId(), tieLineResults.get(2));
+            } else {
+                var branchResult = branch.createBranchResult(Double.NaN, Double.NaN, createResultExtension);
+                branchResults.put(branch.getId(), branchResult);
+            }
         });
     }
 

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -2266,8 +2266,8 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(35.0, dl1Result.getP1(), DELTA_POWER);
         assertEquals(Double.NaN, dl1Result.getP2());
         BranchResult dl2Result = result2.getPreContingencyResult().getNetworkResult().getBranchResult("h2");
-        assertEquals(Double.NaN, dl2Result.getP1());
-        assertEquals(-35.0, dl2Result.getP2(), DELTA_POWER);
+        assertEquals(-35.0, dl2Result.getP1(), DELTA_POWER);
+        assertEquals(Double.NaN, dl2Result.getP2());
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -2258,6 +2258,16 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(399.999, tieLineResultExt.getV2(), DELTA_V);
         assertEquals(0.002256, tieLineResultExt.getAngle1(), DELTA_ANGLE);
         assertEquals(0.0, tieLineResultExt.getAngle2(), DELTA_ANGLE);
+
+        Set<String> allBranchIds = network.getDanglingLineStream(DanglingLineFilter.PAIRED).map(Identifiable::getId).collect(Collectors.toSet());
+        List<StateMonitor> monitors2 = List.of(new StateMonitor(ContingencyContext.all(), allBranchIds, Collections.emptySet(), Collections.emptySet()));
+        SecurityAnalysisResult result2 = runSecurityAnalysis(network, contingencies, monitors2, securityAnalysisParameters);
+        BranchResult dl1Result = result2.getPreContingencyResult().getNetworkResult().getBranchResult("h1");
+        assertEquals(35.0, dl1Result.getP1(), DELTA_POWER);
+        assertEquals(Double.NaN, dl1Result.getP2());
+        BranchResult dl2Result = result2.getPreContingencyResult().getNetworkResult().getBranchResult("h2");
+        assertEquals(Double.NaN, dl2Result.getP1());
+        assertEquals(-35.0, dl2Result.getP2(), DELTA_POWER);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

Yes, issue #972 

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

A proposal, even if I am not really satisfied on my proposal. When a tie line id or at least one of the dangling line ids are in the input state monitor, we output the three branch results.  

**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
