### PR TITLE
Fix restoreInitialTopology in SA with multiple SCs

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
@@ -237,9 +237,6 @@ public final class Networks {
                     // disable all buses and branches not connected to main component (because of switch to close)
                     restoreInitialTopology(lfNetwork, switchAndBranchIdsLeftToClose);
                 }
-                if (!switchAndBranchIdsLeftToClose.isEmpty()) {
-                    throw new PowsyblException("Could not restore initial topology: " + switchAndBranchIdsLeftToClose.size() + " switches or branches were not closed");
-                }
             }
 
             return new LfNetworkList(lfNetworks, variantCleanerFactory.create(network, workingVariantId, tmpVariantId));

--- a/src/test/java/com/powsybl/openloadflow/network/FourBusNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/FourBusNetworkFactory.java
@@ -188,5 +188,16 @@ public class FourBusNetworkFactory extends AbstractLoadFlowNetworkFactory {
                 .setMinP(0.0);
         return network;
     }
+
+    public static Network createWithTwoScs() {
+        Network network = createBaseNetwork();
+        Bus c1 = createBus(network, "c1");
+        Bus c2 = createBus(network, "c2");
+        createGenerator(c1, "gc1", 2);
+        createLoad(c2, "dc2", 1);
+        createLine(network, c1, c2, "lc12", 1f);
+        createLine(network, c1, c2, "lc12Bis", 1f);
+        return network;
+    }
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)




**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When restoring the initial topology in SA, we try to close switches/branches in all LfNetworks. When we have more than 1 LfNetwork, the code crashes.


**What is the new behavior (if this is a feature change)?**
We will be able to restore the initial topology in SA with multiple SCs.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No