### PR TITLE
Fix empty string parameter string list parsing

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
@@ -1199,6 +1199,9 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
     }
 
     private static List<String> parseStringListProp(String prop) {
+        if (prop.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
         return Arrays.asList(prop.split("[:,]"));
     }
 

--- a/src/test/java/com/powsybl/openloadflow/OpenLoadFlowParametersTest.java
+++ b/src/test/java/com/powsybl/openloadflow/OpenLoadFlowParametersTest.java
@@ -293,6 +293,16 @@ class OpenLoadFlowParametersTest {
     }
 
     @Test
+    void updateEmptyStringListParametersIssue() {
+        Map<String, String> updateParametersMap = new HashMap<>();
+        updateParametersMap.put("reportedFeatures", "");
+        OpenLoadFlowParameters parameters = new OpenLoadFlowParameters();
+        assertTrue(parameters.getReportedFeatures().isEmpty());
+        parameters.update(updateParametersMap);
+        assertTrue(parameters.getReportedFeatures().isEmpty());
+    }
+
+    @Test
     void testCompareParameters() {
         assertTrue(OpenLoadFlowParameters.equals(new LoadFlowParameters(), new LoadFlowParameters()));
         assertFalse(OpenLoadFlowParameters.equals(new LoadFlowParameters(), new LoadFlowParameters().setDc(true)));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When updating olf specific parameters from a json and if there is a string list attribute with an empty string, the parsing is failing.


**What is the new behavior (if this is a feature change)?**
An empty string is like an empty list and does not fail anymore.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
