### PR TITLE
DC security analysis: RHS is not invalidated

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/equations/TargetVector.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/TargetVector.java
@@ -68,6 +68,15 @@ public class TargetVector<V extends Enum<V> & Quantity, E extends Enum<E> & Quan
         public void onShuntSusceptanceChange(LfShunt shunt, double b) {
             invalidateValues();
         }
+
+        @Override
+        public void onDisableChange(LfElement element, boolean disabled) {
+            for (var equationTerm : equationSystem.getEquationTerms(element.getType(), element.getNum())) {
+                if (equationTerm.hasRhs()) {
+                    invalidateValues();
+                }
+            }
+        }
     };
 
     public TargetVector(LfNetwork network, EquationSystem<V, E> equationSystem, Initializer<V, E> initializer) {

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -3185,4 +3185,58 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(1000., limitViolations.get(0).getLimit(), 0.0001);
         assertEquals(945.51416, limitViolations.get(0).getValue(), 0.0001);
     }
+
+    @Test
+    void testPhaseTapChangerContingency() {
+        Network network = PhaseControlFactory.createNetworkWithT2wt();
+        TwoWindingsTransformer pst = network.getTwoWindingsTransformer("PS1");
+        pst.getPhaseTapChanger().setTapPosition(2);
+
+        network.newLine().setId("L3")
+                .setConnectableBus1("B1")
+                .setBus1("B1")
+                .setConnectableBus2("B2")
+                .setBus2("B2")
+                .setR(4.0)
+                .setX(200.0)
+                .add();
+
+        network.newLine().setId("L4")
+                .setConnectableBus1("B3")
+                .setBus1("B3")
+                .setConnectableBus2("B2")
+                .setBus2("B2")
+                .setR(4.0)
+                .setX(200.0)
+                .add();
+
+        LoadFlowParameters lfParameters = new LoadFlowParameters()
+                .setDc(true);
+
+        List<Contingency> contingencies = List.of(Contingency.twoWindingsTransformer("PS1"));
+        List<StateMonitor> monitors = createAllBranchesMonitors(network);
+        SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies, monitors, lfParameters);
+        // pre-contingency tests
+        PreContingencyResult preContingencyResult = result.getPreContingencyResult();
+        assertEquals(7.623, preContingencyResult.getNetworkResult().getBranchResult("L1").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(56.503, preContingencyResult.getNetworkResult().getBranchResult("L2").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(7.623, preContingencyResult.getNetworkResult().getBranchResult("L3").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(28.252, preContingencyResult.getNetworkResult().getBranchResult("L4").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(84.755, preContingencyResult.getNetworkResult().getBranchResult("PS1").getP1(), LoadFlowAssert.DELTA_POWER);
+        // post-contingency tests
+        PostContingencyResult ps1ContingencyResult = getPostContingencyResult(result, "PS1");
+        assertEquals(-13.006, ps1ContingencyResult.getNetworkResult().getBranchResult("L1").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(84.009, ps1ContingencyResult.getNetworkResult().getBranchResult("L2").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(-13.006, ps1ContingencyResult.getNetworkResult().getBranchResult("L3").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(42.004, ps1ContingencyResult.getNetworkResult().getBranchResult("L4").getP1(), LoadFlowAssert.DELTA_POWER);
+
+        // we compare with a dc load flow
+        pst.getTerminal1().disconnect();
+        pst.getTerminal2().disconnect();
+        LoadFlow.run(network, lfParameters);
+        assertActivePowerEquals(50.0, network.getBranch("L1").getTerminal1());
+        assertActivePowerEquals(0.0, network.getBranch("L2").getTerminal1());
+        assertActivePowerEquals(50.0, network.getBranch("L3").getTerminal1());
+        assertActivePowerEquals(0.0, network.getBranch("L4").getTerminal1());
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -3225,10 +3225,10 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(84.755, preContingencyResult.getNetworkResult().getBranchResult("PS1").getP1(), LoadFlowAssert.DELTA_POWER);
         // post-contingency tests
         PostContingencyResult ps1ContingencyResult = getPostContingencyResult(result, "PS1");
-        assertEquals(-13.006, ps1ContingencyResult.getNetworkResult().getBranchResult("L1").getP1(), LoadFlowAssert.DELTA_POWER);
-        assertEquals(84.009, ps1ContingencyResult.getNetworkResult().getBranchResult("L2").getP1(), LoadFlowAssert.DELTA_POWER);
-        assertEquals(-13.006, ps1ContingencyResult.getNetworkResult().getBranchResult("L3").getP1(), LoadFlowAssert.DELTA_POWER);
-        assertEquals(42.004, ps1ContingencyResult.getNetworkResult().getBranchResult("L4").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(50.0, ps1ContingencyResult.getNetworkResult().getBranchResult("L1").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(0.0, ps1ContingencyResult.getNetworkResult().getBranchResult("L2").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(50.0, ps1ContingencyResult.getNetworkResult().getBranchResult("L3").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(0.0, ps1ContingencyResult.getNetworkResult().getBranchResult("L4").getP1(), LoadFlowAssert.DELTA_POWER);
 
         // we compare with a dc load flow
         pst.getTerminal1().disconnect();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

Yes, https://github.com/powsybl/pypowsybl/issues/758

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Nothing for the moment, just a unit test that shows the bug. In DC security analysis only, equations can have rhs. If the rhs of these equations changed, because in contingency for example, but it could be a tap position change of a P0 change for HVDC, we have to invalidate the DC target vector. It is not the case on main branch. 

We have the issue just today because it was hidden before through the sensitivity analysis API.   

**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
