### PR TITLE
Absolute generator action ignores post-contingency slack

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/LfAction.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfAction.java
@@ -227,7 +227,7 @@ public final class LfAction {
                 var generatorChange = new GeneratorChange(generator, activePowerValue.getAsDouble() / PerUnit.SB, relativeValue.get());
                 return Optional.of(new LfAction(action.getId(), null, null, null, null, generatorChange, null, null));
             } else {
-                throw new UnsupportedOperationException("Generator action on " + action.getGeneratorId() + " : configuration not supported yet. Active power value and boolean for relative value are required.");
+                throw new UnsupportedOperationException("Generator action on " + action.getGeneratorId() + " : configuration not supported yet.");
             }
         }
         return Optional.empty();

--- a/src/test/java/com/powsybl/openloadflow/sa/LfActionTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/LfActionTest.java
@@ -103,7 +103,7 @@ class LfActionTest extends AbstractSerDeTest {
         try (LfNetworkList lfNetworks = Networks.load(network, acParameters.getNetworkParameters(), new LfTopoConfig(), ReportNode.NO_OP)) {
             LfNetwork lfNetwork = lfNetworks.getLargest().orElseThrow();
             UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class, () -> LfAction.create(generatorAction, lfNetwork, network, acParameters.getNetworkParameters().isBreakers()));
-            assertEquals("Generator action: configuration not supported yet.", e.getMessage());
+            assertEquals("Generator action on G : configuration not supported yet. Active power value and boolean for relative value are required.", e.getMessage());
         }
     }
 

--- a/src/test/java/com/powsybl/openloadflow/sa/LfActionTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/LfActionTest.java
@@ -103,7 +103,7 @@ class LfActionTest extends AbstractSerDeTest {
         try (LfNetworkList lfNetworks = Networks.load(network, acParameters.getNetworkParameters(), new LfTopoConfig(), ReportNode.NO_OP)) {
             LfNetwork lfNetwork = lfNetworks.getLargest().orElseThrow();
             UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class, () -> LfAction.create(generatorAction, lfNetwork, network, acParameters.getNetworkParameters().isBreakers()));
-            assertEquals("Generator action on G : configuration not supported yet. Active power value and boolean for relative value are required.", e.getMessage());
+            assertEquals("Generator action on G : configuration not supported yet.", e.getMessage());
         }
     }
 

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
@@ -912,7 +912,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
 
         // reverse action and apply third remedial action
         network.getGenerator(g2).setTargetP(g2PostContingencyTargetP);
-        network.getGenerator(g4).setTargetP(targetPG4 + g4PostContingencyTargetP - g4InitialTargetP);
+        network.getGenerator(g4).setTargetP(targetPG4);
         loadFlowRunner.run(network, parameters);
         assertEquals(network.getLine("l12").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG3").getNetworkResult().getBranchResult("l12").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(network.getLine("l14").getTerminal1().getP(), getOperatorStrategyResult(result, "strategyG3").getNetworkResult().getBranchResult("l14").getP1(), LoadFlowAssert.DELTA_POWER);
@@ -935,7 +935,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
         testGeneratorAction(false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD, 2.0, -1.5, 2, 0.0001);
         testGeneratorAction(false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD, 1.0, -1.0, 4, 0.0001);
         testGeneratorAction(false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX, 1.77, -1.0, 0.0, 0.0005);
-        testGeneratorAction(false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX, 1.0, -1.0, 2, 0.0005);
+        testGeneratorAction(false, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX, 1.0, -1.0, 1.7, 0.0005);
         testGeneratorAction(true, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD, 2.0, -1.5, 0, 0.0001);
         testGeneratorAction(true, LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX, 1.0, -1.0, 2, 0.0001);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix (i guess ?)


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Powsybl Generator actions are all converted to relative power actions, applied on top of the power after the contingency (and potential slack distribution)


**What is the new behavior (if this is a feature change)?**

If the action is absolute, the absolute targetP is directly set, regardless of the potential changes due to slack after contingency

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
