### PR TITLE
Fix slack distribution if reference generator is not participating element

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -219,7 +218,7 @@ public class DcLoadFlowEngine implements LoadFlowEngine<DcVariableType, DcEquati
 
                     return new DcLoadFlowResult(n, getActivePowerMismatch(n.getBuses()), false);
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
@@ -51,10 +51,10 @@ public class DcLoadFlowEngine implements LoadFlowEngine<DcVariableType, DcEquati
         return context;
     }
 
-    public static void distributeSlack(Collection<LfBus> buses, LoadFlowParameters.BalanceType balanceType, boolean useActiveLimits) {
+    public static void distributeSlack(LfNetwork network, Collection<LfBus> buses, LoadFlowParameters.BalanceType balanceType, boolean useActiveLimits) {
         double mismatch = getActivePowerMismatch(buses);
         ActivePowerDistribution activePowerDistribution = ActivePowerDistribution.create(balanceType, false, useActiveLimits);
-        activePowerDistribution.run(buses, mismatch);
+        activePowerDistribution.run(network.getReferenceGenerator(), buses, mismatch);
     }
 
     public static double getActivePowerMismatch(Collection<LfBus> buses) {
@@ -174,7 +174,7 @@ public class DcLoadFlowEngine implements LoadFlowEngine<DcVariableType, DcEquati
         initStateVector(network, equationSystem, new UniformValueVoltageInitializer());
 
         if (parameters.isDistributedSlack()) {
-            distributeSlack(network.getBuses(), parameters.getBalanceType(), parameters.getNetworkParameters().isUseActiveLimits());
+            distributeSlack(network, network.getBuses(), parameters.getBalanceType(), parameters.getNetworkParameters().isUseActiveLimits());
         }
 
         // we need to copy the target array because JacobianMatrix.solveTransposed take as an input the second member
@@ -237,7 +237,7 @@ public class DcLoadFlowEngine implements LoadFlowEngine<DcVariableType, DcEquati
 
         DcLoadFlowParameters parameters = loadFlowContext.getParameters();
         if (parameters.isDistributedSlack()) {
-            distributeSlack(remainingBuses, parameters.getBalanceType(), parameters.getNetworkParameters().isUseActiveLimits());
+            distributeSlack(loadFlowContext.getNetwork(), remainingBuses, parameters.getBalanceType(), parameters.getNetworkParameters().isUseActiveLimits());
         }
 
         // we need to copy the target array because:

--- a/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
@@ -90,27 +90,17 @@ public final class ActivePowerDistribution {
     }
 
     public static Step getStep(LoadFlowParameters.BalanceType balanceType, boolean loadPowerFactorConstant, boolean useActiveLimits) {
-        Step step;
-        switch (balanceType) {
-            case PROPORTIONAL_TO_LOAD,
-                 PROPORTIONAL_TO_CONFORM_LOAD:
-                step = new LoadActivePowerDistributionStep(loadPowerFactorConstant);
-                break;
-            case PROPORTIONAL_TO_GENERATION_P_MAX:
-                step = new GenerationActivePowerDistributionStep(GenerationActivePowerDistributionStep.ParticipationType.MAX, useActiveLimits);
-                break;
-            case PROPORTIONAL_TO_GENERATION_P:
-                step = new GenerationActivePowerDistributionStep(GenerationActivePowerDistributionStep.ParticipationType.TARGET, useActiveLimits);
-                break;
-            case PROPORTIONAL_TO_GENERATION_PARTICIPATION_FACTOR:
-                step = new GenerationActivePowerDistributionStep(GenerationActivePowerDistributionStep.ParticipationType.PARTICIPATION_FACTOR, useActiveLimits);
-                break;
-            case PROPORTIONAL_TO_GENERATION_REMAINING_MARGIN:
-                step = new GenerationActivePowerDistributionStep(GenerationActivePowerDistributionStep.ParticipationType.REMAINING_MARGIN, useActiveLimits);
-                break;
-            default:
-                throw new UnsupportedOperationException("Unknown balance type mode: " + balanceType);
-        }
-        return step;
+        return switch (balanceType) {
+            case PROPORTIONAL_TO_LOAD, PROPORTIONAL_TO_CONFORM_LOAD ->
+                    new LoadActivePowerDistributionStep(loadPowerFactorConstant);
+            case PROPORTIONAL_TO_GENERATION_P_MAX ->
+                    new GenerationActivePowerDistributionStep(GenerationActivePowerDistributionStep.ParticipationType.MAX, useActiveLimits);
+            case PROPORTIONAL_TO_GENERATION_P ->
+                    new GenerationActivePowerDistributionStep(GenerationActivePowerDistributionStep.ParticipationType.TARGET, useActiveLimits);
+            case PROPORTIONAL_TO_GENERATION_PARTICIPATION_FACTOR ->
+                    new GenerationActivePowerDistributionStep(GenerationActivePowerDistributionStep.ParticipationType.PARTICIPATION_FACTOR, useActiveLimits);
+            case PROPORTIONAL_TO_GENERATION_REMAINING_MARGIN ->
+                    new GenerationActivePowerDistributionStep(GenerationActivePowerDistributionStep.ParticipationType.REMAINING_MARGIN, useActiveLimits);
+        };
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
@@ -63,6 +63,7 @@ public final class ActivePowerDistribution {
         double remainingMismatch = activePowerMismatch;
 
         if (referenceGenerator != null) {
+            // "undo" everything from targetP to go back to initialP for reference generator
             remainingMismatch -= referenceGenerator.getInitialTargetP() - referenceGenerator.getTargetP();
             referenceGenerator.setTargetP(referenceGenerator.getInitialTargetP());
         }

--- a/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
@@ -90,6 +90,7 @@ public final class ActivePowerDistribution {
     }
 
     public static Step getStep(LoadFlowParameters.BalanceType balanceType, boolean loadPowerFactorConstant, boolean useActiveLimits) {
+        Objects.requireNonNull(balanceType);
         return switch (balanceType) {
             case PROPORTIONAL_TO_LOAD, PROPORTIONAL_TO_CONFORM_LOAD ->
                     new LoadActivePowerDistributionStep(loadPowerFactorConstant);

--- a/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
@@ -91,7 +91,6 @@ public final class ActivePowerDistribution {
     }
 
     public static Step getStep(LoadFlowParameters.BalanceType balanceType, boolean loadPowerFactorConstant, boolean useActiveLimits) {
-        Objects.requireNonNull(balanceType);
         return switch (balanceType) {
             case PROPORTIONAL_TO_LOAD, PROPORTIONAL_TO_CONFORM_LOAD ->
                     new LoadActivePowerDistributionStep(loadPowerFactorConstant);

--- a/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
@@ -619,18 +619,18 @@ class DistributedSlackOnGenerationTest {
         assertTrue(result.isFullyConverged());
 
         var expectedDistributedActivePower = -network.getGeneratorStream().mapToDouble(g -> g.getTargetP() + g.getTerminal().getP()).sum();
-        assertEquals(120.2055, expectedDistributedActivePower, LoadFlowAssert.DELTA_POWER);
+        assertEquals(120.2021, expectedDistributedActivePower, LoadFlowAssert.DELTA_POWER);
         assertEquals(expectedDistributedActivePower, result.getComponentResults().get(0).getDistributedActivePower(), LoadFlowAssert.DELTA_POWER);
 
         // Only g1 gets slack "normally" distributed, and g2 being reference generator picks up the remaining slack
         // generator | targetP | Participation Factor | Reference
         // ----------|---------|----------------------|-----------
         //   g1      |  100    |         1.0          |           --> expected to hit limit 110MW with 10MW distributed
-        //   g2      |  200    |          -           |     X     --> expected to pick up the remaining slack 110.2055 MW
+        //   g2      |  200    |          -           |     X     --> expected to pick up the remaining slack 110.2021 MW
         //   g3      |   90    |          -           |           --> unchanged
         //   g4      |   90    |          -           |           --> unchanged
-        assertActivePowerEquals(-97.732, g1.getTerminal()); // FIXME should be -110
-        assertActivePowerEquals(-322.4728, g2.getTerminal()); // FIXME should be -310
+        assertActivePowerEquals(-110.000, g1.getTerminal());
+        assertActivePowerEquals(-310.2021, g2.getTerminal());
         assertActivePowerEquals(-90.000, g3.getTerminal());
         assertActivePowerEquals(-90.000, g4.getTerminal());
     }

--- a/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
@@ -216,7 +216,7 @@ class DistributedSlackOnGenerationTest {
 
     @Test
     void maxTestActivePowerLimitDisabled() {
-        parameters.getExtension(OpenLoadFlowParameters.class).setUseActiveLimits(false);
+        parametersExt.setUseActiveLimits(false);
         // decrease g1 max limit power, so that distributed slack algo reach the g1 max
         // Because we disabled active power limits, g1 will exceed max
         g1.setMaxP(105);
@@ -231,7 +231,7 @@ class DistributedSlackOnGenerationTest {
 
     @Test
     void minTestActivePowerLimitDisabled() {
-        parameters.getExtension(OpenLoadFlowParameters.class).setUseActiveLimits(false);
+        parametersExt.setUseActiveLimits(false);
         // increase g1 min limit power and global load so that distributed slack algo reach the g1 min
         // Because we disabled active power limits, g1 will exceed min
         g1.setMinP(95);
@@ -246,7 +246,7 @@ class DistributedSlackOnGenerationTest {
 
     @Test
     void targetBelowMinAndActivePowerLimitDisabled() {
-        parameters.getExtension(OpenLoadFlowParameters.class).setUseActiveLimits(false);
+        parametersExt.setUseActiveLimits(false);
         g1.setMinP(100); // was 0
         g1.setTargetP(80);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
@@ -260,7 +260,7 @@ class DistributedSlackOnGenerationTest {
 
     @Test
     void targetAboveMaxAndActivePowerLimitDisabled() {
-        parameters.getExtension(OpenLoadFlowParameters.class).setUseActiveLimits(false);
+        parametersExt.setUseActiveLimits(false);
         g1.setTargetP(240); // max is 200
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
@@ -336,7 +336,7 @@ class DistributedSlackOnGenerationTest {
     @Test
     void notEnoughActivePowerFailTest() {
         network.getLoad("l1").setP0(1000);
-        parameters.getExtension(OpenLoadFlowParameters.class).setSlackDistributionFailureBehavior(OpenLoadFlowParameters.SlackDistributionFailureBehavior.FAIL);
+        parametersExt.setSlackDistributionFailureBehavior(OpenLoadFlowParameters.SlackDistributionFailureBehavior.FAIL);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         LoadFlowResult.ComponentResult componentResult = result.getComponentResults().get(0);
         assertFalse(result.isFullyConverged());
@@ -349,7 +349,7 @@ class DistributedSlackOnGenerationTest {
     @Test
     void notEnoughActivePowerLeaveOnSlackBusTest() {
         network.getLoad("l1").setP0(1000);
-        parameters.getExtension(OpenLoadFlowParameters.class).setSlackDistributionFailureBehavior(OpenLoadFlowParameters.SlackDistributionFailureBehavior.LEAVE_ON_SLACK_BUS);
+        parametersExt.setSlackDistributionFailureBehavior(OpenLoadFlowParameters.SlackDistributionFailureBehavior.LEAVE_ON_SLACK_BUS);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         LoadFlowResult.ComponentResult componentResult = result.getComponentResults().get(0);
         assertTrue(result.isFullyConverged());
@@ -363,7 +363,7 @@ class DistributedSlackOnGenerationTest {
         network.getLoad("l1").setP0(1000);
         ReferencePriority.set(g1, 1);
         g1.setMaxP(200.);
-        parameters.getExtension(OpenLoadFlowParameters.class)
+        parametersExt
                 .setReferenceBusSelectionMode(ReferenceBusSelectionMode.GENERATOR_REFERENCE_PRIORITY)
                 .setSlackDistributionFailureBehavior(OpenLoadFlowParameters.SlackDistributionFailureBehavior.DISTRIBUTE_ON_REFERENCE_GENERATOR);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
@@ -387,7 +387,7 @@ class DistributedSlackOnGenerationTest {
         g1.setMaxP(200.);
         // We request to distribute on reference generator, but ReferenceBusSelectionMode is FIRST_SLACK.
         // FIRST_SLACK mode does not select a reference generator, therefore internally we switch to FAIL mode.
-        parameters.getExtension(OpenLoadFlowParameters.class)
+        parametersExt
                 .setReferenceBusSelectionMode(ReferenceBusSelectionMode.FIRST_SLACK)
                 .setSlackDistributionFailureBehavior(OpenLoadFlowParameters.SlackDistributionFailureBehavior.DISTRIBUTE_ON_REFERENCE_GENERATOR);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);

--- a/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnLoadTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnLoadTest.java
@@ -112,8 +112,7 @@ class DistributedSlackOnLoadTest {
 
     private void assertPowerFactor(Network network) {
         switch (parameters.getBalanceType()) {
-            case PROPORTIONAL_TO_CONFORM_LOAD:
-            case PROPORTIONAL_TO_LOAD:
+            case PROPORTIONAL_TO_CONFORM_LOAD, PROPORTIONAL_TO_LOAD:
                 for (Load load : network.getLoads()) {
                     assertEquals(load.getP0() / load.getQ0(),
                             load.getTerminal().getP() / load.getTerminal().getQ(),
@@ -237,7 +236,7 @@ class DistributedSlackOnLoadTest {
 
     @Test
     void testPowerFactorConstant2() {
-        Network network = DistributedSlackNetworkFactory.createNetworkWithLoads2();
+        network = DistributedSlackNetworkFactory.createNetworkWithLoads2();
         parameters.setBalanceType(LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD);
         parametersExt.setLoadPowerFactorConstant(true).setNewtonRaphsonConvEpsPerEq(1e-6);
         network.getLoad("l4").newExtension(LoadDetailAdder.class)
@@ -256,11 +255,11 @@ class DistributedSlackOnLoadTest {
 
     @Test
     void testPowerFactorConstant3() {
-        Network network = DistributedSlackNetworkFactory.createNetworkWithLoads2();
+        network = DistributedSlackNetworkFactory.createNetworkWithLoads2();
         parameters.setBalanceType(LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD);
         parametersExt.setLoadPowerFactorConstant(true);
         network.getGenerator("g1").setTargetP(-208);
-        Load l4 = network.getLoad("l4");
+        l4 = network.getLoad("l4");
         l4.setP0(0.0).setQ0(-50);
         l4.newExtension(LoadDetailAdder.class)
                 .withFixedActivePower(0)
@@ -268,7 +267,7 @@ class DistributedSlackOnLoadTest {
                 .withVariableActivePower(0)
                 .withVariableReactivePower(-50)
                 .add();
-        Load l5 = network.getLoad("l5");
+        l5 = network.getLoad("l5");
         l5.setP0(-10.0).setQ0(0.0);
         l5.newExtension(LoadDetailAdder.class)
                 .withFixedActivePower(-10)
@@ -284,16 +283,16 @@ class DistributedSlackOnLoadTest {
 
     @Test
     void testPowerFactorConstant4() {
-        Network network = DistributedSlackNetworkFactory.createNetworkWithLoads2();
+        network = DistributedSlackNetworkFactory.createNetworkWithLoads2();
         parameters.setBalanceType(LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD);
         parametersExt.setLoadPowerFactorConstant(true)
                 .setNewtonRaphsonStoppingCriteriaType(NewtonRaphsonStoppingCriteriaType.PER_EQUATION_TYPE_CRITERIA)
                 .setMaxActivePowerMismatch(1e-2)
                 .setMaxReactivePowerMismatch(1e-2);
         // network has 300 MW generation, we set 400MW total P0 load
-        Load l4 = network.getLoad("l4");
+        l4 = network.getLoad("l4");
         l4.setP0(0.0).setQ0(50.0); // 0MW -> 0% participation factor
-        Load l5 = network.getLoad("l5");
+        l5 = network.getLoad("l5");
         l5.setP0(400.0).setQ0(50.0); // only non-zero load -> 100% participation factor
 
         // test with l4 being reactive only load


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bugfix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Corner case which wasn't handled in #1041: in case the reference generator is not in the "participating elements", we still see the unwanted hysteresis effect.


**What is the new behavior (if this is a feature change)?**
Correct slack distribution on generators.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No
