### PR TITLE
add MostMeshedSlackBusSelector as a fallback for LargestGeneratorSlackBusSelector

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/LargestGeneratorSlackBusSelector.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LargestGeneratorSlackBusSelector.java
@@ -22,13 +22,16 @@ public class LargestGeneratorSlackBusSelector extends AbstractSlackBusSelector {
 
     private final double plausibleActivePowerLimit;
 
+    private final SlackBusSelector fallbackSelector;
+
     public LargestGeneratorSlackBusSelector(double plausibleActivePowerLimit) {
-        this(plausibleActivePowerLimit, Collections.emptySet());
+        this(plausibleActivePowerLimit, Collections.emptySet(), new MostMeshedSlackBusSelector());
     }
 
-    public LargestGeneratorSlackBusSelector(double plausibleActivePowerLimit, Set<Country> countries) {
+    public LargestGeneratorSlackBusSelector(double plausibleActivePowerLimit, Set<Country> countries, SlackBusSelector fallbackSelector) {
         super(countries);
         this.plausibleActivePowerLimit = plausibleActivePowerLimit;
+        this.fallbackSelector = fallbackSelector;
     }
 
     private static double getMaxP(LfBus bus) {
@@ -49,6 +52,10 @@ public class LargestGeneratorSlackBusSelector extends AbstractSlackBusSelector {
                 .limit(limit)
                 .collect(Collectors.toList());
 
-        return new SelectedSlackBus(slackBuses, "Largest generator bus");
+        if (!slackBuses.isEmpty()) {
+            return new SelectedSlackBus(slackBuses, "Largest generator bus");
+        } else {
+            return fallbackSelector.select(buses, limit);
+        }
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/SlackBusSelector.java
+++ b/src/main/java/com/powsybl/openloadflow/network/SlackBusSelector.java
@@ -31,7 +31,7 @@ public interface SlackBusSelector {
             case NAME:
                 return new NameSlackBusSelector(slackBusesIds, countries, new MostMeshedSlackBusSelector(mostMeshedMaxNominalVoltagePercentile, countries));
             case LARGEST_GENERATOR:
-                return new LargestGeneratorSlackBusSelector(plausibleActivePowerLimit, countries);
+                return new LargestGeneratorSlackBusSelector(plausibleActivePowerLimit, countries, new MostMeshedSlackBusSelector(mostMeshedMaxNominalVoltagePercentile, countries));
             default:
                 throw new IllegalStateException("Unknown slack bus selection mode: " + mode);
         }

--- a/src/test/java/com/powsybl/openloadflow/network/LargestGeneratorSlackBusSelectorTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/LargestGeneratorSlackBusSelectorTest.java
@@ -82,4 +82,16 @@ class LargestGeneratorSlackBusSelectorTest {
         slackBus = lfNetwork.getSlackBus();
         assertEquals("S2VL1_0", slackBus.getId());
     }
+
+    @Test
+    void testNoGeneratorDcMode() {
+        var network = DistributedSlackNetworkFactory.create();
+        network.getGeneratorStream().forEach(g -> g.getTerminal().disconnect());
+        var parameters = new LfNetworkParameters()
+                .setSlackBusSelector(new LargestGeneratorSlackBusSelector(5000))
+                .setLoadFlowModel(LoadFlowModel.DC);
+        var lfNetwork = LfNetwork.load(network, new LfNetworkLoaderImpl(), parameters).get(0);
+        var slackBus = lfNetwork.getSlackBus();
+        assertEquals("b2_vl_0", slackBus.getId());
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/network/LargestGeneratorSlackBusSelectorTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/LargestGeneratorSlackBusSelectorTest.java
@@ -72,13 +72,13 @@ class LargestGeneratorSlackBusSelectorTest {
         network.getSubstation("S3").setCountry(Country.FR);
         network.getSubstation("S4").setCountry(Country.FR);
         lfNetwork = LfNetwork.load(network, new LfNetworkLoaderImpl(),
-                new LargestGeneratorSlackBusSelector(5000, Collections.singleton(Country.FR))).get(0);
+                new LargestGeneratorSlackBusSelector(5000, Collections.singleton(Country.FR), new MostMeshedSlackBusSelector())).get(0);
         slackBus = lfNetwork.getSlackBus();
         assertEquals("S3VL1_0", slackBus.getId());
 
         lfNetwork = LfNetwork.load(network, new LfNetworkLoaderImpl(),
                 new LargestGeneratorSlackBusSelector(5000,
-                        Set.of(Country.BE, Country.FR))).get(0);
+                        Set.of(Country.BE, Country.FR), new MostMeshedSlackBusSelector())).get(0);
         slackBus = lfNetwork.getSlackBus();
         assertEquals("S2VL1_0", slackBus.getId());
     }
@@ -92,6 +92,6 @@ class LargestGeneratorSlackBusSelectorTest {
                 .setLoadFlowModel(LoadFlowModel.DC);
         var lfNetwork = LfNetwork.load(network, new LfNetworkLoaderImpl(), parameters).get(0);
         var slackBus = lfNetwork.getSlackBus();
-        assertEquals("b2_vl_0", slackBus.getId());
+        assertEquals("b4_vl_0", slackBus.getId());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No, using this PR just to demonstrate and discuss the issue. Note that https://github.com/powsybl/powsybl-open-loadflow/pull/919 proposes to flag islands without any generator as invalid, therefore https://github.com/powsybl/powsybl-open-loadflow/pull/919 would fix this issue. If https://github.com/powsybl/powsybl-open-loadflow/pull/919 functional change is accepted by the community, this PR can be closed. Otherwise if the functional change is not accepted, a secondary slack bus selector should be implemented for the LargestGeneratorSlackBusSelector.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
