### PR TITLE
Remove grouping by element necessary to connectivity

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sensi/ConnectivityBreakAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/ConnectivityBreakAnalysis.java
@@ -62,11 +62,11 @@ public final class ConnectivityBreakAnalysis {
             partialDisabledBranches = connectivity.getEdgesRemovedFromMainComponent();
         }
 
-        public PropagatedContingency getContingency() {
+        public PropagatedContingency getPropagatedContingency() {
             return contingency;
         }
 
-        public void setContingency(PropagatedContingency contingency) {
+        public void setPropagatedContingency(PropagatedContingency contingency) {
             this.contingency = contingency;
         }
 
@@ -169,7 +169,7 @@ public final class ConnectivityBreakAnalysis {
                     if (!lfFactors.isEmpty()) {
                         Set<String> elementsToReconnect = computeElementsToReconnect(connectivity, breakingConnectivityElements);
                         ConnectivityAnalysisResult connectivityAnalysisResult = new ConnectivityAnalysisResult(elementsToReconnect, connectivity, lfNetwork);
-                        connectivityAnalysisResult.setContingency(contingency);
+                        connectivityAnalysisResult.setPropagatedContingency(contingency);
                         connectivityAnalysisResults.add(connectivityAnalysisResult);
                     } else {
                         // write contingency status

--- a/src/main/java/com/powsybl/openloadflow/sensi/ConnectivityBreakAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/ConnectivityBreakAnalysis.java
@@ -101,8 +101,8 @@ public final class ConnectivityBreakAnalysis {
     private static void detectPotentialConnectivityBreak(LfNetwork lfNetwork, DenseMatrix states, List<PropagatedContingency> contingencies,
                                                          Map<String, ComputedContingencyElement> contingencyElementByBranch,
                                                          EquationSystem<DcVariableType, DcEquationType> equationSystem,
-                                                         Collection<PropagatedContingency> nonLosingConnectivityContingencies,
-                                                         Collection<PropagatedContingency> losingConnectivityContingencies) {
+                                                         List<PropagatedContingency> nonLosingConnectivityContingencies,
+                                                         List<PropagatedContingency> losingConnectivityContingencies) {
         for (PropagatedContingency contingency : contingencies) {
             List<ComputedContingencyElement> contingencyElements = contingency.getBranchIdsToOpen().keySet().stream().map(contingencyElementByBranch::get).collect(Collectors.toList());
             if (isGroupOfElementsBreakingConnectivity(lfNetwork, states, contingencyElements, equationSystem)) { // connectivity broken
@@ -114,7 +114,7 @@ public final class ConnectivityBreakAnalysis {
     }
 
     private static boolean isGroupOfElementsBreakingConnectivity(LfNetwork lfNetwork, DenseMatrix contingenciesStates,
-                                                                 Collection<ComputedContingencyElement> contingencyElements,
+                                                                 List<ComputedContingencyElement> contingencyElements,
                                                                  EquationSystem<DcVariableType, DcEquationType> equationSystem) {
         // use a sensitivity-criterion to detect the loss of connectivity after a contingency
         // we consider a +1 -1 on a line, and we observe the sensitivity of these injections on the other contingency elements

--- a/src/main/java/com/powsybl/openloadflow/sensi/ConnectivityBreakAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/ConnectivityBreakAnalysis.java
@@ -101,14 +101,14 @@ public final class ConnectivityBreakAnalysis {
     private static void detectPotentialConnectivityBreak(LfNetwork lfNetwork, DenseMatrix states, List<PropagatedContingency> contingencies,
                                                          Map<String, ComputedContingencyElement> contingencyElementByBranch,
                                                          EquationSystem<DcVariableType, DcEquationType> equationSystem,
-                                                         List<PropagatedContingency> nonLosingConnectivityContingencies,
-                                                         List<PropagatedContingency> potentiallyLosingConnectivityContingencies) {
+                                                         List<PropagatedContingency> nonBreakingConnectivityContingencies,
+                                                         List<PropagatedContingency> potentiallyBreakingConnectivityContingencies) {
         for (PropagatedContingency contingency : contingencies) {
             List<ComputedContingencyElement> contingencyElements = contingency.getBranchIdsToOpen().keySet().stream().map(contingencyElementByBranch::get).collect(Collectors.toList());
             if (isGroupOfElementsBreakingConnectivity(lfNetwork, states, contingencyElements, equationSystem)) { // connectivity broken
-                potentiallyLosingConnectivityContingencies.add(contingency);
+                potentiallyBreakingConnectivityContingencies.add(contingency);
             } else {
-                nonLosingConnectivityContingencies.add(contingency);
+                nonBreakingConnectivityContingencies.add(contingency);
             }
         }
     }

--- a/src/main/java/com/powsybl/openloadflow/sensi/ConnectivityBreakAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/ConnectivityBreakAnalysis.java
@@ -102,11 +102,11 @@ public final class ConnectivityBreakAnalysis {
                                                          Map<String, ComputedContingencyElement> contingencyElementByBranch,
                                                          EquationSystem<DcVariableType, DcEquationType> equationSystem,
                                                          List<PropagatedContingency> nonLosingConnectivityContingencies,
-                                                         List<PropagatedContingency> losingConnectivityContingencies) {
+                                                         List<PropagatedContingency> potentiallyLosingConnectivityContingencies) {
         for (PropagatedContingency contingency : contingencies) {
             List<ComputedContingencyElement> contingencyElements = contingency.getBranchIdsToOpen().keySet().stream().map(contingencyElementByBranch::get).collect(Collectors.toList());
             if (isGroupOfElementsBreakingConnectivity(lfNetwork, states, contingencyElements, equationSystem)) { // connectivity broken
-                losingConnectivityContingencies.add(contingency);
+                potentiallyLosingConnectivityContingencies.add(contingency);
             } else {
                 nonLosingConnectivityContingencies.add(contingency);
             }

--- a/src/main/java/com/powsybl/openloadflow/sensi/ConnectivityBreakAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/ConnectivityBreakAnalysis.java
@@ -43,7 +43,7 @@ public final class ConnectivityBreakAnalysis {
 
     public static final class ConnectivityAnalysisResult {
 
-        private final Collection<PropagatedContingency> contingencies = new HashSet<>();
+        private PropagatedContingency contingency;
 
         private final Set<String> elementsToReconnect;
 
@@ -62,8 +62,12 @@ public final class ConnectivityBreakAnalysis {
             partialDisabledBranches = connectivity.getEdgesRemovedFromMainComponent();
         }
 
-        public Collection<PropagatedContingency> getContingencies() {
-            return contingencies;
+        public PropagatedContingency getContingency() {
+            return contingency;
+        }
+
+        public void setContingency(PropagatedContingency contingency) {
+            this.contingency = contingency;
         }
 
         public Set<String> getElementsToReconnect() {
@@ -98,60 +102,55 @@ public final class ConnectivityBreakAnalysis {
                                                          Map<String, ComputedContingencyElement> contingencyElementByBranch,
                                                          EquationSystem<DcVariableType, DcEquationType> equationSystem,
                                                          Collection<PropagatedContingency> nonLosingConnectivityContingencies,
-                                                         Map<Set<ComputedContingencyElement>, List<PropagatedContingency>> contingenciesByGroupOfElementsBreakingConnectivity) {
+                                                         Collection<PropagatedContingency> losingConnectivityContingencies) {
         for (PropagatedContingency contingency : contingencies) {
             List<ComputedContingencyElement> contingencyElements = contingency.getBranchIdsToOpen().keySet().stream().map(contingencyElementByBranch::get).collect(Collectors.toList());
-            Set<ComputedContingencyElement> groupOfElementsBreakingConnectivity = getGroupOfElementsBreakingConnectivity(lfNetwork, states, contingencyElements, equationSystem);
-            if (groupOfElementsBreakingConnectivity.isEmpty()) { // connectivity not broken
-                nonLosingConnectivityContingencies.add(contingency);
+            if (isGroupOfElementsBreakingConnectivity(lfNetwork, states, contingencyElements, equationSystem)) { // connectivity broken
+                losingConnectivityContingencies.add(contingency);
             } else {
-                contingenciesByGroupOfElementsBreakingConnectivity.computeIfAbsent(groupOfElementsBreakingConnectivity, key -> new LinkedList<>()).add(contingency);
+                nonLosingConnectivityContingencies.add(contingency);
             }
         }
     }
 
-    private static Set<ComputedContingencyElement> getGroupOfElementsBreakingConnectivity(LfNetwork lfNetwork, DenseMatrix contingenciesStates,
-                                                                                          Collection<ComputedContingencyElement> contingencyElements,
-                                                                                          EquationSystem<DcVariableType, DcEquationType> equationSystem) {
+    private static boolean isGroupOfElementsBreakingConnectivity(LfNetwork lfNetwork, DenseMatrix contingenciesStates,
+                                                                 Collection<ComputedContingencyElement> contingencyElements,
+                                                                 EquationSystem<DcVariableType, DcEquationType> equationSystem) {
         // use a sensitivity-criterion to detect the loss of connectivity after a contingency
         // we consider a +1 -1 on a line, and we observe the sensitivity of these injections on the other contingency elements
         // if the sum of the sensitivities (in absolute value) is 1, it means that all the flow is going through the lines with a non-zero sensitivity
         // thus, losing these lines will lose the connectivity
-        Set<ComputedContingencyElement> groupOfElementsBreakingConnectivity = new LinkedHashSet<>();
         for (ComputedContingencyElement element : contingencyElements) {
-            Set<ComputedContingencyElement> responsibleElements = new LinkedHashSet<>();
             double sum = 0d;
             for (ComputedContingencyElement element2 : contingencyElements) {
                 LfBranch branch = lfNetwork.getBranchById(element2.getElement().getId());
                 ClosedBranchSide1DcFlowEquationTerm p = equationSystem.getEquationTerm(ElementType.BRANCH, branch.getNum(), ClosedBranchSide1DcFlowEquationTerm.class);
                 double value = Math.abs(p.calculateSensi(contingenciesStates, element.getContingencyIndex()));
-                if (value > CONNECTIVITY_LOSS_THRESHOLD) {
-                    responsibleElements.add(element2);
-                }
                 sum += value;
             }
             if (sum > 1d - CONNECTIVITY_LOSS_THRESHOLD) {
                 // all lines that have a non-0 sensitivity associated to "element" breaks the connectivity
-                groupOfElementsBreakingConnectivity.addAll(responsibleElements);
+                return true;
             }
         }
-        return groupOfElementsBreakingConnectivity;
+        return false;
     }
 
     private static List<ConnectivityAnalysisResult> computeConnectivityData(LfNetwork lfNetwork, AbstractSensitivityAnalysis.SensitivityFactorHolder<DcVariableType, DcEquationType> factorHolder,
-                                                                            Map<Set<ComputedContingencyElement>, List<PropagatedContingency>> contingenciesByGroupOfElementsBreakingConnectivity,
-                                                                            List<PropagatedContingency> nonLosingConnectivityContingencies, SensitivityResultWriter resultWriter) {
-        if (contingenciesByGroupOfElementsBreakingConnectivity.isEmpty()) {
+                                                                            List<PropagatedContingency> potentiallyBreakingConnectivityContingencies, Map<String, ComputedContingencyElement> contingencyElementByBranch,
+                                                                            List<PropagatedContingency> nonLosingConnectivityContingencies,
+                                                                            SensitivityResultWriter resultWriter) {
+        if (potentiallyBreakingConnectivityContingencies.isEmpty()) {
             return Collections.emptyList();
         }
 
-        Map<Set<ComputedContingencyElement>, ConnectivityAnalysisResult> connectivityAnalysisResults = new LinkedHashMap<>();
+        List<ConnectivityAnalysisResult> connectivityAnalysisResults = new ArrayList<>();
 
         GraphConnectivity<LfBus, LfBranch> connectivity = lfNetwork.getConnectivity();
-        for (Map.Entry<Set<ComputedContingencyElement>, List<PropagatedContingency>> e : contingenciesByGroupOfElementsBreakingConnectivity.entrySet()) {
-            Set<ComputedContingencyElement> breakingConnectivityCandidates = e.getKey();
-            List<PropagatedContingency> contingencyList = e.getValue();
+        for (PropagatedContingency contingency : potentiallyBreakingConnectivityContingencies) {
+            List<ComputedContingencyElement> breakingConnectivityCandidates = contingency.getBranchIdsToOpen().keySet().stream().map(contingencyElementByBranch::get).collect(Collectors.toList());
 
+            // we confirm the breaking of connectivity by network connectivity
             Set<ComputedContingencyElement> breakingConnectivityElements;
             connectivity.startTemporaryChanges();
             try {
@@ -166,33 +165,28 @@ public final class ConnectivityBreakAnalysis {
 
             if (breakingConnectivityElements.isEmpty()) {
                 // we did not break any connectivity
-                nonLosingConnectivityContingencies.addAll(contingencyList);
+                nonLosingConnectivityContingencies.add(contingency);
             } else {
                 // only compute for factors that have to be computed for this contingency lost
-                List<String> contingenciesIds = contingencyList.stream().map(contingency -> contingency.getContingency().getId()).collect(Collectors.toList());
-
-                List<AbstractSensitivityAnalysis.LfSensitivityFactor<DcVariableType, DcEquationType>> lfFactors = factorHolder.getFactorsForContingencies(contingenciesIds);
+                List<AbstractSensitivityAnalysis.LfSensitivityFactor<DcVariableType, DcEquationType>> lfFactors = factorHolder.getFactorsForContingencies(List.of(contingency.getContingency().getId()));
                 if (!lfFactors.isEmpty()) {
-                    connectivity.startTemporaryChanges();
+                    connectivity.startTemporaryChanges(); // FIXME, not necessary anymore, connectivity has not changed
                     try {
                         ComputedContingencyElement.applyToConnectivity(lfNetwork, connectivity, breakingConnectivityElements);
-                        ConnectivityAnalysisResult connectivityAnalysisResult = connectivityAnalysisResults.computeIfAbsent(breakingConnectivityElements, k -> {
-                            Set<String> elementsToReconnect = computeElementsToReconnect(connectivity, breakingConnectivityElements);
-                            return new ConnectivityAnalysisResult(elementsToReconnect, connectivity, lfNetwork);
-                        });
-                        connectivityAnalysisResult.getContingencies().addAll(contingencyList);
+                        Set<String> elementsToReconnect = computeElementsToReconnect(connectivity, breakingConnectivityElements);
+                        ConnectivityAnalysisResult connectivityAnalysisResult = new ConnectivityAnalysisResult(elementsToReconnect, connectivity, lfNetwork);
+                        connectivityAnalysisResult.setContingency(contingency);
+                        connectivityAnalysisResults.add(connectivityAnalysisResult);
                     } finally {
                         connectivity.undoTemporaryChanges();
                     }
                 } else {
                     // write contingency status
-                    for (PropagatedContingency propagatedContingency : contingencyList) {
-                        resultWriter.writeContingencyStatus(propagatedContingency.getIndex(), SensitivityAnalysisResult.Status.SUCCESS);
-                    }
+                    resultWriter.writeContingencyStatus(contingency.getIndex(), SensitivityAnalysisResult.Status.SUCCESS);
                 }
             }
         }
-        return new ArrayList<>(connectivityAnalysisResults.values());
+        return connectivityAnalysisResults;
     }
 
     private static boolean isBreakingConnectivity(GraphConnectivity<LfBus, LfBranch> connectivity, ComputedContingencyElement element) {
@@ -310,26 +304,23 @@ public final class ConnectivityBreakAnalysis {
 
         // connectivity analysis by contingency
         // we have to compute sensitivities and reference functions in a different way depending on either or not the contingency breaks connectivity
-        // so, we will index contingencies by a list of branch that may break connectivity
-        // for example, if in the network, loosing line L1 breaks connectivity, and loosing L2 and L3 together breaks connectivity,
-        // the index would be: L1, L2, L3
         // a contingency involving a phase tap changer loss has to be processed separately
         List<PropagatedContingency> nonBreakingConnectivityContingencies = new ArrayList<>();
-        Map<Set<ComputedContingencyElement>, List<PropagatedContingency>> contingenciesByGroupOfElementsPotentiallyBreakingConnectivity = new LinkedHashMap<>();
+        List<PropagatedContingency> potentiallyBreakingConnectivityContingencies = new ArrayList<>();
 
         // this first method based on sensitivity criteria is able to detect some contingencies that do not break
         // connectivity and other contingencies that potentially break connectivity
         detectPotentialConnectivityBreak(loadFlowContext.getNetwork(), contingenciesStates, contingencies, contingencyElementByBranch, loadFlowContext.getEquationSystem(),
-                nonBreakingConnectivityContingencies, contingenciesByGroupOfElementsPotentiallyBreakingConnectivity);
+                nonBreakingConnectivityContingencies, potentiallyBreakingConnectivityContingencies);
         LOGGER.info("After sensitivity based connectivity analysis, {} contingencies do not break connectivity, {} contingencies potentially break connectivity",
-                nonBreakingConnectivityContingencies.size(), contingenciesByGroupOfElementsPotentiallyBreakingConnectivity.values().stream().mapToInt(List::size).count());
+                nonBreakingConnectivityContingencies.size(), potentiallyBreakingConnectivityContingencies.size());
 
         // this second method process all contingencies that potentially break connectivity and using graph algorithms
         // find remaining contingencies that do not break connectivity
-        List<ConnectivityAnalysisResult> connectivityAnalysisResults = computeConnectivityData(loadFlowContext.getNetwork(), factorHolder, contingenciesByGroupOfElementsPotentiallyBreakingConnectivity,
-                nonBreakingConnectivityContingencies, resultWriter);
+        List<ConnectivityAnalysisResult> connectivityAnalysisResults = computeConnectivityData(loadFlowContext.getNetwork(), factorHolder,
+                potentiallyBreakingConnectivityContingencies, contingencyElementByBranch, nonBreakingConnectivityContingencies, resultWriter);
         LOGGER.info("After graph based connectivity analysis, {} contingencies do not break connectivity, {} contingencies break connectivity",
-                nonBreakingConnectivityContingencies.size(), connectivityAnalysisResults.stream().mapToInt(results -> results.getContingencies().size()).count());
+                nonBreakingConnectivityContingencies.size(), connectivityAnalysisResults.size());
 
         return new ConnectivityBreakAnalysisResults(nonBreakingConnectivityContingencies, connectivityAnalysisResults, contingenciesStates, contingencyElementByBranch);
     }

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -478,7 +478,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
                                                           ReportNode reportNode) {
         DenseMatrix modifiedFlowStates = flowStates;
 
-        List<String> contingenciesIds = connectivityAnalysisResult.getContingencies().stream().map(c -> c.getContingency().getId()).collect(Collectors.toList());
+        List<String> contingenciesIds = List.of(connectivityAnalysisResult.getContingency().getContingency().getId()); // FIXME
         List<LfSensitivityFactor<DcVariableType, DcEquationType>> lfFactorsForContingencies = validFactorHolder.getFactorsForContingencies(contingenciesIds);
 
         Set<LfBus> disabledBuses = connectivityAnalysisResult.getDisabledBuses();
@@ -488,10 +488,9 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
         // if one bus of the line is lost.
         for (LfHvdc hvdc : loadFlowContext.getNetwork().getHvdcs()) {
             if (Networks.isIsolatedBusForHvdc(hvdc.getBus1(), disabledBuses) ^ Networks.isIsolatedBusForHvdc(hvdc.getBus2(), disabledBuses)) {
-                connectivityAnalysisResult.getContingencies().forEach(contingency -> {
-                    contingency.getGeneratorIdsToLose().add(hvdc.getConverterStation1().getId());
-                    contingency.getGeneratorIdsToLose().add(hvdc.getConverterStation2().getId());
-                });
+                PropagatedContingency contingency = connectivityAnalysisResult.getContingency();
+                contingency.getGeneratorIdsToLose().add(hvdc.getConverterStation1().getId());
+                contingency.getGeneratorIdsToLose().add(hvdc.getConverterStation2().getId());
             }
         }
 
@@ -524,7 +523,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
 
         calculateSensitivityValuesForContingencyList(loadFlowContext, lfParametersExt,
                 validFactorHolder, factorGroups, factorStateForThisConnectivity, contingenciesStates, modifiedFlowStates,
-                connectivityAnalysisResult.getContingencies(), contingencyElementByBranch, disabledBuses, participatingElementsForThisConnectivity,
+                List.of(connectivityAnalysisResult.getContingency()), contingencyElementByBranch, disabledBuses, participatingElementsForThisConnectivity,
                 connectivityAnalysisResult.getElementsToReconnect(), resultWriter, reportNode, partialDisabledBranches);
 
         if (rhsChanged) {
@@ -699,8 +698,8 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
                 // process contingencies with connectivity break
                 for (ConnectivityBreakAnalysis.ConnectivityAnalysisResult connectivityAnalysisResult : connectivityBreakAnalysisResults.connectivityAnalysisResults()) {
                     processContingenciesBreakingConnectivity(connectivityAnalysisResult, loadFlowContext, lfParameters, lfParametersExt,
-                            validFactorHolder, factorGroups, participatingElements,
-                            connectivityBreakAnalysisResults.contingencyElementByBranch(), flowStates, factorsStates, connectivityBreakAnalysisResults.contingenciesStates(), resultWriter, reportNode);
+                            validFactorHolder, factorGroups, participatingElements, connectivityBreakAnalysisResults.contingencyElementByBranch(),
+                            flowStates, factorsStates, connectivityBreakAnalysisResults.contingenciesStates(), resultWriter, reportNode);
                 }
             }
 

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -340,7 +340,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
 
     /**
      * Calculate sensitivity values for a post-contingency state.
-     * When a contingency involves the loss of a load or a generator, the slack distribution could changed
+     * When a contingency involves the loss of a load or a generator, the slack distribution could be changed
      * or the sensitivity factors in case of GLSK.
      */
     private void calculateContingencySensitivityValues(PropagatedContingency contingency, SensitivityFactorGroupList<DcVariableType, DcEquationType> factorGroups, DenseMatrix factorStates, DenseMatrix contingenciesStates,
@@ -478,17 +478,17 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
                                                           ReportNode reportNode) {
         DenseMatrix modifiedFlowStates = flowStates;
 
-        List<String> contingenciesIds = List.of(connectivityAnalysisResult.getContingency().getContingency().getId()); // FIXME
-        List<LfSensitivityFactor<DcVariableType, DcEquationType>> lfFactorsForContingencies = validFactorHolder.getFactorsForContingencies(contingenciesIds);
+        PropagatedContingency contingency = connectivityAnalysisResult.getPropagatedContingency();
+        List<String> contingencyId = List.of(contingency.getContingency().getId());
+        List<LfSensitivityFactor<DcVariableType, DcEquationType>> lfFactorsForContingencies = validFactorHolder.getFactorsForContingencies(contingencyId);
 
         Set<LfBus> disabledBuses = connectivityAnalysisResult.getDisabledBuses();
         Set<LfBranch> partialDisabledBranches = connectivityAnalysisResult.getPartialDisabledBranches();
 
-        // as we are processing contingencies with connectivity break, we have to reset active power flow of a hvdc line
+        // as we are processing a contingency with connectivity break, we have to reset active power flow of a hvdc line
         // if one bus of the line is lost.
         for (LfHvdc hvdc : loadFlowContext.getNetwork().getHvdcs()) {
             if (Networks.isIsolatedBusForHvdc(hvdc.getBus1(), disabledBuses) ^ Networks.isIsolatedBusForHvdc(hvdc.getBus2(), disabledBuses)) {
-                PropagatedContingency contingency = connectivityAnalysisResult.getContingency();
                 contingency.getGeneratorIdsToLose().add(hvdc.getConverterStation1().getId());
                 contingency.getGeneratorIdsToLose().add(hvdc.getConverterStation2().getId());
             }
@@ -523,7 +523,7 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
 
         calculateSensitivityValuesForContingencyList(loadFlowContext, lfParametersExt,
                 validFactorHolder, factorGroups, factorStateForThisConnectivity, contingenciesStates, modifiedFlowStates,
-                List.of(connectivityAnalysisResult.getContingency()), contingencyElementByBranch, disabledBuses, participatingElementsForThisConnectivity,
+                List.of(contingency), contingencyElementByBranch, disabledBuses, participatingElementsForThisConnectivity,
                 connectivityAnalysisResult.getElementsToReconnect(), resultWriter, reportNode, partialDisabledBranches);
 
         if (rhsChanged) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

No. We have an optimization in the DC sensitivity analysis that groups contingencies if they include the lost of the same element necessary to connectivity. This optimisation is really small compared to the difficulties it adds to the code and its maintainability. 

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
