### PR TITLE
Honnor HVDCOperatorActivePowerRange as well as Pmax of hvdcLine in AC emulation

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractHvdcAcEmulationFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractHvdcAcEmulationFlowEquationTerm.java
@@ -55,6 +55,9 @@ public abstract class AbstractHvdcAcEmulationFlowEquationTerm extends AbstractEl
     }
 
     protected double boundedP(double rawP) {
+        // If there is a maximal active power
+        // it is applied at the entry of the controller VSC station
+        // on the AC side of the network.
         if (rawP >= 0) {
             return Math.min(rawP, pMaxFromCS1toCS2);
         } else {

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractHvdcAcEmulationFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractHvdcAcEmulationFlowEquationTerm.java
@@ -33,6 +33,10 @@ public abstract class AbstractHvdcAcEmulationFlowEquationTerm extends AbstractEl
 
     protected final double lossFactor2;
 
+    protected final double pMaxFromCS1toCS2;
+
+    protected final double pMaxFromCS2toCS1;
+
     protected AbstractHvdcAcEmulationFlowEquationTerm(LfHvdc hvdc, LfBus bus1, LfBus bus2, VariableSet<AcVariableType> variableSet) {
         super(hvdc);
         ph1Var = variableSet.getVariable(bus1.getNum(), AcVariableType.BUS_PHI);
@@ -42,6 +46,20 @@ public abstract class AbstractHvdcAcEmulationFlowEquationTerm extends AbstractEl
         p0 = hvdc.getP0();
         lossFactor1 = hvdc.getConverterStation1().getLossFactor() / 100;
         lossFactor2 = hvdc.getConverterStation2().getLossFactor() / 100;
+        pMaxFromCS1toCS2 = hvdc.getPMaxFromCS1toCS2();
+        pMaxFromCS2toCS1 = hvdc.getPMaxFromCS2toCS1();
+    }
+
+    protected double rawP(double p0, double k, double ph1, double ph2) {
+        return p0 + k * (ph1 - ph2);
+    }
+
+    protected double boundedP(double rawP) {
+        if (rawP >= 0) {
+            return Math.min(rawP, pMaxFromCS1toCS2);
+        } else {
+            return Math.max(rawP, -pMaxFromCS2toCS1);
+        }
     }
 
     protected double ph1() {
@@ -52,7 +70,7 @@ public abstract class AbstractHvdcAcEmulationFlowEquationTerm extends AbstractEl
         return sv.get(ph2Var.getRow());
     }
 
-    protected static double getLossMultiplier(double lossFactor1, double lossFactor2) {
+    protected double getVscLossMultiplier() {
         return (1 - lossFactor1) * (1 - lossFactor2);
     }
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide1ActiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide1ActiveFlowEquationTerm.java
@@ -22,34 +22,45 @@ public class HvdcAcEmulationSide1ActiveFlowEquationTerm extends AbstractHvdcAcEm
         super(hvdc, bus1, bus2, variableSet);
     }
 
-    private static double p1(double p0, double k, double lossFactor1, double lossFactor2, double ph1, double ph2) {
-        return (isController(p0, k, ph1, ph2) ? 1 : getLossMultiplier(lossFactor1, lossFactor2)) * (p0 + k * (ph1 - ph2));
+    private double p1(double ph1, double ph2) {
+        double rawP = rawP(p0, k, ph1, ph2);
+        double boundedP = boundedP(rawP);
+        return (isController(rawP) ? 1 : getVscLossMultiplier()) * boundedP;
     }
 
-    private static boolean isController(double p0, double k, double ph1, double ph2) {
-        return (p0 + k * (ph1 - ph2)) >= 0;
+    private static boolean isController(double rawP) {
+        return rawP >= 0;
     }
 
-    private static double dp1dph1(double p0, double k, double lossFactor1, double lossFactor2, double ph1, double ph2) {
-        return (isController(p0, k, ph1, ph2) ? 1 : getLossMultiplier(lossFactor1, lossFactor2)) * k;
+    private boolean isInOperatingRange(double rawP) {
+        return rawP < pMaxFromCS1toCS2 && rawP > -pMaxFromCS2toCS1;
     }
 
-    private static double dp1dph2(double p0, double k, double lossFactor1, double lossFactor2, double ph1, double ph2) {
-        return -dp1dph1(p0, k, lossFactor1, lossFactor2, ph1, ph2);
+    protected double dp1dph1(double ph1, double ph2) {
+        double rawP = rawP(p0, k, ph1, ph2);
+        if (isInOperatingRange(rawP)) {
+            return (isController(rawP) ? 1 : getVscLossMultiplier()) * k;
+        } else {
+            return 0;
+        }
+    }
+
+    protected double dp1dph2(double ph1, double ph2) {
+        return -dp1dph1(ph1, ph2);
     }
 
     @Override
     public double eval() {
-        return p1(p0, k, lossFactor1, lossFactor2, ph1(), ph2());
+        return p1(ph1(), ph2());
     }
 
     @Override
     public double der(Variable<AcVariableType> variable) {
         Objects.requireNonNull(variable);
         if (variable.equals(ph1Var)) {
-            return dp1dph1(p0, k, lossFactor1, lossFactor2, ph1(), ph2());
+            return dp1dph1(ph1(), ph2());
         } else if (variable.equals(ph2Var)) {
-            return dp1dph2(p0, k, lossFactor1, lossFactor2, ph1(), ph2());
+            return dp1dph2(ph1(), ph2());
         } else {
             throw new IllegalStateException("Unknown variable: " + variable);
         }

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide2ActiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide2ActiveFlowEquationTerm.java
@@ -22,34 +22,45 @@ public class HvdcAcEmulationSide2ActiveFlowEquationTerm extends AbstractHvdcAcEm
         super(hvdc, bus1, bus2, variableSet);
     }
 
-    private static double p2(double p0, double k, double lossFactor1, double lossFactor2, double ph1, double ph2) {
-        return -(isController(p0, k, ph1, ph2) ? 1 : getLossMultiplier(lossFactor1, lossFactor2)) * (p0 + k * (ph1 - ph2));
+    private double p2(double ph1, double ph2) {
+        double rawP = rawP(p0, k, ph1, ph2);
+        double boundedP = boundedP(rawP);
+        return -(isController(rawP) ? 1 : getVscLossMultiplier()) * boundedP;
     }
 
-    private static boolean isController(double p0, double k, double ph1, double ph2) {
-        return (p0 + k * (ph1 - ph2)) < 0;
+    private boolean isController(double rawP) {
+        return rawP < 0;
     }
 
-    private static double dp2dph1(double p0, double k, double lossFactor1, double lossFactor2, double ph1, double ph2) {
-        return -(isController(p0, k, ph1, ph2) ? 1 : getLossMultiplier(lossFactor1, lossFactor2)) * k;
+    private boolean isInOperatingRange(double rawP) {
+        return rawP < pMaxFromCS2toCS1 && rawP > -pMaxFromCS1toCS2;
     }
 
-    private static double dp2dph2(double p0, double k, double lossFactor1, double lossFactor2, double ph1, double ph2) {
-        return -dp2dph1(p0, k, lossFactor1, lossFactor2, ph1, ph2);
+    private double dp2dph1(double ph1, double ph2) {
+        double rawP = rawP(p0, k, ph1, ph2);
+        if (isInOperatingRange(rawP)) {
+            return -(isController(rawP) ? 1 : getVscLossMultiplier()) * k;
+        } else {
+            return 0;
+        }
+    }
+
+    private double dp2dph2(double ph1, double ph2) {
+        return -dp2dph1(ph1, ph2);
     }
 
     @Override
     public double eval() {
-        return p2(p0, k, lossFactor1, lossFactor2, ph1(), ph2());
+        return p2(ph1(), ph2());
     }
 
     @Override
     public double der(Variable<AcVariableType> variable) {
         Objects.requireNonNull(variable);
         if (variable.equals(ph1Var)) {
-            return dp2dph1(p0, k, lossFactor1, lossFactor2, ph1(), ph2());
+            return dp2dph1(ph1(), ph2());
         } else if (variable.equals(ph2Var)) {
-            return dp2dph2(p0, k, lossFactor1, lossFactor2, ph1(), ph2());
+            return dp2dph2(ph1(), ph2());
         } else {
             throw new IllegalStateException("Unknown variable: " + variable);
         }

--- a/src/main/java/com/powsybl/openloadflow/network/LfHvdc.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfHvdc.java
@@ -44,4 +44,8 @@ public interface LfHvdc extends LfElement {
     void setConverterStation2(LfVscConverterStation converterStation2);
 
     void updateState();
+
+    double getPMaxFromCS1toCS2();
+
+    double getPMaxFromCS2toCS1();
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfHvdcImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfHvdcImpl.java
@@ -46,12 +46,7 @@ public class LfHvdcImpl extends AbstractElement implements LfHvdc {
 
     private final double pMaxFromCS2toCS1;
 
-    public LfHvdcImpl(String id,
-                      LfBus bus1,
-                      LfBus bus2,
-                      LfNetwork network,
-                      HvdcLine hvdcLine,
-                      boolean acEmulation) {
+    public LfHvdcImpl(String id, LfBus bus1, LfBus bus2, LfNetwork network, HvdcLine hvdcLine, boolean acEmulation) {
         super(network);
         this.id = Objects.requireNonNull(id);
         this.bus1 = bus1;

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfHvdcImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfHvdcImpl.java
@@ -6,7 +6,9 @@
  */
 package com.powsybl.openloadflow.network.impl;
 
+import com.powsybl.iidm.network.HvdcLine;
 import com.powsybl.iidm.network.extensions.HvdcAngleDroopActivePowerControl;
+import com.powsybl.iidm.network.extensions.HvdcOperatorActivePowerRange;
 import com.powsybl.openloadflow.network.*;
 import com.powsybl.openloadflow.util.Evaluable;
 import com.powsybl.openloadflow.util.PerUnit;
@@ -40,16 +42,33 @@ public class LfHvdcImpl extends AbstractElement implements LfHvdc {
 
     private boolean acEmulation;
 
-    public LfHvdcImpl(String id, LfBus bus1, LfBus bus2, LfNetwork network, HvdcAngleDroopActivePowerControl control,
+    private final double pMaxFromCS1toCS2;
+
+    private final double pMaxFromCS2toCS1;
+
+    public LfHvdcImpl(String id,
+                      LfBus bus1,
+                      LfBus bus2,
+                      LfNetwork network,
+                      HvdcLine hvdcLine,
                       boolean acEmulation) {
         super(network);
         this.id = Objects.requireNonNull(id);
         this.bus1 = bus1;
         this.bus2 = bus2;
-        this.acEmulation = acEmulation && control != null && control.isEnabled();
+        HvdcAngleDroopActivePowerControl droopControl = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
+        this.acEmulation = acEmulation && droopControl != null && droopControl.isEnabled();
         if (this.acEmulation) {
-            droop = control.getDroop();
-            p0 = control.getP0();
+            droop = droopControl.getDroop();
+            p0 = droopControl.getP0();
+        }
+        HvdcOperatorActivePowerRange powerRange = hvdcLine.getExtension(HvdcOperatorActivePowerRange.class);
+        if (powerRange != null) {
+            pMaxFromCS1toCS2 = powerRange.getOprFromCS1toCS2();
+            pMaxFromCS2toCS1 = powerRange.getOprFromCS2toCS1();
+        } else {
+            pMaxFromCS2toCS1 = hvdcLine.getMaxP();
+            pMaxFromCS1toCS2 = hvdcLine.getMaxP();
         }
     }
 
@@ -156,5 +175,15 @@ public class LfHvdcImpl extends AbstractElement implements LfHvdc {
             ((LfVscConverterStationImpl) converterStation1).getStation().getTerminal().setP(p1.eval() * PerUnit.SB);
             ((LfVscConverterStationImpl) converterStation2).getStation().getTerminal().setP(p2.eval() * PerUnit.SB);
         }
+    }
+
+    @Override
+    public double getPMaxFromCS1toCS2() {
+        return Double.isNaN(pMaxFromCS1toCS2) ? Double.MAX_VALUE : pMaxFromCS1toCS2 / PerUnit.SB;
+    }
+
+    @Override
+    public double getPMaxFromCS2toCS1() {
+        return Double.isNaN(pMaxFromCS1toCS2) ? Double.MAX_VALUE : pMaxFromCS2toCS1 / PerUnit.SB;
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -487,9 +487,8 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
             LfBus lfBus2 = getLfBus(hvdcLine.getConverterStation2().getTerminal(), lfNetwork, parameters.isBreakers());
             LfVscConverterStationImpl cs1 = (LfVscConverterStationImpl) lfNetwork.getGeneratorById(hvdcLine.getConverterStation1().getId());
             LfVscConverterStationImpl cs2 = (LfVscConverterStationImpl) lfNetwork.getGeneratorById(hvdcLine.getConverterStation2().getId());
-            HvdcAngleDroopActivePowerControl control = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
             if (cs1 != null && cs2 != null) {
-                LfHvdc lfHvdc = new LfHvdcImpl(hvdcLine.getId(), lfBus1, lfBus2, lfNetwork, control, parameters.isHvdcAcEmulation());
+                LfHvdc lfHvdc = new LfHvdcImpl(hvdcLine.getId(), lfBus1, lfBus2, lfNetwork, hvdcLine, parameters.isHvdcAcEmulation());
                 lfHvdc.setConverterStation1(cs1);
                 lfHvdc.setConverterStation2(cs2);
                 lfNetwork.addHvdc(lfHvdc);

--- a/src/test/java/com/powsybl/openloadflow/EquationsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/EquationsTest.java
@@ -256,6 +256,8 @@ class EquationsTest {
         Mockito.doReturn(false).when(hvdc).isDisabled();
         Mockito.doReturn(DROOP).when(hvdc).getDroop();
         Mockito.doReturn(P_0).when(hvdc).getP0();
+        Mockito.doReturn(Double.MAX_VALUE).when(hvdc).getPMaxFromCS1toCS2();
+        Mockito.doReturn(Double.MAX_VALUE).when(hvdc).getPMaxFromCS2toCS1();
         LfVscConverterStationImpl station1 = Mockito.mock(LfVscConverterStationImpl.class, new RuntimeExceptionAnswer());
         LfVscConverterStationImpl station2 = Mockito.mock(LfVscConverterStationImpl.class, new RuntimeExceptionAnswer());
         Mockito.doReturn(station1).when(hvdc).getConverterStation1();

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
@@ -517,8 +517,8 @@ class AcLoadFlowVscTest {
         assertTrue(result.isFullyConverged());
 
         // Active flow capped at limit. Output has losses (due to VSC stations)
-        assertEquals(170, network.getHvdcConverterStation("cs2").getTerminal().getP(), DELTA_POWER);
-        assertEquals(-166.280, network.getHvdcConverterStation("cs3").getTerminal().getP(), DELTA_POWER);
+        assertActivePowerEquals(170, network.getHvdcConverterStation("cs2").getTerminal());
+        assertActivePowerEquals(-166.280, network.getHvdcConverterStation("cs3").getTerminal());
 
         // now invert power direction
         HvdcAngleDroopActivePowerControl activePowerControl = network.getHvdcLine("hvdc23").getExtension(HvdcAngleDroopActivePowerControl.class);
@@ -526,7 +526,7 @@ class AcLoadFlowVscTest {
         result = loadFlowRunner.run(network, p);
         assertTrue(result.isFullyConverged());
 
-        assertEquals(-166.280, network.getHvdcConverterStation("cs2").getTerminal().getP(), DELTA_POWER);
-        assertEquals(170, network.getHvdcConverterStation("cs3").getTerminal().getP(), DELTA_POWER);
+        assertActivePowerEquals(-166.280, network.getHvdcConverterStation("cs2").getTerminal());
+        assertActivePowerEquals(170, network.getHvdcConverterStation("cs3").getTerminal());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
@@ -501,4 +501,33 @@ class AcLoadFlowVscTest {
         System.out.println(network.getHvdcConverterStation("cs2").getTerminal().getP());
         System.out.println(network.getHvdcConverterStation("cs3").getTerminal().getP());
     }
+
+    @Test
+    void testAcEmuAndPMax() {
+        Network network = HvdcNetworkFactory.createHvdcLinkedByTwoLinesAndSwitch(HvdcConverterStation.HvdcType.VSC);
+        // without limit p=195
+        network.getHvdcLine("hvdc23")
+                .setMaxP(180);
+
+        LoadFlow.Runner loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
+        LoadFlowParameters p = new LoadFlowParameters();
+        p.setHvdcAcEmulation(true);
+        LoadFlowResult result = loadFlowRunner.run(network, p);
+
+        assertTrue(result.isFullyConverged());
+
+        // TODO: replace by comparison with accurate values once coded
+        System.out.println(network.getHvdcConverterStation("cs2").getTerminal().getP());
+        System.out.println(network.getHvdcConverterStation("cs3").getTerminal().getP());
+
+        // now invert power direction
+        HvdcAngleDroopActivePowerControl activePowerControl = network.getHvdcLine("hvdc23").getExtension(HvdcAngleDroopActivePowerControl.class);
+        activePowerControl.setP0(-activePowerControl.getP0());
+        result = loadFlowRunner.run(network, p);
+        assertTrue(result.isFullyConverged());
+
+        // TODO: replace by comparison with accurate values once coded
+        System.out.println(network.getHvdcConverterStation("cs2").getTerminal().getP());
+        System.out.println(network.getHvdcConverterStation("cs3").getTerminal().getP());
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
@@ -487,9 +487,9 @@ class AcLoadFlowVscTest {
 
         assertTrue(result.isFullyConverged());
 
-        // TODO: replace by comparison with accurate values once coded
-        System.out.println(network.getHvdcConverterStation("cs2").getTerminal().getP());
-        System.out.println(network.getHvdcConverterStation("cs3").getTerminal().getP());
+        // Active flow capped at limit. Output has losses (due to VSC stations)
+        assertEquals(170, network.getHvdcConverterStation("cs2").getTerminal().getP(), DELTA_POWER);
+        assertEquals(-166.280, network.getHvdcConverterStation("cs3").getTerminal().getP(), DELTA_POWER);
 
         // now invert power direction
         HvdcAngleDroopActivePowerControl activePowerControl = network.getHvdcLine("hvdc23").getExtension(HvdcAngleDroopActivePowerControl.class);
@@ -497,9 +497,9 @@ class AcLoadFlowVscTest {
         result = loadFlowRunner.run(network, p);
         assertTrue(result.isFullyConverged());
 
-        // TODO: replace by comparison with accurate values once coded
-        System.out.println(network.getHvdcConverterStation("cs2").getTerminal().getP());
-        System.out.println(network.getHvdcConverterStation("cs3").getTerminal().getP());
+        // Active flow capped at other direction's limit. Output has losses (due to VSC stations)
+        assertEquals(-176.062, network.getHvdcConverterStation("cs2").getTerminal().getP(), DELTA_POWER);
+        assertEquals(180, network.getHvdcConverterStation("cs3").getTerminal().getP(), DELTA_POWER);
     }
 
     @Test
@@ -507,7 +507,7 @@ class AcLoadFlowVscTest {
         Network network = HvdcNetworkFactory.createHvdcLinkedByTwoLinesAndSwitch(HvdcConverterStation.HvdcType.VSC);
         // without limit p=195
         network.getHvdcLine("hvdc23")
-                .setMaxP(180);
+                .setMaxP(170);
 
         LoadFlow.Runner loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
         LoadFlowParameters p = new LoadFlowParameters();
@@ -516,9 +516,9 @@ class AcLoadFlowVscTest {
 
         assertTrue(result.isFullyConverged());
 
-        // TODO: replace by comparison with accurate values once coded
-        System.out.println(network.getHvdcConverterStation("cs2").getTerminal().getP());
-        System.out.println(network.getHvdcConverterStation("cs3").getTerminal().getP());
+        // Active flow capped at limit. Output has losses (due to VSC stations)
+        assertEquals(170, network.getHvdcConverterStation("cs2").getTerminal().getP(), DELTA_POWER);
+        assertEquals(-166.280, network.getHvdcConverterStation("cs3").getTerminal().getP(), DELTA_POWER);
 
         // now invert power direction
         HvdcAngleDroopActivePowerControl activePowerControl = network.getHvdcLine("hvdc23").getExtension(HvdcAngleDroopActivePowerControl.class);
@@ -526,8 +526,7 @@ class AcLoadFlowVscTest {
         result = loadFlowRunner.run(network, p);
         assertTrue(result.isFullyConverged());
 
-        // TODO: replace by comparison with accurate values once coded
-        System.out.println(network.getHvdcConverterStation("cs2").getTerminal().getP());
-        System.out.println(network.getHvdcConverterStation("cs3").getTerminal().getP());
+        assertEquals(-166.280, network.getHvdcConverterStation("cs2").getTerminal().getP(), DELTA_POWER);
+        assertEquals(170, network.getHvdcConverterStation("cs3").getTerminal().getP(), DELTA_POWER);
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
@@ -9,6 +9,7 @@ package com.powsybl.openloadflow.ac;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.HvdcAngleDroopActivePowerControl;
 import com.powsybl.iidm.network.extensions.HvdcAngleDroopActivePowerControlAdder;
+import com.powsybl.iidm.network.extensions.HvdcOperatorActivePowerRangeAdder;
 import com.powsybl.loadflow.LoadFlow;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.LoadFlowResult;
@@ -467,5 +468,37 @@ class AcLoadFlowVscTest {
 
         assertActivePowerEquals(0, network.getVscConverterStation("cs2").getTerminal());
         assertVoltageEquals(vcs2, network.getVscConverterStation("cs2").getTerminal().getBusView().getBus());
+    }
+
+    @Test
+    void testAcEmuWithOperationalLimits() {
+        Network network = HvdcNetworkFactory.createHvdcLinkedByTwoLinesAndSwitch(HvdcConverterStation.HvdcType.VSC);
+        // without limit p=195
+        network.getHvdcLine("hvdc23")
+                .newExtension(HvdcOperatorActivePowerRangeAdder.class)
+                .withOprFromCS2toCS1(180)
+                .withOprFromCS1toCS2(170)
+                .add();
+
+        LoadFlow.Runner loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
+        LoadFlowParameters p = new LoadFlowParameters();
+        p.setHvdcAcEmulation(true);
+        LoadFlowResult result = loadFlowRunner.run(network, p);
+
+        assertTrue(result.isFullyConverged());
+
+        // TODO: replace by comparison with accurate values once coded
+        System.out.println(network.getHvdcConverterStation("cs2").getTerminal().getP());
+        System.out.println(network.getHvdcConverterStation("cs3").getTerminal().getP());
+
+        // now invert power direction
+        HvdcAngleDroopActivePowerControl activePowerControl = network.getHvdcLine("hvdc23").getExtension(HvdcAngleDroopActivePowerControl.class);
+        activePowerControl.setP0(-activePowerControl.getP0());
+        result = loadFlowRunner.run(network, p);
+        assertTrue(result.isFullyConverged());
+
+        // TODO: replace by comparison with accurate values once coded
+        System.out.println(network.getHvdcConverterStation("cs2").getTerminal().getP());
+        System.out.println(network.getHvdcConverterStation("cs3").getTerminal().getP());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
Take into account active power limits of HVDC in AC emulations
They can be defined by
  maxP in the HVDC line
Or in the  HvdcOperatorActivePowerRange extension that provides a limit in each direction



**What is the current behavior?**
Limits are ignored in AC Emulation



**What is the new behavior (if this is a feature change)?**
Limits are honoured.
If P0+KdeltaPhi out of range, P is capped to a bound of the range?


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ X] No


