### PR TITLE
Fix Q dispatch not accounting for plausible reactive power range

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -525,18 +525,13 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     }
 
     private static ToDoubleFunction<String> splitDispatchQ(List<LfGenerator> generatorsWithControl, double qToDispatch) {
-        // proportional to reactive keys
-        if (allGeneratorsHaveReactiveKeys(generatorsWithControl)) {
-            return splitDispatchQWithReactiveKeys(generatorsWithControl, qToDispatch);
-        }
-
-        // fallback on dispatch q proportional to max reactive power range
-        if (allGeneratorsHavePlausibleReactiveLimits(generatorsWithControl)) {
-            return splitDispatchQFromMaxReactivePowerRange(generatorsWithControl, qToDispatch);
-        }
-
-        // fall back on dispatch q equally
-        return splitDispatchQEqually(generatorsWithControl, qToDispatch);
+        // proportional to reactive keys if possible,
+        // or else, fallback on dispatch q proportional to max reactive power range if possible,
+        // or else, fallback on dispatch q equally (always possible)
+        return splitDispatchQWithReactiveKeys(generatorsWithControl, qToDispatch)
+                .orElse(splitDispatchQFromMaxReactivePowerRange(generatorsWithControl, qToDispatch)
+                        .orElse(splitDispatchQEqually(generatorsWithControl, qToDispatch))
+                );
     }
 
     private static ToDoubleFunction<String> splitDispatchQEqually(List<LfGenerator> generatorsWithControl, double qToDispatch) {
@@ -569,11 +564,15 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
         return qToDispatchByGeneratorId::get;
     }
 
-    private static ToDoubleFunction<String> splitDispatchQWithReactiveKeys(List<LfGenerator> generatorsWithControl, double qToDispatch) {
-        double sumQkeys = 0; // guaranteed to become non-zero by previous checks
+    private static Optional<ToDoubleFunction<String>> splitDispatchQWithReactiveKeys(List<LfGenerator> generatorsWithControl, double qToDispatch) {
+        double sumQkeys = 0;
         for (LfGenerator generator : generatorsWithControl) {
-            double qKey = generator.getRemoteControlReactiveKey().orElseThrow();
+            double qKey = generator.getRemoteControlReactiveKey().orElse(Double.NaN);
             sumQkeys += qKey;
+        }
+
+        if (Double.isNaN(sumQkeys) || sumQkeys == 0.0) {
+            return Optional.empty();
         }
 
         Map<String, Double> qToDispatchByGeneratorId = new HashMap<>(generatorsWithControl.size());
@@ -582,14 +581,20 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
             qToDispatchByGeneratorId.put(generator.getId(), (qKey / sumQkeys) * qToDispatch);
         }
 
-        return qToDispatchByGeneratorId::get;
+        return Optional.of(qToDispatchByGeneratorId::get);
     }
 
-    private static ToDoubleFunction<String> splitDispatchQFromMaxReactivePowerRange(List<LfGenerator> generatorsWithControl, double qToDispatch) {
-        double sumMaxRanges = 0.0; // guaranteed to become non-zero by previous checks
+    private static Optional<ToDoubleFunction<String>> splitDispatchQFromMaxReactivePowerRange(List<LfGenerator> generatorsWithControl, double qToDispatch) {
+        double sumMaxRanges = 0.0;
         for (LfGenerator generator : generatorsWithControl) {
+            if (!generatorHasPlausibleReactiveLimits(generator)) {
+                return Optional.empty();
+            }
             double maxRangeQ = generator.getRangeQ(LfGenerator.ReactiveRangeMode.MAX);
             sumMaxRanges += maxRangeQ;
+        }
+        if (sumMaxRanges == 0.0) {
+            return Optional.empty();
         }
 
         Map<String, Double> qToDispatchByGeneratorId = new HashMap<>(generatorsWithControl.size());
@@ -598,37 +603,21 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
             qToDispatchByGeneratorId.put(generator.getId(), (maxRangeQ / sumMaxRanges) * qToDispatch);
         }
 
-        return qToDispatchByGeneratorId::get;
+        return Optional.of(qToDispatchByGeneratorId::get);
     }
 
-    private static boolean allGeneratorsHaveReactiveKeys(List<LfGenerator> generators) {
-        // All keys must be defined.
-        // It is OK to have *some* zero keys, but there must be at least one non-zero key.
-        double sumKeys = 0.0;
-        for (LfGenerator generator : generators) {
-            double qKey = generator.getRemoteControlReactiveKey().orElse(Double.NaN);
-            if (Double.isNaN(qKey)) {
-                return false;
-            } else {
-                sumKeys += qKey;
-            }
-        }
-        return sumKeys > 0.0;
+    private static boolean generatorHasPlausibleReactiveLimits(LfGenerator generator) {
+        double minQ = generator.getMinQ();
+        double maxQ = generator.getMaxQ();
+        double rangeQ = maxQ - minQ;
+        return Math.abs(minQ) < PLAUSIBLE_REACTIVE_LIMITS &&
+                Math.abs(maxQ) < PLAUSIBLE_REACTIVE_LIMITS &&
+                rangeQ > PlausibleValues.MIN_REACTIVE_RANGE / PerUnit.SB &&
+                rangeQ < PlausibleValues.MAX_REACTIVE_RANGE / PerUnit.SB;
     }
 
     private static boolean allGeneratorsHavePlausibleReactiveLimits(List<LfGenerator> generators) {
-        for (LfGenerator generator : generators) {
-            double minQ = generator.getMinQ();
-            double maxQ = generator.getMaxQ();
-            double rangeQ = maxQ - minQ;
-            if (Math.abs(minQ) > PLAUSIBLE_REACTIVE_LIMITS ||
-                    Math.abs(maxQ) > PLAUSIBLE_REACTIVE_LIMITS ||
-                    rangeQ < PlausibleValues.MIN_REACTIVE_RANGE / PerUnit.SB ||
-                    rangeQ > PlausibleValues.MAX_REACTIVE_RANGE / PerUnit.SB) {
-                return false;
-            }
-        }
-        return true;
+        return generators.stream().allMatch(AbstractLfBus::generatorHasPlausibleReactiveLimits);
     }
 
     protected static double dispatchQ(List<LfGenerator> generatorsWithControl, boolean reactiveLimits,

--- a/src/test/java/com/powsybl/openloadflow/ac/AcloadFlowReactiveLimitsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcloadFlowReactiveLimitsTest.java
@@ -158,4 +158,19 @@ class AcloadFlowReactiveLimitsTest {
         assertReactivePowerEquals(-120, gen2.getTerminal());
         assertReactivePowerEquals(100, ngen2Nhv1.getTerminal1());
     }
+
+    @Test
+    void testZeroReactiveRangeAndReactiveLimitsDisabled() {
+        parameters.setUseReactiveLimits(false);
+
+        gen2.newMinMaxReactiveLimits()
+                .setMinQ(0)
+                .setMaxQ(0)
+                .add();
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isFullyConverged());
+        assertReactivePowerEquals(-109.228, gen.getTerminal());
+        assertReactivePowerEquals(-152.265, gen2.getTerminal());
+        assertReactivePowerEquals(-199.998, nhv2Nload.getTerminal2());
+    }
 }


### PR DESCRIPTION
Signed-off-by: Damien Jeandemange <damien.jeandemange@artelys.com

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bugfix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Reactive power dispatch is not accounting for plausible reactive power range.

In case of:
- a generator with Qmin;Qmax = [0.0; 0.0]
- with voltage regulation enabled
- and reactive limits disabled in parameters,

this results in incorrect (zero) Mvar result on the generator's terminal, and sum of bus reactive flows is not zero.

(Especially visible e.g. on Entso-e "RealGrid" test case).

**What is the new behavior (if this is a feature change)?**
Reactive power dispatch is accounting for plausible reactive power range and as a consequence correct bus reactive power balance.

**Does this PR introduce a breaking change or deprecate an API?**
- [x] No
