### PR TITLE
Fix Battery update state after voltage control

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBatteryImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBatteryImpl.java
@@ -122,6 +122,6 @@ public final class LfBatteryImpl extends AbstractLfGenerator {
         var battery = getBattery();
         battery.getTerminal()
                 .setP(-targetP * PerUnit.SB)
-                .setQ(-battery.getTargetQ());
+                .setQ(Double.isNaN(calculatedQ) ? -getTargetQ() * PerUnit.SB : -calculatedQ * PerUnit.SB);
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowBatteryTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowBatteryTest.java
@@ -82,5 +82,7 @@ class AcLoadFlowBatteryTest {
         LoadFlowAssert.assertAngleEquals(5.468356, genBus);
         assertVoltageEquals(401.0, batBus);
         LoadFlowAssert.assertAngleEquals(0.0, batBus);
+        assertActivePowerEquals(1000.0, battery2.getTerminal());
+        assertReactivePowerEquals(122.716, battery2.getTerminal());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

No, only notice on two buses that Kirchoff law is violated on RTE network.

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix that because update state was not taken into account for a battery with voltage control.

**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
