### PR TITLE
Generation action generator change must stay within Pmin and Pmax

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/LfAction.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfAction.java
@@ -328,36 +328,25 @@ public final class LfAction {
         }
     }
 
-        if (generatorChange != null) {
-            LfGenerator generator = generatorChange.generator();
-            if (!generator.isDisabled()) {
-                double changeTargetP = generatorChange.changeTargetP();
-                double oldTargetP = generator.getTargetP();
-                double newTargetP;
-                if (generatorChange.isRelative()) {
-                    newTargetP = oldTargetP + changeTargetP;
-                    // relative change : active limits are applied if useActiveLimits is true and if the generator target is already within its [Pmin;Pmax]
-                    if (networkParameters.isUseActiveLimits() && oldTargetP >= generator.getMinP() && oldTargetP <= generator.getMaxP()) {
-                        newTargetP = Math.max(Math.min(newTargetP, generator.getMaxP()), generator.getMinP());
-                        if (newTargetP == generator.getMaxP() || newTargetP == generator.getMinP()) {
-                            LOGGER.warn("Action on generator {} restricted to its active power limits [{}MW;{}MW], new target P set to {}MW", generator.getId(), generator.getMinP() * PerUnit.SB, generator.getMaxP() * PerUnit.SB, newTargetP * PerUnit.SB);
-                        }
-                    }
-                } else {
-                    // absolute change : active limits are ignored
-                    newTargetP = changeTargetP;
-                }
-                generator.setTargetP(newTargetP);
-                if (!AbstractLfGenerator.checkActivePowerControl(generator.getId(), generator.getTargetP(), generator.getMinP(), generator.getMaxP(),
-                        networkParameters.getPlausibleActivePowerLimit(), networkParameters.isUseActiveLimits(), null)) {
-                    generator.setParticipating(false);
-                }
-            }
-        }
     private void applyGeneratorChange(LfNetworkParameters networkParameters) {
         LfGenerator generator = generatorChange.generator();
         if (!generator.isDisabled()) {
-            double newTargetP = generatorChange.isRelative() ? generator.getTargetP() + generatorChange.activePowerValue() : generatorChange.activePowerValue();
+            double activePowerValue = generatorChange.activePowerValue();
+            double oldTargetP = generator.getTargetP();
+            double newTargetP;
+            if (generatorChange.isRelative()) {
+                newTargetP = oldTargetP + activePowerValue;
+                // relative change : active limits are applied if useActiveLimits is true and if the generator target is already within its [Pmin;Pmax]
+                if (networkParameters.isUseActiveLimits() && oldTargetP >= generator.getMinP() && oldTargetP <= generator.getMaxP()) {
+                    newTargetP = Math.max(Math.min(newTargetP, generator.getMaxP()), generator.getMinP());
+                    if (newTargetP == generator.getMaxP() || newTargetP == generator.getMinP()) {
+                        LOGGER.warn("Action on generator {} restricted to its active power limits [{}MW;{}MW], new target P set to {}MW", generator.getId(), generator.getMinP() * PerUnit.SB, generator.getMaxP() * PerUnit.SB, newTargetP * PerUnit.SB);
+                    }
+                }
+            } else {
+                // absolute change : active limits are ignored
+                newTargetP = activePowerValue;
+            }
             generator.setTargetP(newTargetP);
             if (!AbstractLfGenerator.checkActivePowerControl(generator.getId(), generator.getTargetP(), generator.getMinP(), generator.getMaxP(),
                     networkParameters.getPlausibleActivePowerLimit(), networkParameters.isUseActiveLimits(), null)) {

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
@@ -872,7 +872,10 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
         parameters.setDistributedSlack(true).setBalanceType(balanceType);
         parameters.setDc(dc);
         OpenLoadFlowParameters openLoadFlowParameters = new OpenLoadFlowParameters();
-        openLoadFlowParameters.setSlackBusPMaxMismatch(slackBusPMaxMismatch);
+        openLoadFlowParameters.setUseActiveLimits(useActiveLimits);
+        openLoadFlowParameters.setNewtonRaphsonStoppingCriteriaType(NewtonRaphsonStoppingCriteriaType.PER_EQUATION_TYPE_CRITERIA);
+        openLoadFlowParameters.setMaxActivePowerMismatch(1e-3);
+        openLoadFlowParameters.setSlackBusPMaxMismatch(1e-3);
         parameters.addExtension(OpenLoadFlowParameters.class, openLoadFlowParameters);
         SecurityAnalysisParameters securityAnalysisParameters = new SecurityAnalysisParameters();
         securityAnalysisParameters.setLoadFlowParameters(parameters);
@@ -912,8 +915,8 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
         assertEquals(network.getLine("l34").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG2").getNetworkResult().getBranchResult("l34").getP1(), LoadFlowAssert.DELTA_POWER);
 
         // reverse action and apply third remedial action
-        setTargetPWithinLimits(network.getGenerator(g2), g2PostContingencyTargetP, openLoadFlowParameters);
-        setTargetPWithinLimits(network.getGenerator(g4), targetPG4 + g4PostContingencyTargetP - g4InitialTargetP, openLoadFlowParameters);
+        network.getGenerator(g2).setTargetP(g2PostContingencyTargetP);
+        network.getGenerator(g4).setTargetP(targetPG4);
         loadFlowRunner.run(network, parameters);
         assertEquals(network.getLine("l12").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG3").getNetworkResult().getBranchResult("l12").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(network.getLine("l14").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG3").getNetworkResult().getBranchResult("l14").getP1(), LoadFlowAssert.DELTA_POWER);
@@ -928,7 +931,6 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
         assertEquals(network.getLine("l14").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG4").getNetworkResult().getBranchResult("l14").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(network.getLine("l23").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG4").getNetworkResult().getBranchResult("l23").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(network.getLine("l34").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG4").getNetworkResult().getBranchResult("l34").getP1(), LoadFlowAssert.DELTA_POWER);
-
     }
 
     void setTargetPWithinLimits(Generator g, final double askedTargetP, final OpenLoadFlowParameters parameters) {
@@ -942,15 +944,15 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
 
     @Test
     void testGeneratorAction() {
-        testGeneratorAction(false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD, true, 2.0, -1.5, 2, 0.0001);
-        testGeneratorAction(false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD, true, 1.0, -1.0, 4, 0.0001);
-        testGeneratorAction(false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD, false, 1.0, -1.0, 4, 0.0001);
-        testGeneratorAction(false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX, true, 1.77, -0.3, 0.0, 0.0005);
-        testGeneratorAction(false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX, false, 1.77, -0.3, 0.0, 0.0005);
-        testGeneratorAction(false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX, true, 0.5, -1.0, 2, 0.0005);
-        testGeneratorAction(true, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD, true, 2.0, -1.5, 0, 0.0001);
-        testGeneratorAction(true, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX, false, 1.0, -1.0, 2, 0.0001);
-        testGeneratorAction(true, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX, true, 1.0, -1.0, 2, 0.0001);
+        testGeneratorAction(false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD, true, 1.0, 2.0, -1.5, 2);
+        testGeneratorAction(false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD, true, 2.0, 1.0, -1.0, 4);
+        testGeneratorAction(false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD, false, 1.0, 1.0, -1.0, 4);
+        testGeneratorAction(false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX, true, 1.0, 1.77, -0.3, 2.0);
+        testGeneratorAction(false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX, false, 2.0, 1.77, -0.3, 0);
+        testGeneratorAction(false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX, true, 2.0, 0.5, -1.0, 2);
+        testGeneratorAction(true, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD, true, 1.0, 2.0, -1.5, 0);
+        testGeneratorAction(true, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX, false, 1.0, 1.0, -1.0, 2);
+        testGeneratorAction(true, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX, true, 2.0, 1.0, -1.0, 2);
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
@@ -847,6 +847,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
         Network network = FourBusNetworkFactory.create();
         network.getLoad("d2").setP0(2.3); // to unbalance the network.
         network.getGenerator("g1").setMinP(1.95).setTargetP(initialG1); // set a high minP value to test cases when g1 is outside its P limits
+        network.getGenerator("g4").setMinP(0.5);
 
         final String lineInContingencyId = "l13";
         List<Contingency> contingencies = Stream.of(lineInContingencyId)

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
@@ -18,7 +18,6 @@ import com.powsybl.openloadflow.ac.solver.NewtonRaphsonStoppingCriteriaType;
 import com.powsybl.openloadflow.graph.GraphConnectivityFactory;
 import com.powsybl.openloadflow.graph.NaiveGraphConnectivityFactory;
 import com.powsybl.openloadflow.network.*;
-import com.powsybl.openloadflow.network.impl.AbstractLfGenerator;
 import com.powsybl.openloadflow.util.LoadFlowAssert;
 import com.powsybl.security.*;
 import com.powsybl.security.condition.AllViolationCondition;

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
@@ -895,7 +895,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
         double g2PostContingencyTargetP = network.getGenerator(g2).getTargetP();
 
         // apply remedial action
-        network.getGenerator(g1).setTargetP(g1PostContingencyTargetP + deltaG1);
+        setTargetPWithinLimits(network.getGenerator(g1), g1PostContingencyTargetP + deltaG1);
         loadFlowRunner.run(network, parameters);
         assertEquals(network.getLine("l12").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG1").getNetworkResult().getBranchResult("l12").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(network.getLine("l14").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG1").getNetworkResult().getBranchResult("l14").getP1(), LoadFlowAssert.DELTA_POWER);
@@ -903,8 +903,8 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
         assertEquals(network.getLine("l34").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG1").getNetworkResult().getBranchResult("l34").getP1(), LoadFlowAssert.DELTA_POWER);
 
         // reverse action and apply second remedial action
-        network.getGenerator(g1).setTargetP(g1PostContingencyTargetP);
-        network.getGenerator(g2).setTargetP(g2PostContingencyTargetP + deltaG2);
+        setTargetPWithinLimits(network.getGenerator(g1), g1PostContingencyTargetP);
+        setTargetPWithinLimits(network.getGenerator(g2), g2PostContingencyTargetP + deltaG2);
         loadFlowRunner.run(network, parameters);
         assertEquals(network.getLine("l12").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG2").getNetworkResult().getBranchResult("l12").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(network.getLine("l14").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG2").getNetworkResult().getBranchResult("l14").getP1(), LoadFlowAssert.DELTA_POWER);
@@ -921,14 +921,18 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
         assertEquals(network.getLine("l34").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG3").getNetworkResult().getBranchResult("l34").getP1(), LoadFlowAssert.DELTA_POWER);
 
         // reverse action and apply fourth remedial action
-        network.getGenerator(g2).setTargetP(g2PostContingencyTargetP + deltaG2);
-        network.getGenerator(g1).setTargetP(g1PostContingencyTargetP + deltaG1);
+        setTargetPWithinLimits(network.getGenerator(g2), g2PostContingencyTargetP + deltaG2);
+        setTargetPWithinLimits(network.getGenerator(g1), g1PostContingencyTargetP + deltaG1);
         loadFlowRunner.run(network, parameters);
         assertEquals(network.getLine("l12").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG4").getNetworkResult().getBranchResult("l12").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(network.getLine("l14").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG4").getNetworkResult().getBranchResult("l14").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(network.getLine("l23").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG4").getNetworkResult().getBranchResult("l23").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(network.getLine("l34").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG4").getNetworkResult().getBranchResult("l34").getP1(), LoadFlowAssert.DELTA_POWER);
 
+    }
+
+    void setTargetPWithinLimits(Generator g, double askedTargetP) {
+        g.setTargetP(Math.max(Math.min(askedTargetP, g.getMaxP()), g.getMinP()));
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
bugfix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
During SA, when applying a lfAction that changes generator's Target P, it can set a target that is outside of the generator's Pmin and Pmax.


**What is the new behavior (if this is a feature change)?**
The new targetP value is limited by Pmin and Pmax


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
