### PR TITLE
Fix terminals connection action

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
@@ -365,7 +365,10 @@ public abstract class AbstractSecurityAnalysis<V extends Enum<V> & Quantity, E e
                 TerminalsConnectionAction terminalsConnectionAction = (TerminalsConnectionAction) action;
                 if (terminalsConnectionAction.getSide().isEmpty() && !terminalsConnectionAction.isOpen()) {
                     Branch branch = network.getBranch(terminalsConnectionAction.getElementId());
-                    if (branch != null && !(branch instanceof TieLine)) {
+                    if (branch != null && !(branch instanceof TieLine) &&
+                            !branch.getTerminal1().isConnected() && !branch.getTerminal2().isConnected()) {
+                        // both terminals must be disconnected. If only one is connected, the branch is present
+                        // in the Lf network.
                         topoConfig.getBranchIdsToClose().add(terminalsConnectionAction.getElementId());
                     }
                 }

--- a/src/test/java/com/powsybl/openloadflow/NonImpedantBranchTest.java
+++ b/src/test/java/com/powsybl/openloadflow/NonImpedantBranchTest.java
@@ -20,6 +20,7 @@ import com.powsybl.math.matrix.DenseMatrixFactory;
 import com.powsybl.openloadflow.graph.EvenShiloachGraphDecrementalConnectivityFactory;
 import com.powsybl.openloadflow.network.AbstractLoadFlowNetworkFactory;
 import com.powsybl.openloadflow.network.SlackBusSelectionMode;
+import com.powsybl.openloadflow.network.ZeroImpedanceNetworkFactory;
 import com.powsybl.openloadflow.network.impl.OlfBranchResult;
 import com.powsybl.openloadflow.sa.OpenSecurityAnalysisParameters;
 import com.powsybl.openloadflow.sa.OpenSecurityAnalysisProvider;
@@ -380,46 +381,8 @@ class NonImpedantBranchTest extends AbstractLoadFlowNetworkFactory {
      */
     @Test
     void securityAnalysisNotSameNumberOfVariablesAndEquationsIssueTest() {
-        Network network = Network.create("test", "code");
-        Bus b0 = createBus(network, "s", "b0");
-        Bus b1 = createBus(network, "s", "b1");
-        Bus b2 = createBus(network, "s", "b2");
-        Bus b3 = createBus(network, "s", "b3");
-        Bus b4 = createBus(network, "s", "b4");
-        Bus b5 = createBus(network, "s", "b5");
-        Generator g0 = createGenerator(b0, "g0", 2, 1); // 1 kV
-        createGenerator(b4, "g4", 2, 1.15); // 1.15 kV
-        createLoad(b5, "ld5", 4);
-        Line l01 = createLine(network, b0, b1, "l01", 0.1);
-        createLine(network, b1, b2, "l12", 0.0);
-        createLine(network, b2, b3, "l23", 0.0);
-        createLine(network, b1, b5, "l15", 0.1);
-        createLine(network, b5, b3, "l53", 0.1);
-        g0.setRegulatingTerminal(l01.getTerminal2()); // remote
-        TwoWindingsTransformer t34 = createTransformer(network, "s", b3, b4, "tr34", 0.15, 1);
-        t34.newRatioTapChanger()
-                .beginStep()
-                    .setRho(0.9)
-                .endStep()
-                .beginStep()
-                    .setRho(1)
-                .endStep()
-                .beginStep()
-                    .setRho(1.1)
-                .endStep()
-                .beginStep()
-                    .setRho(1.2)
-                .endStep()
-                .setTapPosition(1)
-                .setLoadTapChangingCapabilities(true)
-                .setRegulating(true)
-                .setTargetV(1.1)
-                .setRegulationTerminal(t34.getTerminal1())
-                .setTargetDeadband(0.01)
-                .add();
-
+        Network network = ZeroImpedanceNetworkFactory.createWithVoltageControl();
         List<Contingency> contingencies = List.of(new Contingency("contingency", List.of(new BranchContingency("l01"))));
-
         LoadFlowParameters loadFlowParameters = new LoadFlowParameters()
                 .setDistributedSlack(false)
                 .setTransformerVoltageControlOn(true);

--- a/src/test/java/com/powsybl/openloadflow/network/NonImpedantNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/NonImpedantNetworkFactory.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openloadflow.network;
+
+import com.powsybl.iidm.network.*;
+
+/**
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
+ */
+public class NonImpedantNetworkFactory extends AbstractLoadFlowNetworkFactory {
+
+    /**
+     *
+     * g0 (regulate b1)                     g4
+     * |                                    | t34 (regulate b3)
+     * b0 ----- b1 ===== b2 ===== b3 --OO-- b4
+     *          |                 |
+     *           ------- b5 ------
+     *                   |
+     *                   ld5
+     */
+    public static Network createWithVoltageRegulation() {
+        Network network = Network.create("test", "code");
+        Bus b0 = createBus(network, "s", "b0");
+        Bus b1 = createBus(network, "s", "b1");
+        Bus b2 = createBus(network, "s", "b2");
+        Bus b3 = createBus(network, "s", "b3");
+        Bus b4 = createBus(network, "s", "b4");
+        Bus b5 = createBus(network, "s", "b5");
+        Generator g0 = createGenerator(b0, "g0", 2, 1); // 1 kV
+        createGenerator(b4, "g4", 2, 1.15); // 1.15 kV
+        createLoad(b5, "ld5", 4);
+        Line l01 = createLine(network, b0, b1, "l01", 0.1);
+        createLine(network, b1, b2, "l12", 0.0);
+        createLine(network, b2, b3, "l23", 0.0);
+        createLine(network, b1, b5, "l15", 0.1);
+        createLine(network, b5, b3, "l53", 0.1);
+        g0.setRegulatingTerminal(l01.getTerminal2()); // remote
+        TwoWindingsTransformer t34 = createTransformer(network, "s", b3, b4, "tr34", 0.15, 1);
+        t34.newRatioTapChanger()
+                .beginStep()
+                .setRho(0.9)
+                .endStep()
+                .beginStep()
+                .setRho(1)
+                .endStep()
+                .beginStep()
+                .setRho(1.1)
+                .endStep()
+                .beginStep()
+                .setRho(1.2)
+                .endStep()
+                .setTapPosition(1)
+                .setLoadTapChangingCapabilities(true)
+                .setRegulating(true)
+                .setTargetV(1.1)
+                .setRegulationTerminal(t34.getTerminal1())
+                .setTargetDeadband(0.01)
+                .add();
+        return network;
+    }
+}

--- a/src/test/java/com/powsybl/openloadflow/network/ZeroImpedanceNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/ZeroImpedanceNetworkFactory.java
@@ -23,7 +23,7 @@ public class ZeroImpedanceNetworkFactory extends AbstractLoadFlowNetworkFactory 
      *                   |
      *                   ld5
      */
-    public static Network createWithVoltageRegulation() {
+    public static Network createWithVoltageControl() {
         Network network = Network.create("test", "code");
         Bus b0 = createBus(network, "s", "b0");
         Bus b1 = createBus(network, "s", "b1");

--- a/src/test/java/com/powsybl/openloadflow/network/ZeroImpedanceNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/ZeroImpedanceNetworkFactory.java
@@ -11,7 +11,7 @@ import com.powsybl.iidm.network.*;
 /**
  * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
-public class NonImpedantNetworkFactory extends AbstractLoadFlowNetworkFactory {
+public class ZeroImpedanceNetworkFactory extends AbstractLoadFlowNetworkFactory {
 
     /**
      *

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
@@ -1422,7 +1422,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
 
     @Test
     void testTerminalsConnectionAction2() {
-        Network network = NonImpedantNetworkFactory.createWithVoltageRegulation();
+        Network network = ZeroImpedanceNetworkFactory.createWithVoltageRegulation();
         LoadFlowParameters loadFlowParameters = new LoadFlowParameters()
                 .setDistributedSlack(false)
                 .setTransformerVoltageControlOn(true);

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
@@ -1443,6 +1443,6 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
         // pre-contingency verification
         PreContingencyResult preContingencyResult = result.getPreContingencyResult();
         assertEquals(1.000, preContingencyResult.getNetworkResult().getBusResult("b1").getV(), DELTA_V); // g0 is controlling voltage of b1
-        assertEquals(1.000, preContingencyResult.getNetworkResult().getBusResult("b3").getV(), DELTA_V); // tr34 is controlling voltage of b3
+        assertEquals(1.000, preContingencyResult.getNetworkResult().getBusResult("b3").getV(), DELTA_V); // g0 is controlling voltage of b3
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
@@ -1422,7 +1422,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
 
     @Test
     void testTerminalsConnectionAction2() {
-        Network network = ZeroImpedanceNetworkFactory.createWithVoltageRegulation();
+        Network network = ZeroImpedanceNetworkFactory.createWithVoltageControl();
         LoadFlowParameters loadFlowParameters = new LoadFlowParameters()
                 .setDistributedSlack(false)
                 .setTransformerVoltageControlOn(true);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

Yes, in PR #955 issue found during unit testing.

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

A line is reconnected temporary for loading only if it is disconnected at both side. If one side is connected, the line is in the LF network. In main branch, a line connected tagged as to be closed in an action is processed as disconnected. The result is a big bug in the topology restauration just after loading.  

**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
