### PR TITLE
[WIP] Avoid angle divergence with HVDC AC emulation and PMax

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractHvdcAcEmulationFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractHvdcAcEmulationFlowEquationTerm.java
@@ -19,6 +19,8 @@ import java.util.List;
  */
 public abstract class AbstractHvdcAcEmulationFlowEquationTerm extends AbstractElementEquationTerm<LfHvdc, AcVariableType, AcEquationType> {
 
+    static final double EPSILON = 0.1;
+
     protected final Variable<AcVariableType> ph1Var;
 
     protected final Variable<AcVariableType> ph2Var;
@@ -37,6 +39,10 @@ public abstract class AbstractHvdcAcEmulationFlowEquationTerm extends AbstractEl
 
     protected final double pMaxFromCS2toCS1;
 
+    protected final double tetaMax;
+    protected final double tetaMin;
+    protected final double tetaZero;
+
     protected AbstractHvdcAcEmulationFlowEquationTerm(LfHvdc hvdc, LfBus bus1, LfBus bus2, VariableSet<AcVariableType> variableSet) {
         super(hvdc);
         ph1Var = variableSet.getVariable(bus1.getNum(), AcVariableType.BUS_PHI);
@@ -48,13 +54,16 @@ public abstract class AbstractHvdcAcEmulationFlowEquationTerm extends AbstractEl
         lossFactor2 = hvdc.getConverterStation2().getLossFactor() / 100;
         pMaxFromCS1toCS2 = hvdc.getPMaxFromCS1toCS2();
         pMaxFromCS2toCS1 = hvdc.getPMaxFromCS2toCS1();
+        tetaMax = (pMaxFromCS1toCS2 - p0) / k;
+        tetaMin = -(pMaxFromCS2toCS1 - p0) / k;
+        tetaZero = -p0 / k;
     }
 
-    protected double rawP(double p0, double k, double ph1, double ph2) {
+    protected double rawP(double ph1, double ph2) {
         return p0 + k * (ph1 - ph2);
     }
 
-    protected double boundedP(double rawP) {
+    protected double boundedP(double rawP, double ph1, double ph2) {
         // If there is a maximal active power
         // it is applied at the entry of the controller VSC station
         // on the AC side of the network.

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractHvdcAcEmulationFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AbstractHvdcAcEmulationFlowEquationTerm.java
@@ -53,7 +53,7 @@ public abstract class AbstractHvdcAcEmulationFlowEquationTerm extends AbstractEl
         pMaxFromCS1toCS2 = hvdc.getPMaxFromCS1toCS2();
         pMaxFromCS2toCS1 = hvdc.getPMaxFromCS2toCS1();
         tetaMax = (pMaxFromCS1toCS2 - p0) / k;
-        tetaMin = -(pMaxFromCS2toCS1 - p0) / k;
+        tetaMin = (-pMaxFromCS2toCS1 - p0) / k;
         tetaZero = -p0 / k;
     }
 
@@ -81,7 +81,7 @@ public abstract class AbstractHvdcAcEmulationFlowEquationTerm extends AbstractEl
      * @param ph2
      * @return
      */
-    protected double pseudoK(double rawP, double ph1, double ph2) {
+    protected double dummySlope(double rawP, double ph1, double ph2) {
         double boundedP = boundedP(rawP);
         double factor = k;
         double teta = ph1 - ph2;

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide1ActiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide1ActiveFlowEquationTerm.java
@@ -24,7 +24,7 @@ public class HvdcAcEmulationSide1ActiveFlowEquationTerm extends AbstractHvdcAcEm
 
     private double p1(double ph1, double ph2) {
         double rawP = rawP(ph1, ph2);
-        double boundedP = boundedP(rawP, ph1, ph2);
+        double boundedP = boundedP(rawP);
         return (isController(rawP) ? 1 : getVscLossMultiplier()) * boundedP;
     }
 
@@ -38,15 +38,7 @@ public class HvdcAcEmulationSide1ActiveFlowEquationTerm extends AbstractHvdcAcEm
 
     protected double dp1dph1(double ph1, double ph2) {
         double rawP = rawP(ph1, ph2);
-        double boundedP = boundedP(rawP, ph1, ph2);
-        double factor = k;
-        double teta = ph1 - ph2;
-        // for large values of teta return a value that helps convergence
-        if (teta > tetaMax) {
-            factor = teta < tetaMax * 2 ? 0 : (boundedP - p0) / (teta - tetaZero);
-        } else if (teta < tetaMin) {
-            factor = teta > tetaMin * 2 ? 0 : (p0 - boundedP) / (teta - tetaZero);
-        }
+        double factor = pseudoK(rawP, ph1, ph2);
         return (isController(rawP) ? 1 : getVscLossMultiplier()) * factor;
 
     }

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide1ActiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide1ActiveFlowEquationTerm.java
@@ -37,8 +37,10 @@ public class HvdcAcEmulationSide1ActiveFlowEquationTerm extends AbstractHvdcAcEm
     }
 
     protected double dp1dph1(double ph1, double ph2) {
+        // return the exact derivative unless ph1-oh2 us ti large (twice value of P limit)
+        // in this case returns a dummy slope to heo th NR convergence towards desired P
         double rawP = rawP(ph1, ph2);
-        double factor = pseudoK(rawP, ph1, ph2);
+        double factor = dummySlope(rawP, ph1, ph2);
         return (isController(rawP) ? 1 : getVscLossMultiplier()) * factor;
 
     }

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide2ActiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide2ActiveFlowEquationTerm.java
@@ -37,8 +37,10 @@ public class HvdcAcEmulationSide2ActiveFlowEquationTerm extends AbstractHvdcAcEm
     }
 
     private double dp2dph1(double ph1, double ph2) {
+        // return the exact derivative unless ph1-oh2 us ti large (twice value of P limit)
+        // in this case returns a dummy slope to heo th NR convergence towards desired P
         double rawP = rawP(ph1, ph2);
-        double factor = pseudoK(rawP, ph1, ph2);
+        double factor = dummySlope(rawP, ph1, ph2);
         return -(isController(rawP) ? 1 : getVscLossMultiplier()) * factor;
     }
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide2ActiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide2ActiveFlowEquationTerm.java
@@ -23,8 +23,8 @@ public class HvdcAcEmulationSide2ActiveFlowEquationTerm extends AbstractHvdcAcEm
     }
 
     private double p2(double ph1, double ph2) {
-        double rawP = rawP(p0, k, ph1, ph2);
-        double boundedP = boundedP(rawP);
+        double rawP = rawP(ph1, ph2);
+        double boundedP = boundedP(rawP, ph1, ph2);
         return -(isController(rawP) ? 1 : getVscLossMultiplier()) * boundedP;
     }
 
@@ -37,12 +37,17 @@ public class HvdcAcEmulationSide2ActiveFlowEquationTerm extends AbstractHvdcAcEm
     }
 
     private double dp2dph1(double ph1, double ph2) {
-        double rawP = rawP(p0, k, ph1, ph2);
-        if (isInOperatingRange(rawP)) {
-            return -(isController(rawP) ? 1 : getVscLossMultiplier()) * k;
-        } else {
-            return 0;
+        double rawP = rawP(ph1, ph2);
+        double boundedP = boundedP(rawP, ph1, ph2);
+        double factor = k;
+        double teta = ph1 - ph2;
+        // for large values of teta return a value that helps convergence
+        if (teta > tetaMax) {
+            factor = teta < tetaMax * 2 ? 0 : (boundedP - p0) / (teta - tetaZero);
+        } else if (teta < tetaMin) {
+            factor = teta > tetaMin * 2 ? 0 : (p0 - boundedP) / (teta - tetaZero);
         }
+        return -(isController(rawP) ? 1 : getVscLossMultiplier()) * factor;
     }
 
     private double dp2dph2(double ph1, double ph2) {

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide2ActiveFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/HvdcAcEmulationSide2ActiveFlowEquationTerm.java
@@ -24,7 +24,7 @@ public class HvdcAcEmulationSide2ActiveFlowEquationTerm extends AbstractHvdcAcEm
 
     private double p2(double ph1, double ph2) {
         double rawP = rawP(ph1, ph2);
-        double boundedP = boundedP(rawP, ph1, ph2);
+        double boundedP = boundedP(rawP);
         return -(isController(rawP) ? 1 : getVscLossMultiplier()) * boundedP;
     }
 
@@ -38,15 +38,7 @@ public class HvdcAcEmulationSide2ActiveFlowEquationTerm extends AbstractHvdcAcEm
 
     private double dp2dph1(double ph1, double ph2) {
         double rawP = rawP(ph1, ph2);
-        double boundedP = boundedP(rawP, ph1, ph2);
-        double factor = k;
-        double teta = ph1 - ph2;
-        // for large values of teta return a value that helps convergence
-        if (teta > tetaMax) {
-            factor = teta < tetaMax * 2 ? 0 : (boundedP - p0) / (teta - tetaZero);
-        } else if (teta < tetaMin) {
-            factor = teta > tetaMin * 2 ? 0 : (p0 - boundedP) / (teta - tetaZero);
-        }
+        double factor = pseudoK(rawP, ph1, ph2);
         return -(isController(rawP) ? 1 : getVscLossMultiplier()) * factor;
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
Users report convergence problems with  HVDC and AC emulation and PMax



**What kind of change does this PR introduce?**
When angle difference at HVDC bounds is larger than the operational range of the HVDC (ie range in which P grows with angle difference), the derivative for the AC emulation term does not return 0 for dp/dphi but the slope between  bounded teta and angle value for which  P = 0/



**What is the current behavior?**
Possible divergence if NR initialized with angle values out of the HVDC operational range.



**What is the new behavior (if this is a feature change)?**
Better convergence.
However, if a network convergence state is far outside of the operational range of an HVDC in AC eumlation mode, sensitivity analysis may return incorrect value (because dp/dphi does not return null)

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


