### PR TITLE
Add unit test with VSC voltage control and targetP = 0

### DIFF
--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
@@ -401,7 +401,7 @@ class AcLoadFlowVscTest {
     }
 
     @Test
-    void testVscVoltageRegulationWithoutTransit() {
+    void testVscVoltageControlWithZeroTargetP() {
         Network network = HvdcNetworkFactory.createHvdcLinkedByTwoLinesAndSwitch(HvdcConverterStation.HvdcType.VSC);
         LoadFlow.Runner loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
         // Set specific voltage setPoints to the stations
@@ -410,7 +410,7 @@ class AcLoadFlowVscTest {
         network.getVscConverterStation("cs2").setVoltageSetpoint(vcs2);
         network.getVscConverterStation("cs3").setVoltageSetpoint(vcs3);
 
-        // shut down active transit in HVDC
+        // shut down active power flow in HVDC
         network.getHvdcLine("hvdc23").setActivePowerSetpoint(0);
         network.getHvdcLine("hvdc23").getExtension(HvdcAngleDroopActivePowerControl.class).setDroop(0).setP0(0);
 
@@ -421,25 +421,24 @@ class AcLoadFlowVscTest {
         LoadFlowResult result = loadFlowRunner.run(network, p);
 
         assertTrue(result.isFullyConverged());
-        assertEquals(0, network.getVscConverterStation("cs2").getTerminal().getP(), DELTA_POWER);
-        assertEquals(vcs2, network.getVscConverterStation("cs2").getTerminal().getBusView().getBus().getV(), DELTA_V);
-        assertEquals(0, network.getVscConverterStation("cs3").getTerminal().getP(), DELTA_POWER);
-        assertEquals(vcs3, network.getVscConverterStation("cs3").getTerminal().getBusView().getBus().getV(), DELTA_V);
+        assertActivePowerEquals(0, network.getVscConverterStation("cs2").getTerminal());
+        assertVoltageEquals(vcs2, network.getVscConverterStation("cs2").getTerminal().getBusView().getBus());
+        assertActivePowerEquals(0, network.getVscConverterStation("cs3").getTerminal());
+        assertVoltageEquals(vcs3, network.getVscConverterStation("cs3").getTerminal().getBusView().getBus());
 
         // with AC emulation
         p.setHvdcAcEmulation(true);
         result = loadFlowRunner.run(network, p);
 
         assertTrue(result.isFullyConverged());
-        assertEquals(0, network.getVscConverterStation("cs2").getTerminal().getP(), DELTA_POWER);
-        assertEquals(vcs2, network.getVscConverterStation("cs2").getTerminal().getBusView().getBus().getV(), DELTA_V);
-        assertEquals(0, network.getVscConverterStation("cs3").getTerminal().getP(), DELTA_POWER);
-        assertEquals(vcs3, network.getVscConverterStation("cs3").getTerminal().getBusView().getBus().getV(), DELTA_V);
-
+        assertActivePowerEquals(0, network.getVscConverterStation("cs2").getTerminal());
+        assertVoltageEquals(vcs2, network.getVscConverterStation("cs2").getTerminal().getBusView().getBus());
+        assertActivePowerEquals(0, network.getVscConverterStation("cs3").getTerminal());
+        assertVoltageEquals(vcs3, network.getVscConverterStation("cs3").getTerminal().getBusView().getBus());
     }
 
     @Test
-    void testVscVoltageRegulationWhenOneSideDisconnected() {
+    void testVscVoltageControlWithOneSideDisconnected() {
         Network network = HvdcNetworkFactory.createHvdcLinkedByTwoLinesAndSwitch(HvdcConverterStation.HvdcType.VSC);
         LoadFlow.Runner loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
         // Set specific voltage setPoints to the stations
@@ -459,15 +458,14 @@ class AcLoadFlowVscTest {
         LoadFlowResult result = loadFlowRunner.run(network, p);
 
         assertTrue(result.isFullyConverged());
-        assertEquals(0, network.getVscConverterStation("cs2").getTerminal().getP(), DELTA_POWER);
-        assertEquals(vcs2, network.getVscConverterStation("cs2").getTerminal().getBusView().getBus().getV(), DELTA_V);
+        assertActivePowerEquals(0, network.getVscConverterStation("cs2").getTerminal());
+        assertVoltageEquals(vcs2, network.getVscConverterStation("cs2").getTerminal().getBusView().getBus());
 
         // with AC emulation
         p.setHvdcAcEmulation(true);
         result = loadFlowRunner.run(network, p);
 
-        assertEquals(0, network.getVscConverterStation("cs2").getTerminal().getP(), DELTA_POWER);
-        assertEquals(vcs2, network.getVscConverterStation("cs2").getTerminal().getBusView().getBus().getV(), DELTA_V);
-
+        assertActivePowerEquals(0, network.getVscConverterStation("cs2").getTerminal());
+        assertVoltageEquals(vcs2, network.getVscConverterStation("cs2").getTerminal().getBusView().getBus());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.openloadflow.ac;
 
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.extensions.HvdcAngleDroopActivePowerControl;
 import com.powsybl.iidm.network.extensions.HvdcAngleDroopActivePowerControlAdder;
 import com.powsybl.loadflow.LoadFlow;
 import com.powsybl.loadflow.LoadFlowParameters;
@@ -397,5 +398,76 @@ class AcLoadFlowVscTest {
         assertActivePowerEquals(2.0, network.getVscConverterStation("cs4").getTerminal());
         assertActivePowerEquals(-2.0, network.getGenerator("g4").getTerminal());
         assertActivePowerEquals(-2.047, network.getGenerator("g1").getTerminal());
+    }
+
+    @Test
+    void testVscVoltageRegulationWithoutTransit() {
+        Network network = HvdcNetworkFactory.createHvdcLinkedByTwoLinesAndSwitch(HvdcConverterStation.HvdcType.VSC);
+        LoadFlow.Runner loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
+        // Set specific voltage setPoints to the stations
+        double vcs2 = 397;
+        double vcs3 = 401;
+        network.getVscConverterStation("cs2").setVoltageSetpoint(vcs2);
+        network.getVscConverterStation("cs3").setVoltageSetpoint(vcs3);
+
+        // shut down active transit in HVDC
+        network.getHvdcLine("hvdc23").setActivePowerSetpoint(0);
+        network.getHvdcLine("hvdc23").getExtension(HvdcAngleDroopActivePowerControl.class).setDroop(0).setP0(0);
+
+        LoadFlowParameters p = new LoadFlowParameters();
+
+        // without AC emulation
+        p.setHvdcAcEmulation(false);
+        LoadFlowResult result = loadFlowRunner.run(network, p);
+
+        assertTrue(result.isFullyConverged());
+        assertEquals(0, network.getVscConverterStation("cs2").getTerminal().getP(), DELTA_POWER);
+        assertEquals(vcs2, network.getVscConverterStation("cs2").getTerminal().getBusView().getBus().getV(), DELTA_V);
+        assertEquals(0, network.getVscConverterStation("cs3").getTerminal().getP(), DELTA_POWER);
+        assertEquals(vcs3, network.getVscConverterStation("cs3").getTerminal().getBusView().getBus().getV(), DELTA_V);
+
+        // with AC emulation
+        p.setHvdcAcEmulation(true);
+        result = loadFlowRunner.run(network, p);
+
+        assertTrue(result.isFullyConverged());
+        assertEquals(0, network.getVscConverterStation("cs2").getTerminal().getP(), DELTA_POWER);
+        assertEquals(vcs2, network.getVscConverterStation("cs2").getTerminal().getBusView().getBus().getV(), DELTA_V);
+        assertEquals(0, network.getVscConverterStation("cs3").getTerminal().getP(), DELTA_POWER);
+        assertEquals(vcs3, network.getVscConverterStation("cs3").getTerminal().getBusView().getBus().getV(), DELTA_V);
+
+    }
+
+    @Test
+    void testVscVoltageRegulationWhenOneSideDisconnected() {
+        Network network = HvdcNetworkFactory.createHvdcLinkedByTwoLinesAndSwitch(HvdcConverterStation.HvdcType.VSC);
+        LoadFlow.Runner loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
+        // Set specific voltage setPoints to the stations
+        double vcs2 = 397;
+        double vcs3 = 401;
+        network.getVscConverterStation("cs2").setVoltageSetpoint(vcs2);
+        network.getVscConverterStation("cs3").setVoltageSetpoint(vcs3);
+
+        // Disconnect line at HVDCoutput
+        Line l34 = network.getLine("l34");
+        l34.getTerminals().stream().forEach(Terminal::disconnect);
+
+        LoadFlowParameters p = new LoadFlowParameters();
+
+        // without AC emulation
+        p.setHvdcAcEmulation(false);
+        LoadFlowResult result = loadFlowRunner.run(network, p);
+
+        assertTrue(result.isFullyConverged());
+        assertEquals(0, network.getVscConverterStation("cs2").getTerminal().getP(), DELTA_POWER);
+        assertEquals(vcs2, network.getVscConverterStation("cs2").getTerminal().getBusView().getBus().getV(), DELTA_V);
+
+        // with AC emulation
+        p.setHvdcAcEmulation(true);
+        result = loadFlowRunner.run(network, p);
+
+        assertEquals(0, network.getVscConverterStation("cs2").getTerminal().getP(), DELTA_POWER);
+        assertEquals(vcs2, network.getVscConverterStation("cs2").getTerminal().getBusView().getBus().getV(), DELTA_V);
+
     }
 }


### PR DESCRIPTION
… in the hvdc line

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X ] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Explicit tests to check that a VSC in voltage control station holds tension even if no active power is flowing through the HVDC line.



**What is the current behavior?**
VSC stations behave as they should (tension is maintained even if P=0) but there is no explicit test to verify this.
VSC stations are holding tensions because the test check that Pmin < epsilon but for VSC stations Pmin is large but negative.
The tests prevent that a change in this condition breaks the VSC desired behviour. 



**What is the new behavior (if this is a feature change)?**
No behaviour change. Just tests that ensure that the desired behaviour will not be broken by accident. 


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ X] No




