### PR TITLE
AC loadflow: no network update on NO_CALCULATION

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
@@ -104,7 +104,7 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
         }
         try {
             // update network state
-            if (atLeastOneComponentHasToBeUpdated || parametersExt.isAlwaysUpdateNetwork()) {
+            if ((atLeastOneComponentHasToBeUpdated || parametersExt.isAlwaysUpdateNetwork()) && result.isSuccess()) {
                 var updateParameters = new LfNetworkStateUpdateParameters(parameters.isUseReactiveLimits(),
                                                                           parameters.isWriteSlackBus(),
                                                                           parameters.isPhaseShifterRegulationOn(),

--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
@@ -104,7 +104,8 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
         }
         try {
             // update network state
-            if ((atLeastOneComponentHasToBeUpdated || parametersExt.isAlwaysUpdateNetwork()) && result.isSuccess()) {
+            if (atLeastOneComponentHasToBeUpdated && result.isSuccess()
+                    || parametersExt.isAlwaysUpdateNetwork()) {
                 var updateParameters = new LfNetworkStateUpdateParameters(parameters.isUseReactiveLimits(),
                                                                           parameters.isWriteSlackBus(),
                                                                           parameters.isPhaseShifterRegulationOn(),

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowReportTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowReportTest.java
@@ -136,6 +136,7 @@ class AcLoadFlowReportTest {
         assertEquals(LfNetwork.Validity.INVALID_NO_GENERATOR_VOLTAGE_CONTROL.toString(), result.getComponentResults().get(1).getStatusText());
         assertEquals(LoadFlowResult.ComponentResult.Status.NO_CALCULATION, result.getComponentResults().get(2).getStatus());
         assertEquals(LfNetwork.Validity.INVALID_NO_GENERATOR.toString(), result.getComponentResults().get(2).getStatusText());
+        assertEquals(Double.NaN, network.getLoad("d9").getTerminal().getP()); // load on the NO_CALCULATION island connected component
         LoadFlowAssert.assertReportEquals("/multipleConnectedComponentsAcReport.txt", reportNode);
 
         // test in DC
@@ -151,6 +152,7 @@ class AcLoadFlowReportTest {
         assertEquals("Converged", result.getComponentResults().get(1).getStatusText());
         assertEquals(LoadFlowResult.ComponentResult.Status.NO_CALCULATION, result.getComponentResults().get(2).getStatus());
         assertEquals(LfNetwork.Validity.INVALID_NO_GENERATOR.toString(), result.getComponentResults().get(2).getStatusText());
+        assertEquals(Double.NaN, network.getLoad("d9").getTerminal().getP()); // load on the NO_CALCULATION island connected component
         LoadFlowAssert.assertReportEquals("/multipleConnectedComponentsDcReport.txt", reportNode);
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
In AC loadflow, network is updated on the connected component even if no calculation has been made. This leads for instance to some incorrect values on islands with no active generators (p0 and q0 set to p and q on loads).

**What is the new behavior (if this is a feature change)?**
In AC loadflow, network is only updated is the result is successful, similarly to DC loadflow.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No