### PR TITLE
Report network angle reference bus and slack bus(es) after network loading

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -661,6 +661,8 @@ public class LfNetwork extends AbstractPropertyBag implements PropertyBag {
                 case VALID -> {
                     lfNetwork.reportSize(networkReport);
                     lfNetwork.reportBalance(networkReport);
+                    lfNetwork.updateSlackBusesAndReferenceBus();
+                    Reports.reportAngleReferenceBusAndSlackBuses(networkReport, lfNetwork.getReferenceBus().getId(), lfNetwork.getSlackBuses().stream().map(LfBus::getId).toList());
                     lfNetwork.setReportNode(Reports.createLfNetworkReportNode(reportNode, lfNetwork.getReportNode(), lfNetwork.getNumCC(), lfNetwork.getNumCC()));
                 }
                 case INVALID_NO_GENERATOR_VOLTAGE_CONTROL -> {

--- a/src/main/java/com/powsybl/openloadflow/util/Reports.java
+++ b/src/main/java/com/powsybl/openloadflow/util/Reports.java
@@ -11,6 +11,7 @@ import com.powsybl.commons.report.ReportNode;
 import com.powsybl.commons.report.TypedValue;
 import com.powsybl.openloadflow.OpenLoadFlowReportConstants;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -460,5 +461,18 @@ public final class Reports {
                 .withUntypedValue("busesOutOfRealisticVoltageRange", busesOutOfRealisticVoltageRange.toString())
                 .withSeverity(TypedValue.ERROR_SEVERITY)
                 .add();
+    }
+
+    public static void reportAngleReferenceBusAndSlackBuses(ReportNode reportNode, String referenceBus, List<String> slackBuses) {
+        reportNode.newReportNode()
+                .withMessageTemplate("angleReferenceBusSelection", "Angle Reference Bus: ${referenceBus}")
+                .withUntypedValue("referenceBus", referenceBus)
+                .withSeverity(TypedValue.INFO_SEVERITY)
+                .add();
+        slackBuses.forEach(slackBus -> reportNode.newReportNode()
+                .withMessageTemplate("slackBusSelection", "Slack Bus: ${slackBus}")
+                .withUntypedValue("slackBus", slackBus)
+                .withSeverity(TypedValue.INFO_SEVERITY)
+                .add());
     }
 }

--- a/src/test/resources/detailedNrReportSecurityAnalysis.txt
+++ b/src/test/resources/detailedNrReportSecurityAnalysis.txt
@@ -4,6 +4,8 @@
          + Network info
             Network has 2 buses and 2 branches
             Network balance: active generation=603.77 MW, active load=600.0 MW, reactive generation=0.0 MVar, reactive load=200.0 MVar
+            Angle Reference Bus: VL1_0
+            Slack Bus: VL1_0
          + Pre-contingency simulation
             + Newton Raphson on Network CC0 SC0
                No outer loops have been launched

--- a/src/test/resources/esgTutoReport.txt
+++ b/src/test/resources/esgTutoReport.txt
@@ -4,6 +4,8 @@
          + Network info
             Network has 4 buses and 4 branches
             Network balance: active generation=607.0 MW, active load=600.0 MW, reactive generation=0.0 MVar, reactive load=200.0 MVar
+            Angle Reference Bus: VLHV1_0
+            Slack Bus: VLHV1_0
          + Outer loop DistributedSlack
             + Outer loop iteration 1
                Slack bus active power (-1.4404045651219555 MW) distributed in 1 distribution iteration(s)
@@ -18,6 +20,8 @@
          + Network info
             Network has 4 buses and 4 branches
             Network balance: active generation=607.0 MW, active load=600.0 MW, reactive generation=0.0 MVar, reactive load=200.0 MVar
+            Angle Reference Bus: VLLOAD_0
+            Slack Bus: VLLOAD_0
          Outer loop VoltageMonitoring
          Outer loop ReactiveLimits
          AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)

--- a/src/test/resources/esgTutoReportDetailedNrReportLf.txt
+++ b/src/test/resources/esgTutoReportDetailedNrReportLf.txt
@@ -4,6 +4,8 @@
          + Network info
             Network has 4 buses and 4 branches
             Network balance: active generation=607.0 MW, active load=600.0 MW, reactive generation=0.0 MVar, reactive load=200.0 MVar
+            Angle Reference Bus: VLHV1_0
+            Slack Bus: VLHV1_0
          + Newton Raphson on Network CC0 SC0
             No outer loops have been launched
             + Initial mismatch

--- a/src/test/resources/esgTutoReportDetailedNrReportSensi.txt
+++ b/src/test/resources/esgTutoReportDetailedNrReportSensi.txt
@@ -4,6 +4,8 @@
          + Network info
             Network has 4 buses and 4 branches
             Network balance: active generation=607.0 MW, active load=600.0 MW, reactive generation=0.0 MVar, reactive load=200.0 MVar
+            Angle Reference Bus: VLHV1_0
+            Slack Bus: VLHV1_0
          + Newton Raphson on Network CC0 SC0
             No outer loops have been launched
             + Initial mismatch

--- a/src/test/resources/multipleConnectedComponentsAcReport.txt
+++ b/src/test/resources/multipleConnectedComponentsAcReport.txt
@@ -4,6 +4,8 @@
          + Network info
             Network has 3 buses and 4 branches
             Network balance: active generation=3.0 MW, active load=2.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
+            Angle Reference Bus: b1_vl_0
+            Slack Bus: b1_vl_0
          Outer loop DistributedSlack
          Outer loop VoltageMonitoring
          Outer loop ReactiveLimits

--- a/src/test/resources/multipleConnectedComponentsDcReport.txt
+++ b/src/test/resources/multipleConnectedComponentsDcReport.txt
@@ -4,10 +4,14 @@
          + Network info
             Network has 3 buses and 4 branches
             Network balance: active generation=3.0 MW, active load=2.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
+            Angle Reference Bus: b1_vl_0
+            Slack Bus: b1_vl_0
          DC load flow completed (status=true)
       + Network CC1 SC1
          + Network info
             Network has 3 buses and 4 branches
             Network balance: active generation=2.0 MW, active load=4.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
+            Angle Reference Bus: b5_vl_0
+            Slack Bus: b5_vl_0
          DC load flow completed (status=true)
       No calculation will be done on 1 network(s) that have no generators

--- a/src/test/resources/saReport.txt
+++ b/src/test/resources/saReport.txt
@@ -4,6 +4,8 @@
          + Network info
             Network has 4 buses and 4 branches
             Network balance: active generation=607.0 MW, active load=600.0 MW, reactive generation=0.0 MVar, reactive load=200.0 MVar
+            Angle Reference Bus: VLHV1_0
+            Slack Bus: VLHV1_0
          + Pre-contingency simulation
             + Outer loop DistributedSlack
                + Outer loop iteration 1

--- a/src/test/resources/shuntVoltageControlOuterLoopReport.txt
+++ b/src/test/resources/shuntVoltageControlOuterLoopReport.txt
@@ -4,6 +4,8 @@
          + Network info
             Network has 3 buses and 2 branches
             Network balance: active generation=101.36639999999998 MW, active load=101.0 MW, reactive generation=0.0 MVar, reactive load=150.0 MVar
+            Angle Reference Bus: vl2_0
+            Slack Bus: vl2_0
          + Newton Raphson on Network CC0 SC0
             No outer loops have been launched
             + Initial mismatch

--- a/src/test/resources/transformerReactivePowerControlOuterLoopReport.txt
+++ b/src/test/resources/transformerReactivePowerControlOuterLoopReport.txt
@@ -4,6 +4,8 @@
          + Network info
             Network has 3 buses and 2 branches
             Network balance: active generation=25.0 MW, active load=16.2 MW, reactive generation=0.0 MVar, reactive load=7.5 MVar
+            Angle Reference Bus: VL_2_0
+            Slack Bus: VL_2_0
          + Newton Raphson on Network CC0 SC0
             No outer loops have been launched
             + Initial mismatch


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
We don't report selected angle reference bus and slack bus(es)


**What is the new behavior (if this is a feature change)?**
selected angle reference bus and slack bus(es) are reported after LfNetwork loading


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No
