### PR TITLE
Support generator remote reactive control on 3 windings transformer terminal

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
@@ -289,18 +289,13 @@ public abstract class AbstractLfGenerator extends AbstractLfInjection implements
         return true;
     }
 
-    protected void setReactivePowerControl(Terminal regulatingTerminal, double targetQ) {
+    protected void setRemoteReactivePowerControl(Terminal regulatingTerminal, double targetQ) {
         Connectable<?> connectable = regulatingTerminal.getConnectable();
-        if (connectable instanceof Line l) {
-            this.controlledBranchSide = l.getTerminal(TwoSides.ONE) == regulatingTerminal ?
-                    TwoSides.ONE : TwoSides.TWO;
-            this.controlledBranchId = l.getId();
-        } else if (connectable instanceof TwoWindingsTransformer t) {
-            this.controlledBranchSide = t.getTerminal(TwoSides.ONE) == regulatingTerminal ?
-                    TwoSides.ONE : TwoSides.TWO;
-            this.controlledBranchId = t.getId();
+        if (connectable instanceof Branch<?> branch) {
+            this.controlledBranchSide = branch.getSide(regulatingTerminal);
+            this.controlledBranchId = branch.getId();
         } else {
-            LOGGER.error("Generator '{}' is controlled by an instance of {}: not supported",
+            LOGGER.error("Generator '{}' is remotely controlling reactive power of an instance of {}: not supported",
                     getId(), connectable.getClass());
             return;
         }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
@@ -294,6 +294,9 @@ public abstract class AbstractLfGenerator extends AbstractLfInjection implements
         if (connectable instanceof Branch<?> branch) {
             this.controlledBranchSide = branch.getSide(regulatingTerminal);
             this.controlledBranchId = branch.getId();
+        } else if (connectable instanceof ThreeWindingsTransformer t3w) {
+            this.controlledBranchSide = TwoSides.ONE; // side 2 is star bus of t3w.
+            this.controlledBranchId = LfLegBranch.getId(t3w.getSide(regulatingTerminal), t3w.getId());
         } else {
             LOGGER.error("Generator '{}' is remotely controlling reactive power of an instance of {}: not supported",
                     getId(), connectable.getClass());

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
@@ -71,7 +71,7 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
 
         RemoteReactivePowerControl reactivePowerControl = generator.getExtension(RemoteReactivePowerControl.class);
         if (reactivePowerControl != null && reactivePowerControl.isEnabled() && !generator.isVoltageRegulatorOn() && parameters.isGeneratorReactivePowerRemoteControl()) {
-            setReactivePowerControl(reactivePowerControl.getRegulatingTerminal(), reactivePowerControl.getTargetQ());
+            setRemoteReactivePowerControl(reactivePowerControl.getRegulatingTerminal(), reactivePowerControl.getTargetQ());
         }
 
         CoordinatedReactiveControl coordinatedReactiveControl = getGenerator().getExtension(CoordinatedReactiveControl.class);

--- a/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/GeneratorRemoteControlTest.java
@@ -352,10 +352,8 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
         // create a basic 4-buses network
         Network network = FourBusNetworkFactory.createBaseNetwork();
         Generator g4 = network.getGenerator("g4");
-        Generator g1 = network.getGenerator("g1");
         Line l34 = network.getLine("l34");
         Line l12 = network.getLine("l12");
-        Line l13 = network.getLine("l13");
 
         double targetQ = 1.0;
 
@@ -368,7 +366,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
           .withRegulatingTerminal(l34.getTerminal(TwoSides.TWO))
           .withEnabled(true).add();
 
-        parameters.getExtension(OpenLoadFlowParameters.class).setGeneratorReactivePowerRemoteControl(true);
+        parametersExt.setGeneratorReactivePowerRemoteControl(true);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
@@ -415,7 +413,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
             .withRegulatingTerminal(l34.getTerminal(TwoSides.TWO))
             .withEnabled(true).add();
 
-        parameters.getExtension(OpenLoadFlowParameters.class)
+        parametersExt
                 .setGeneratorReactivePowerRemoteControl(true);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
@@ -441,7 +439,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
                 .withRegulatingTerminal(l34.getTerminal(TwoSides.TWO))
                 .withEnabled(true).add();
 
-        parameters.getExtension(OpenLoadFlowParameters.class).setGeneratorReactivePowerRemoteControl(true);
+        parametersExt.setGeneratorReactivePowerRemoteControl(true);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
@@ -481,7 +479,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
                 .withRegulatingTerminal(l34.getTerminal(TwoSides.TWO))
                 .withEnabled(true).add();
 
-        parameters.getExtension(OpenLoadFlowParameters.class).setGeneratorReactivePowerRemoteControl(true);
+        parametersExt.setGeneratorReactivePowerRemoteControl(true);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
         assertReactivePowerEquals(1, l34.getTerminal(TwoSides.TWO));
@@ -498,7 +496,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
                 .withRegulatingTerminal(l34.getTerminal(TwoSides.ONE))
                 .withEnabled(true).add();
 
-        parameters.getExtension(OpenLoadFlowParameters.class).setGeneratorReactivePowerRemoteControl(true);
+        parametersExt.setGeneratorReactivePowerRemoteControl(true);
         LoadFlowResult result2 = loadFlowRunner.run(network, parameters);
         assertTrue(result2.isFullyConverged());
         assertReactivePowerEquals(1, l34.getTerminal(TwoSides.TWO));
@@ -515,7 +513,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
         Generator g1n1 = network1.getGenerator("g1");
         Line l34n1 = network1.getLine("l34");
 
-        parameters.getExtension(OpenLoadFlowParameters.class)
+        parametersExt
                 .setGeneratorReactivePowerRemoteControl(true)
                 .setNewtonRaphsonStoppingCriteriaType(NewtonRaphsonStoppingCriteriaType.PER_EQUATION_TYPE_CRITERIA)
                 .setMaxReactivePowerMismatch(DELTA_POWER); // needed to ensure convergence within a DELTA_POWER
@@ -551,7 +549,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
         network1.getGenerator("g1Bis").getExtension(RemoteReactivePowerControl.class).setEnabled(false);
         Line l34n1 = network1.getLine("l34");
 
-        parameters.getExtension(OpenLoadFlowParameters.class).setGeneratorReactivePowerRemoteControl(true);
+        parametersExt.setGeneratorReactivePowerRemoteControl(true);
         LoadFlowResult result1 = loadFlowRunner.run(network1, parameters);
         assertTrue(result1.isFullyConverged());
         assertReactivePowerEquals(2, l34n1.getTerminal(TwoSides.TWO));
@@ -577,7 +575,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
         Generator g4 = network.getGenerator("g4");
         Line l34 = network.getLine("l34");
 
-        parameters.getExtension(OpenLoadFlowParameters.class).setGeneratorReactivePowerRemoteControl(true);
+        parametersExt.setGeneratorReactivePowerRemoteControl(true);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
         assertReactivePowerEquals(2, l34.getTerminal(TwoSides.TWO));
@@ -598,7 +596,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
         g1.newExtension(CoordinatedReactiveControlAdder.class).withQPercent(80).add();
         g1Bis.newExtension(CoordinatedReactiveControlAdder.class).withQPercent(20).add();
 
-        parameters.getExtension(OpenLoadFlowParameters.class).setGeneratorReactivePowerRemoteControl(true)
+        parametersExt.setGeneratorReactivePowerRemoteControl(true)
                 .setReactivePowerDispatchMode(ReactivePowerDispatchMode.Q_EQUAL_PROPORTION);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
@@ -622,7 +620,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
         g1.newMinMaxReactiveLimits().setMinQ(-20).setMaxQ(20).add();
         g1Bis.newMinMaxReactiveLimits().setMinQ(-10).setMaxQ(10).add();
 
-        parameters.getExtension(OpenLoadFlowParameters.class).setGeneratorReactivePowerRemoteControl(true)
+        parametersExt.setGeneratorReactivePowerRemoteControl(true)
                 .setReactivePowerDispatchMode(ReactivePowerDispatchMode.Q_EQUAL_PROPORTION);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
@@ -645,7 +643,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
         // not valid max ranges => fallback equally distributed
         // Q should be equally split between g1 and g1Bis
 
-        parameters.getExtension(OpenLoadFlowParameters.class).setGeneratorReactivePowerRemoteControl(true)
+        parametersExt.setGeneratorReactivePowerRemoteControl(true)
                 .setReactivePowerDispatchMode(ReactivePowerDispatchMode.Q_EQUAL_PROPORTION);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
@@ -670,7 +668,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
                 .withRegulatingTerminal(l34.getTerminal(TwoSides.TWO))
                 .withEnabled(true).add();
 
-        parameters.getExtension(OpenLoadFlowParameters.class).setGeneratorReactivePowerRemoteControl(true);
+        parametersExt.setGeneratorReactivePowerRemoteControl(true);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
@@ -710,7 +708,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
                 .withRegulatingTerminal(l34.getTerminal(TwoSides.TWO))
                 .withEnabled(true).add();
 
-        parameters.getExtension(OpenLoadFlowParameters.class).setGeneratorReactivePowerRemoteControl(true);
+        parametersExt.setGeneratorReactivePowerRemoteControl(true);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
@@ -731,7 +729,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
                 .withRegulatingTerminal(l.getTerminal()) // not supported.
                 .withEnabled(true).add();
 
-        parameters.getExtension(OpenLoadFlowParameters.class).setGeneratorReactivePowerRemoteControl(true);
+        parametersExt.setGeneratorReactivePowerRemoteControl(true);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
@@ -784,16 +782,39 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
                 .withRegulatingTerminal(twt.getTerminal(TwoSides.TWO))
                 .withEnabled(true).add();
 
-        parameters.getExtension(OpenLoadFlowParameters.class).setGeneratorReactivePowerRemoteControl(true);
+        parametersExt.setGeneratorReactivePowerRemoteControl(true);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
         assertReactivePowerEquals(targetQ, twt.getTerminal(TwoSides.TWO));
     }
 
+    /**
+     * G1 controls reactive power on T3WT leg1.
+     *<pre>
+     *     G1        LD2        LD3   G3
+     *     |    L12   |          |   /
+     *     | -------- |          |  /
+     *     B1         B2         B3
+     *                  \        /
+     *                leg1     leg2
+     *                   \      /
+     *                     T3WT
+     *                      |
+     *                     leg3
+     *                      |
+     *                      B4
+     *                      |
+     *                     LD4
+     *</pre>
+     */
     @Test
     void testGeneratorRemoteReactivePowerControl3wt() {
         Network network = VoltageControlNetworkFactory.createNetworkWithT3wt();
+
+        var gen1 = network.getGenerator("GEN_1");
+        var t3wt = network.getThreeWindingsTransformer("T3wT");
+
         VoltageLevel vl3 = network.getVoltageLevel("VL_3");
         Bus b3 = vl3.getBusBreakerView().getBus("BUS_3");
         vl3.newGenerator()
@@ -808,9 +829,6 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
                 .setTargetQ(0.0)
                 .add();
 
-        var gen1 = network.getGenerator("GEN_1");
-        var t3wt = network.getThreeWindingsTransformer("T3wT");
-
         double targetQ = -5.0;
         gen1.setTargetQ(0.0).setVoltageRegulatorOn(false)
                 .newExtension(RemoteReactivePowerControlAdder.class)
@@ -818,7 +836,10 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
                 .withRegulatingTerminal(t3wt.getTerminal(ThreeSides.ONE))
                 .withEnabled(true).add();
 
-        parameters.getExtension(OpenLoadFlowParameters.class).setGeneratorReactivePowerRemoteControl(true);
+        parametersExt
+                .setGeneratorReactivePowerRemoteControl(true)
+                .setMaxReactivePowerMismatch(DELTA_POWER)
+                .setNewtonRaphsonStoppingCriteriaType(NewtonRaphsonStoppingCriteriaType.PER_EQUATION_TYPE_CRITERIA);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
@@ -866,13 +887,13 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
         assertVoltageEquals(150.0, nload);
 
         generator2.setTargetP(1.0);
-        parameters.getExtension(OpenLoadFlowParameters.class).setReactiveRangeCheckMode(OpenLoadFlowParameters.ReactiveRangeCheckMode.TARGET_P);
+        parametersExt.setReactiveRangeCheckMode(OpenLoadFlowParameters.ReactiveRangeCheckMode.TARGET_P);
         LoadFlowResult result2 = loadFlowRunner.run(network, parameters);
         assertTrue(result2.isFullyConverged());
         assertVoltageEquals(164.88, nload);
 
         generator2.setTargetP(0.0);
-        parameters.getExtension(OpenLoadFlowParameters.class).setReactiveRangeCheckMode(OpenLoadFlowParameters.ReactiveRangeCheckMode.MIN_MAX);
+        parametersExt.setReactiveRangeCheckMode(OpenLoadFlowParameters.ReactiveRangeCheckMode.MIN_MAX);
         LoadFlowResult result3 = loadFlowRunner.run(network, parameters);
         assertTrue(result3.isFullyConverged());
         assertVoltageEquals(164.88, nload);
@@ -906,7 +927,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
         g4.newMinMaxReactiveLimits().setMinQ(-15.0).setMaxQ(15.0).add();
 
         parameters.setUseReactiveLimits(true);
-        parameters.getExtension(OpenLoadFlowParameters.class).setGeneratorReactivePowerRemoteControl(true);
+        parametersExt.setGeneratorReactivePowerRemoteControl(true);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
@@ -936,7 +957,7 @@ class GeneratorRemoteControlTest extends AbstractLoadFlowNetworkFactory {
         g4.newMinMaxReactiveLimits().setMinQ(-5.0).setMaxQ(5.0).add();
 
         parameters.setUseReactiveLimits(true);
-        parameters.getExtension(OpenLoadFlowParameters.class).setGeneratorReactivePowerRemoteControl(true);
+        parametersExt.setGeneratorReactivePowerRemoteControl(true);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());

--- a/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/VoltageControlNetworkFactory.java
@@ -348,13 +348,14 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
 
     /**
      * A very small network to test with a T2wt.
-     *
+     *<pre>
      *     G1        LD2      LD3
      *     |    L12   |        |
      *     |  ------- |        |
      *     B1         B2      B3
      *                  \    /
      *                   T2WT
+     *</pre>
      */
     public static Network createNetworkWithT2wt() {
 
@@ -413,7 +414,7 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
 
     /**
      * A small network to test with two T2wt linked by a switch.
-     *
+     *<pre>
      *     G1        LD2      LD3           LD4     LD5
      *     |    L12   |        |             |       |
      *     |  ------- |        |   switch    |       |
@@ -422,6 +423,7 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
      *     |             T2WT                 T2WT2       |
      *     |                                              |
      *     |------------------L15-------------------------|
+     *</pre>
      */
     public static Network createNetworkWith2T2wtAndSwitch() {
 
@@ -622,13 +624,14 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
 
     /**
      * A very small network to test with two T2wt.
-     *
+     *<pre>
      *     G1        LD2        LD3
      *     |    L12   |  T2WT2   |
      *     |  ------- | /     \  |
      *     B1         B2       B3
      *                 \      /
      *                  T2WT1
+     *</pre>
      */
     public static Network createNetworkWith2T2wt() {
 
@@ -735,7 +738,7 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
 
     /**
      * A very small network to test with a T3wt.
-     *
+     *<pre>
      *     G1        LD2        LD3
      *     |    L12   |          |
      *     |  ------- |          |
@@ -750,10 +753,11 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
      *                      B4
      *                      |
      *                     LD4
+     *</pre>
      */
     public static Network createNetworkWithT3wt() {
 
-        Network network = VoltageControlNetworkFactory.createTransformerBaseNetwork("two-windings-transformer-control");
+        Network network = VoltageControlNetworkFactory.createTransformerBaseNetwork("three-windings-transformer-control");
 
         VoltageLevel vl4 = network.getSubstation("SUBSTATION").newVoltageLevel()
                 .setId("VL_4")
@@ -1042,12 +1046,13 @@ public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory
 
     /**
      * SVC test case.
-     *
+     *<pre>
      * g1        ld1
      * |          |
      * b1---------b2
      *      l1    |
      *           svc1
+     *</pre>
      */
     public static Network createWithStaticVarCompensator() {
         Network network = Network.create("svc", "test");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Debatable Bug fix vs. feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
We only support remote reactive power control on line and 2 windings transformer


**What is the new behavior (if this is a feature change)?**
We additionally support remote reactive power control on 3 windings transformer


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No
