### PR TITLE
Fixed Static VAR Compensator OFF mode having NaN P and Q results

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -306,16 +306,14 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
 
     void addStaticVarCompensator(StaticVarCompensator staticVarCompensator, LfNetworkParameters parameters,
                                  LfNetworkLoadingReport report) {
-        if (staticVarCompensator.getRegulationMode() != StaticVarCompensator.RegulationMode.OFF) {
-            LfStaticVarCompensatorImpl lfSvc = LfStaticVarCompensatorImpl.create(staticVarCompensator, network, this, parameters, report);
-            add(lfSvc);
-            if (lfSvc.getSlope() != 0) {
-                hasGeneratorsWithSlope = true;
-            }
-            if (lfSvc.getB0() != 0) {
-                svcShunt = LfStandbyAutomatonShunt.create(lfSvc);
-                lfSvc.setStandByAutomatonShunt(svcShunt);
-            }
+        LfStaticVarCompensatorImpl lfSvc = LfStaticVarCompensatorImpl.create(staticVarCompensator, network, this, parameters, report);
+        add(lfSvc);
+        if (lfSvc.getSlope() != 0) {
+            hasGeneratorsWithSlope = true;
+        }
+        if (lfSvc.getB0() != 0) {
+            svcShunt = LfStandbyAutomatonShunt.create(lfSvc);
+            lfSvc.setStandByAutomatonShunt(svcShunt);
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfStaticVarCompensatorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfStaticVarCompensatorImpl.java
@@ -80,14 +80,13 @@ public final class LfStaticVarCompensatorImpl extends AbstractLfGenerator implem
         };
 
         switch (svc.getRegulationMode()) {
-            case VOLTAGE -> setupVoltageRegulation(svc, parameters, report);
+            case VOLTAGE -> setupVoltageControl(svc, parameters, report);
             case REACTIVE_POWER -> targetQ = -svc.getReactivePowerSetpoint() / PerUnit.SB;
             case OFF -> targetQ = 0;
-            default -> throw new IllegalStateException("Unexpected value: " + svc.getRegulationMode());
         }
     }
 
-    private void setupVoltageRegulation(StaticVarCompensator svc, LfNetworkParameters parameters, LfNetworkLoadingReport report) {
+    private void setupVoltageControl(StaticVarCompensator svc, LfNetworkParameters parameters, LfNetworkLoadingReport report) {
         setVoltageControl(svc.getVoltageSetpoint(), svc.getTerminal(), svc.getRegulatingTerminal(), parameters, report);
 
         // slope model: check if to be applied based on 1/ option and 2/ this SVC extension

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowSvcTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowSvcTest.java
@@ -83,8 +83,9 @@ class AcLoadFlowSvcTest {
         assertReactivePowerEquals(150.649, l1.getTerminal1());
         assertActivePowerEquals(-101, l1.getTerminal2());
         assertReactivePowerEquals(-150, l1.getTerminal2());
-        assertTrue(Double.isNaN(svc1.getTerminal().getP()));
-        assertTrue(Double.isNaN(svc1.getTerminal().getQ()));
+        // SVC is OFF
+        assertActivePowerEquals(0, svc1.getTerminal());
+        assertReactivePowerEquals(0, svc1.getTerminal());
 
         svc1.setVoltageSetpoint(385)
                 .setRegulationMode(StaticVarCompensator.RegulationMode.VOLTAGE);
@@ -256,7 +257,7 @@ class AcLoadFlowSvcTest {
     }
 
     @Test
-    void testRegulationModeOff() {
+    void testRegulationModeReactivePower() {
         svc1.setReactivePowerSetpoint(100)
                 .setRegulationMode(StaticVarCompensator.RegulationMode.REACTIVE_POWER);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
#913 


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bugfix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
SVC when OFF result in NaN values for terminal P&Q


**What is the new behavior (if this is a feature change)?**
SVC when OFF result in 0.0 MW/Mvar values for terminal P&Q


**Does this PR introduce a breaking change or deprecate an API?**
- [X] No
