### PR TITLE
Draft : SA : output a result for contingencies with no impact

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
@@ -340,7 +340,7 @@ public class AcSensitivityAnalysis extends AbstractSensitivityAnalysis<AcVariabl
                                 }
                                 networkState.restore();
                             }, () -> {
-                                    // it means that the contingency has no impact.
+                                    // it means that the contingency has no impact or leads to an isolated slack bus
                                     // we need to force the state vector to be re-initialized from base case network state
                                     AcSolverUtil.initStateVector(lfNetwork, context.getEquationSystem(), context.getParameters().getVoltageInitializer());
 

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -1053,8 +1053,8 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
 
         SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies);
 
-        // load is disconnected, contingency is skipped
-        assertFalse(getOptionalPostContingencyResult(result, "l2").isPresent());
+        // load is disconnected, contingency has no impact
+        assertEquals(PostContingencyComputationStatus.NO_IMPACT, getPostContingencyResult(result, "l2").getStatus());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When a contingency is converted to lfContingency befor beeing simulated three options are possible : 
* The contingency leads to an isolated slack bus -> contingency skipped and no result is provided
* The contingency has no impact -> contingency skipped and no result is provided
* The contingency is ok -> converted to lfContingency and simulated


**What is the new behavior (if this is a feature change)?**

* The contingency leads to an isolated slack bus -> contingency skipped and no result is provided
*  The contingency has no impact -> **return empty result with ``PostContingencyComputationStatus.NO_IMPACT``**
* The contingency is ok -> converted to lfContingency and simulated


This MR is a draft for the moment, the three cases are separated by a new enum to look more clear. But maybe it is a bit overkill.

New unit tests should still be added.

Another option could be to still create the lfContingency if it has no impact and add a hasNoImpact() method to the class (which won't be the same as hasNoImpact() from propagatedContingency, it is a deeper check) 


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
