### PR TITLE
Fix ComponentResult distributed active power

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/DistributedSlackOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/DistributedSlackOuterLoop.java
@@ -91,6 +91,9 @@ public class DistributedSlackOuterLoop implements AcOuterLoop {
                 case DISTRIBUTE_ON_REFERENCE_GENERATOR -> {
                     Objects.requireNonNull(referenceGenerator, () -> "No reference generator in " + context.getNetwork());
                     // remaining goes to reference generator, without any limit consideration
+                    LOGGER.debug("{} MW distributed to reference generator '{}'",
+                            remainingMismatch * PerUnit.SB, referenceGenerator.getId());
+                    contextData.addDistributedActivePower(remainingMismatch);
                     referenceGenerator.setTargetP(referenceGenerator.getTargetP() + remainingMismatch);
                     // create a new result with iteration++, 0.0 mismatch and movedBuses to true
                     result = new ActivePowerDistribution.Result(result.iteration() + 1, 0.0, true);

--- a/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
@@ -330,6 +330,10 @@ class DistributedSlackOnGenerationTest {
         LoadFlowResult.ComponentResult componentResult = result.getComponentResults().get(0);
         assertTrue(result.isFullyConverged());
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, componentResult.getStatus());
+        // DistributedActivePower: 520MW, breakdown:
+        // - 320MW by all 4 generators hitting maxP limit
+        // - 200MW by distributing on reference generator g1
+        assertEquals(520., componentResult.getDistributedActivePower(), 1e-3);
         assertEquals(0., componentResult.getSlackBusResults().get(0).getActivePowerMismatch(), 1e-3);
         assertAngleEquals(0., g1.getTerminal().getBusView().getBus());
         // can exceed maxP (200MW)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
With parameter `slackDistributionFailureBehavior` set to `DISTRIBUTE_ON_REFERENCE_GENERATOR`, the reported distributed active power in the LoadFlowResult's component results is wrong.


**What is the new behavior (if this is a feature change)?**
Fixed the DistributedSlackOuterLoop to properly account slack active power distributed to reference generator


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
The feature `slackDistributionFailureBehavior` `DISTRIBUTE_ON_REFERENCE_GENERATOR` was originally developed in #959.
