### PR TITLE
Fix Security Analysis in case of no more voltage regulated bus

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/AcloadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcloadFlowEngine.java
@@ -138,9 +138,8 @@ public class AcloadFlowEngine implements LoadFlowEngine<AcVariableType, AcEquati
         // For example: a contingency may cause the last PV node to disappear. In this case here we would
         // just report SOLVER_FAILED. However, there could be other generators blocked at MinQ or MaxQ that
         // _could potentially_ recover the situation, but this will not be tried at all...
-        boolean hasVoltageRegulatedBus = context.getEquationSystem().getEquations()
-                .stream()
-                .anyMatch(eq -> eq.isActive() && eq.getType() == AcEquationType.BUS_TARGET_V);
+        boolean hasVoltageRegulatedBus = context.getNetwork().getBuses().stream()
+                .anyMatch(b -> b.isGeneratorVoltageControlEnabled() && !b.isDisabled() && !b.getGeneratorVoltageControl().orElseThrow().isDisabled());
         if (!hasVoltageRegulatedBus) {
             LOGGER.info("Network must have at least one bus with generator voltage control enabled");
             Reports.reportNetworkMustHaveAtLeastOneBusGeneratorVoltageControlEnabled(reportNode);

--- a/src/main/java/com/powsybl/openloadflow/ac/AcloadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcloadFlowEngine.java
@@ -227,10 +227,10 @@ public class AcloadFlowEngine implements LoadFlowEngine<AcVariableType, AcEquati
                                                        runningContext.outerLoopTotalIterations,
                                                        runningContext.nrTotalIterations.getValue(),
                                                        runningContext.lastSolverResult.getStatus(),
-                outerLoopFinalResult,
+                                                       outerLoopFinalResult,
                                                        runningContext.lastSolverResult.getSlackBusActivePowerMismatch(),
-                distributedActivePower
-                                                       );
+                                                       distributedActivePower
+        );
 
         LOGGER.info("Ac loadflow complete on network {} (result={})", context.getNetwork(), result);
 

--- a/src/main/java/com/powsybl/openloadflow/ac/AcloadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcloadFlowEngine.java
@@ -122,9 +122,9 @@ public class AcloadFlowEngine implements LoadFlowEngine<AcVariableType, AcEquati
     public AcLoadFlowResult run() {
         LOGGER.info("Start AC loadflow on network {}", context.getNetwork());
 
-        boolean hasVoltageRegulatedBus = context.getEquationSystem().getEquations().stream()
-                .filter(eq -> eq.getType() == AcEquationType.BUS_TARGET_V)
-                .anyMatch(Equation::isActive);
+        boolean hasVoltageRegulatedBus = context.getEquationSystem().getEquations()
+                .stream()
+                .anyMatch(eq -> eq.isActive() && eq.getType() == AcEquationType.BUS_TARGET_V);
         RunningContext runningContext = new RunningContext();
         double distributedActivePower = 0.0;
         ReportNode reportNode = context.getNetwork().getReportNode();

--- a/src/main/java/com/powsybl/openloadflow/ac/AcloadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcloadFlowEngine.java
@@ -137,7 +137,7 @@ public class AcloadFlowEngine implements LoadFlowEngine<AcVariableType, AcEquati
         if (!hasVoltageRegulatedBus) {
             LOGGER.info("Network has no voltage regulated bus");
             Reports.reportNoVoltageRegulatedBus(reportNode);
-            runningContext.lastSolverResult = new AcSolverResult(AcSolverStatus.SOLVER_FAILED, 0, Double.NaN); // or UNREALISTIC_STATE ?
+            runningContext.lastSolverResult = new AcSolverResult(AcSolverStatus.UNREALISTIC_STATE, 0, Double.NaN);
             return buildAcLoadFlowResult(runningContext, OuterLoopResult.stable(), distributedActivePower);
         }
 
@@ -229,7 +229,7 @@ public class AcloadFlowEngine implements LoadFlowEngine<AcVariableType, AcEquati
                                                        outerLoopFinalResult,
                                                        runningContext.lastSolverResult.getSlackBusActivePowerMismatch(),
                                                        distributedActivePower
-        );
+                                                       );
 
         LOGGER.info("Ac loadflow complete on network {} (result={})", context.getNetwork(), result);
 

--- a/src/main/java/com/powsybl/openloadflow/ac/AcloadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcloadFlowEngine.java
@@ -135,7 +135,7 @@ public class AcloadFlowEngine implements LoadFlowEngine<AcVariableType, AcEquati
         ReportNode reportNode = context.getNetwork().getReportNode();
 
         if (!hasVoltageRegulatedBus) {
-            LOGGER.info("Network has no voltage regulated bus");
+            LOGGER.info("Network must have at least one bus with generator voltage control enabled");
             Reports.reportNetworkMustHaveAtLeastOneBusGeneratorVoltageControlEnabled(reportNode);
             runningContext.lastSolverResult = new AcSolverResult(AcSolverStatus.UNREALISTIC_STATE, 0, Double.NaN);
             return buildAcLoadFlowResult(runningContext, OuterLoopResult.stable(), distributedActivePower);

--- a/src/main/java/com/powsybl/openloadflow/ac/AcloadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcloadFlowEngine.java
@@ -136,7 +136,7 @@ public class AcloadFlowEngine implements LoadFlowEngine<AcVariableType, AcEquati
 
         if (!hasVoltageRegulatedBus) {
             LOGGER.info("Network has no voltage regulated bus");
-            Reports.reportNoVoltageRegulatedBus(reportNode);
+            Reports.reportNetworkMustHaveAtLeastOneBusGeneratorVoltageControlEnabled(reportNode);
             runningContext.lastSolverResult = new AcSolverResult(AcSolverStatus.UNREALISTIC_STATE, 0, Double.NaN);
             return buildAcLoadFlowResult(runningContext, OuterLoopResult.stable(), distributedActivePower);
         }

--- a/src/main/java/com/powsybl/openloadflow/util/Reports.java
+++ b/src/main/java/com/powsybl/openloadflow/util/Reports.java
@@ -628,11 +628,4 @@ public final class Reports {
                 .withSeverity(TypedValue.INFO_SEVERITY)
                 .add());
     }
-
-    public static void reportNoVoltageRegulatedBus(ReportNode reportNode) {
-        reportNode.newReportNode()
-                .withMessageTemplate("noVoltageRegulatedBus", "Network has no voltage regulated bus")
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .add();
-    }
 }

--- a/src/main/java/com/powsybl/openloadflow/util/Reports.java
+++ b/src/main/java/com/powsybl/openloadflow/util/Reports.java
@@ -628,4 +628,11 @@ public final class Reports {
                 .withSeverity(TypedValue.INFO_SEVERITY)
                 .add());
     }
+
+    public static void reportNoVoltageRegulatedBus(ReportNode reportNode) {
+        reportNode.newReportNode()
+                .withMessageTemplate("noVoltageRegulatedBus", "Network has no voltage regulated bus")
+                .withSeverity(TypedValue.INFO_SEVERITY)
+                .add();
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -3776,13 +3776,13 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
 
         SecurityAnalysisParameters securityAnalysisParameters = new SecurityAnalysisParameters();
         OpenLoadFlowParameters.create(securityAnalysisParameters.getLoadFlowParameters())
-            .setSlackBusSelectionMode(SlackBusSelectionMode.MOST_MESHED);
+                .setSlackBusSelectionMode(SlackBusSelectionMode.MOST_MESHED);
 
-        // This contingency will cut off bus with highest voltage level
+        // This contingency will cut off bus with the highest voltage level
         List<Contingency> contingencies = List.of(new Contingency("contingency", List.of(new BranchContingency("l23"))));
         assertDoesNotThrow(() -> runSecurityAnalysis(network, contingencies, Collections.emptyList(), securityAnalysisParameters, Collections.emptyList(), Collections.emptyList(), ReportNode.NO_OP));
     }
-    
+
     @Test
     void testNoRemainingGenerator2() {
         Network network = EurostagFactory.fix(EurostagTutorialExample1Factory.create());

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -282,7 +282,7 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         network.getGenerator("GEN").getTerminal().disconnect();
 
         SecurityAnalysisResult result = runSecurityAnalysis(network);
-        assertNotSame(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getPreContingencyResult().getStatus());
+        assertSame(LoadFlowResult.ComponentResult.Status.FAILED, result.getPreContingencyResult().getStatus());
     }
 
     @Test
@@ -292,16 +292,15 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         List<Contingency> contingencies = List.of(new Contingency("NGEN_NHV1", new BranchContingency("NGEN_NHV1")));
 
         LoadFlowParameters parameters = new LoadFlowParameters();
-        OpenLoadFlowParameters.create(parameters)
-                .setMaxRealisticVoltage(1.5);
         SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies, parameters);
 
-        assertNotSame(PostContingencyComputationStatus.CONVERGED, result.getPostContingencyResults().get(0).getStatus());
+        assertSame(PostContingencyComputationStatus.FAILED, result.getPostContingencyResults().get(0).getStatus());
     }
 
     @Test
     void testNoRemainingLoad() {
         Network network = EurostagFactory.fix(EurostagTutorialExample1Factory.create());
+
         LoadFlowParameters lfParameters = new LoadFlowParameters()
                 .setDistributedSlack(true)
                 .setBalanceType(LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD);
@@ -1505,7 +1504,7 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
     void testEmptyNetwork() {
         Network network = Network.create("empty", "");
         SecurityAnalysisResult result = runSecurityAnalysis(network);
-        assertNotSame(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getPreContingencyResult().getStatus());
+        assertSame(LoadFlowResult.ComponentResult.Status.FAILED, result.getPreContingencyResult().getStatus());
     }
 
     @Test
@@ -1514,7 +1513,7 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         network.getLine("NHV1_NHV2_1").setR(100).setX(-999);
         network.getLine("NHV1_NHV2_2").setR(100).setX(-999);
         SecurityAnalysisResult result = runSecurityAnalysis(network);
-        assertNotSame(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getPreContingencyResult().getStatus());
+        assertSame(LoadFlowResult.ComponentResult.Status.MAX_ITERATION_REACHED, result.getPreContingencyResult().getStatus());
     }
 
     @Test
@@ -3784,21 +3783,6 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
     }
 
     @Test
-    void testNoRemainingGenerator2() {
-        Network network = EurostagFactory.fix(EurostagTutorialExample1Factory.create());
-
-        List<Contingency> contingencies = List.of(new Contingency("GEN", new GeneratorContingency("GEN")));
-
-        LoadFlowParameters parameters = new LoadFlowParameters()
-                .setTransformerVoltageControlOn(false);
-        OpenLoadFlowParameters.create(parameters)
-                .setMaxRealisticVoltage(1.5);
-        SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies, parameters);
-
-        assertEquals(PostContingencyComputationStatus.SOLVER_FAILED, result.getPostContingencyResults().get(0).getStatus());
-    }
-
-    @Test
     void testOneBus() {
         Network network = Network.create("test", "code");
         VoltageLevel vl1 = network.newVoltageLevel()
@@ -3826,6 +3810,6 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         OpenLoadFlowParameters.create(parameters);
         SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies, parameters);
 
-        assertEquals(PostContingencyComputationStatus.SOLVER_FAILED, result.getPostContingencyResults().get(0).getStatus());
+        assertSame(PostContingencyComputationStatus.FAILED, result.getPostContingencyResults().get(0).getStatus());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -3776,7 +3776,7 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
 
         SecurityAnalysisParameters securityAnalysisParameters = new SecurityAnalysisParameters();
         OpenLoadFlowParameters.create(securityAnalysisParameters.getLoadFlowParameters())
-                .setSlackBusSelectionMode(SlackBusSelectionMode.MOST_MESHED);
+            .setSlackBusSelectionMode(SlackBusSelectionMode.MOST_MESHED);
 
         // This contingency will cut off bus with the highest voltage level
         List<Contingency> contingencies = List.of(new Contingency("contingency", List.of(new BranchContingency("l23"))));
@@ -3795,9 +3795,7 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
                 .setMaxRealisticVoltage(1.5);
         SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies, parameters);
 
-        // FIXME: this test passes, but only because of the unrealistic state check, the NR is converging to I don't know really what.
-        //  This is strange, we don't have any voltage control anymore, should not be converging.
-        assertNotSame(PostContingencyComputationStatus.CONVERGED, result.getPostContingencyResults().get(0).getStatus());
+        assertEquals(PostContingencyComputationStatus.SOLVER_FAILED, result.getPostContingencyResults().get(0).getStatus());
     }
 
     @Test
@@ -3826,9 +3824,8 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
 
         LoadFlowParameters parameters = new LoadFlowParameters();
         OpenLoadFlowParameters.create(parameters);
-        // FIXME: PowsyblException: Expected to have same number of equations (2) and variables (1)
         SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies, parameters);
 
-        assertNotSame(PostContingencyComputationStatus.CONVERGED, result.getPostContingencyResults().get(0).getStatus());
+        assertEquals(PostContingencyComputationStatus.SOLVER_FAILED, result.getPostContingencyResults().get(0).getStatus());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
@@ -1609,7 +1609,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
 
         assertSame(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getPreContingencyResult().getStatus());
         assertSame(PostContingencyComputationStatus.CONVERGED, result.getPostContingencyResults().get(0).getStatus());
-        assertSame(PostContingencyComputationStatus.FAILED, result.getOperatorStrategyResults().get(0).getStatus());
+        assertSame(PostContingencyComputationStatus.SOLVER_FAILED, result.getOperatorStrategyResults().get(0).getStatus());
 
         assertReportEquals("/saReportOperatorStrategyNoVoltageControl.txt", reportNode);
     }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
@@ -12,8 +12,10 @@ import com.powsybl.commons.report.ReportNode;
 import com.powsybl.contingency.*;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.HvdcAngleDroopActivePowerControlAdder;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.serde.test.MetrixTutorialSixBusesFactory;
 import com.powsybl.loadflow.LoadFlowParameters;
+import com.powsybl.loadflow.LoadFlowResult;
 import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.ac.solver.NewtonRaphsonStoppingCriteriaType;
 import com.powsybl.openloadflow.graph.GraphConnectivityFactory;
@@ -39,7 +41,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.powsybl.openloadflow.util.LoadFlowAssert.*;
@@ -114,7 +115,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
 
         List<Contingency> contingencies = Stream.of("L1", "L3", "L2")
                 .map(id -> new Contingency(id, new BranchContingency(id)))
-                .collect(Collectors.toList());
+                .toList();
 
         List<Action> actions = List.of(new SwitchAction("action1", "C1", false),
                                        new SwitchAction("action3", "C2", false));
@@ -216,7 +217,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
 
         List<Contingency> contingencies = Stream.of("L1", "L3", "L2")
                 .map(id -> new Contingency(id, new BranchContingency(id)))
-                .collect(Collectors.toList());
+                .toList();
 
         List<Action> actions = List.of(new SwitchAction("action1", "C1", false),
                                        new SwitchAction("action3", "C2", false));
@@ -273,7 +274,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
 
         List<Contingency> contingencies = Stream.of("L3", "L2")
                 .map(id -> new Contingency(id, new BranchContingency(id)))
-                .collect(Collectors.toList());
+                .toList();
 
         List<Action> actions = List.of(new SwitchAction("action1", "C1", false),
                                        new SwitchAction("action3", "C2", false));
@@ -306,7 +307,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
 
         List<Contingency> contingencies = Stream.of("s25")
                 .map(id -> new Contingency(id, new SwitchContingency(id)))
-                .collect(Collectors.toList());
+                .toList();
 
         List<Action> actions = List.of(new SwitchAction("action1", "s34", true));
 
@@ -644,7 +645,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
 
         List<Contingency> contingencies = Stream.of("L1", "L3", "L2")
                 .map(id -> new Contingency(id, new BranchContingency(id)))
-                .collect(Collectors.toList());
+                .toList();
 
         List<Action> actions = List.of(new SwitchAction("action1", "C1", false),
                 new SwitchAction("action3", "C2", false));
@@ -692,7 +693,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
         Network network = FourBusNetworkFactory.create();
         List<Contingency> contingencies = Stream.of("l14")
                 .map(id -> new Contingency(id, new BranchContingency(id)))
-                .collect(Collectors.toList());
+                .toList();
 
         List<Action> actions = List.of(new TerminalsConnectionAction("openLine", "l13", true));
         List<OperatorStrategy> operatorStrategies = List.of(new OperatorStrategy("strategyL1", ContingencyContext.specificContingency("l14"), new TrueCondition(), List.of("openLine")));
@@ -786,7 +787,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
 
         List<Contingency> contingencies = Stream.of("l2")
                 .map(id -> new Contingency(id, new LoadContingency(id)))
-                .collect(Collectors.toList());
+                .toList();
 
         List<Action> actions = List.of(new LoadActionBuilder().withId("action1").withLoadId("l4").withRelativeValue(false).withActivePowerValue(90).build(),
                 new LoadActionBuilder().withId("action2").withLoadId("l1").withRelativeValue(true).withActivePowerValue(50).build(),
@@ -965,7 +966,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
         final String lineInContingencyId = "l13";
         List<Contingency> contingencies = Stream.of(lineInContingencyId)
                 .map(id -> new Contingency(id, new BranchContingency(id)))
-                .collect(Collectors.toList());
+                .toList();
 
         final String g1 = "g1";
         final String g2 = "g2";
@@ -1066,7 +1067,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
 
         List<Contingency> contingencies = Stream.of("g1")
                 .map(id -> new Contingency(id, new GeneratorContingency(id)))
-                .collect(Collectors.toList());
+                .toList();
 
         List<Action> actions = List.of(new GeneratorActionBuilder().withId("action1").withGeneratorId("g1").withActivePowerRelativeValue(true).withActivePowerValue(100).build(),
                                        new GeneratorActionBuilder().withId("action2").withGeneratorId("g2").withActivePowerRelativeValue(false).withActivePowerValue(300).build());
@@ -1506,7 +1507,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
         network.getLine("l23").getTerminal2().disconnect();
         List<Contingency> contingencies = Stream.of("l14")
                 .map(id -> new Contingency(id, new BranchContingency(id)))
-                .collect(Collectors.toList());
+                .toList();
 
         List<Action> actions = List.of(new TerminalsConnectionAction("closeLine", "l23", false));
         List<OperatorStrategy> operatorStrategies = List.of(new OperatorStrategy("strategyL1", ContingencyContext.specificContingency("l14"), new TrueCondition(), List.of("closeLine")));
@@ -1571,7 +1572,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
         network.getLine("l23").getTerminal2().disconnect();
         List<Contingency> contingencies = Stream.of("l14")
                 .map(id -> new Contingency(id, new BranchContingency(id)))
-                .collect(Collectors.toList());
+                .toList();
 
         List<Action> actions = List.of(new TerminalsConnectionAction("closeLine", "l23", false));
         List<OperatorStrategy> operatorStrategies = List.of(new OperatorStrategy("strategyL1", ContingencyContext.specificContingency("l14"), new TrueCondition(), List.of("closeLine")));
@@ -1589,5 +1590,27 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
         assertEquals(1.445, acStrategyResult.getNetworkResult().getBranchResult("l12").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(0.445, acStrategyResult.getNetworkResult().getBranchResult("l23").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(-1.666, acStrategyResult.getNetworkResult().getBranchResult("l34").getP1(), LoadFlowAssert.DELTA_POWER);
+    }
+
+    @Test
+    void testOperatorStrategyNoMoreBusVoltageControlled() throws IOException {
+        Network network = EurostagFactory.fix(EurostagTutorialExample1Factory.create());
+        // trip one of the two parallel lines
+        List<Contingency> contingencies = List.of(new Contingency("NHV1_NHV2_2", new BranchContingency("NHV1_NHV2_2")));
+        // opening this transformer will disconnect the only generator and there is no other voltage control
+        List<Action> actions = List.of(new TerminalsConnectionAction("open NGEN_NHV1", "NGEN_NHV1", true));
+        List<OperatorStrategy> operatorStrategies = List.of(new OperatorStrategy("strategy1",
+                ContingencyContext.specificContingency("NHV1_NHV2_2"), new TrueCondition(), List.of("open NGEN_NHV1")));
+
+        ReportNode reportNode = ReportNode.newRootReportNode()
+                .withMessageTemplate("testSaReport", "Test report of security analysis")
+                .build();
+        SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies, Collections.emptyList(), new SecurityAnalysisParameters(), operatorStrategies, actions, reportNode);
+
+        assertSame(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getPreContingencyResult().getStatus());
+        assertSame(PostContingencyComputationStatus.CONVERGED, result.getPostContingencyResults().get(0).getStatus());
+        assertSame(PostContingencyComputationStatus.FAILED, result.getOperatorStrategyResults().get(0).getStatus());
+
+        assertReportEquals("/saReportOperatorStrategyNoVoltageControl.txt", reportNode);
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisContingenciesTest.java
@@ -1291,6 +1291,17 @@ class AcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
     @Test
     void testBusContingency() {
         Network network = EurostagFactory.fix(EurostagTutorialExample1Factory.create());
+        // add another generator otherwise we end up with no bus voltage regulated in post-contingency state
+        network.getVoltageLevel("VLLOAD").newGenerator()
+                .setId("GEN2")
+                .setConnectableBus("NLOAD")
+                .setBus("NLOAD")
+                .setMinP(0.0)
+                .setMaxP(1.0)
+                .setTargetP(1e-6)
+                .setTargetV(147.58)
+                .setVoltageRegulatorOn(true)
+                .add();
         SensitivityAnalysisParameters sensiParameters = createParameters(false, "NGEN", true);
         sensiParameters.getLoadFlowParameters().setBalanceType(LoadFlowParameters.BalanceType.PROPORTIONAL_TO_GENERATION_P_MAX);
         List<SensitivityFactor> factors = List.of(createBranchFlowPerInjectionIncrease("NHV1_NHV2_1", "LOAD"),
@@ -1306,10 +1317,10 @@ class AcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
         assertEquals(0.019, result.getBranchFlow1FunctionReferenceValue("NLOAD", "NHV1_NHV2_1"), LoadFlowAssert.DELTA_POWER);
         // Contingency 'NHV1' leads to an isolated slack bus:  slack bus is relocated.
         assertEquals(SensitivityAnalysisResult.Status.SUCCESS, result.getContingencyStatus("NHV1"));
-        assertEquals(600.413, result.getBranchFlow1FunctionReferenceValue("NHV1", "NHV2_NLOAD"), LoadFlowAssert.DELTA_POWER);
+        assertEquals(600.784, result.getBranchFlow1FunctionReferenceValue("NHV1", "NHV2_NLOAD"), LoadFlowAssert.DELTA_POWER);
         // Contingency 'NGEN' leads to the loss of a slack bus: slack bus is relocated.
         assertEquals(SensitivityAnalysisResult.Status.SUCCESS, result.getContingencyStatus("NGEN"));
-        assertEquals(301.056, result.getBranchFlow1FunctionReferenceValue("NGEN", "NHV1_NHV2_1"), LoadFlowAssert.DELTA_POWER);
+        assertEquals(302.304, result.getBranchFlow1FunctionReferenceValue("NGEN", "NHV1_NHV2_1"), LoadFlowAssert.DELTA_POWER);
         assertEquals(Double.NaN, result.getBranchFlow1FunctionReferenceValue("NGEN", "NGEN_NHV1"), LoadFlowAssert.DELTA_POWER);
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisContingenciesTest.java
@@ -1291,7 +1291,8 @@ class AcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
     @Test
     void testBusContingency() {
         Network network = EurostagFactory.fix(EurostagTutorialExample1Factory.create());
-        // add another generator otherwise we end up with no bus voltage regulated in post-contingency state
+        // add another generator producing epsilon MW with voltage regulation enabled at NLOAD bus,
+        // otherwise we end up with no bus voltage regulated in 'NHV1' and 'NGEN' post-contingency states
         network.getVoltageLevel("VLLOAD").newGenerator()
                 .setId("GEN2")
                 .setConnectableBus("NLOAD")
@@ -1310,7 +1311,7 @@ class AcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
                                                   createBranchFlowPerInjectionIncrease("NGEN_NHV1", "LOAD"));
         List<Contingency> contingencies = network.getBusBreakerView().getBusStream()
                 .map(bus -> new Contingency(bus.getId(), new BusContingency(bus.getId())))
-                .collect(Collectors.toList());
+                .toList();
         SensitivityAnalysisResult result = sensiRunner.run(network, factors, contingencies, Collections.emptyList(), sensiParameters);
         assertEquals(302.444, result.getBranchFlow1FunctionReferenceValue("NHV1_NHV2_1"), LoadFlowAssert.DELTA_POWER);
         assertEquals(302.444, result.getBranchFlow1FunctionReferenceValue("NHV1_NHV2_2"), LoadFlowAssert.DELTA_POWER);

--- a/src/test/resources/saReport.txt
+++ b/src/test/resources/saReport.txt
@@ -38,7 +38,7 @@
             AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
          + Post-contingency simulation 'NGEN_NHV1'
             Network has no voltage regulated bus
-            AC load flow completed with error (solverStatus=SOLVER_FAILED, outerloopStatus=STABLE)
+            AC load flow completed with error (solverStatus=UNREALISTIC_STATE, outerloopStatus=STABLE)
          + Post-contingency simulation 'NHV2_NLOAD'
             + Outer loop DistributedSlack
                + Outer loop iteration 1

--- a/src/test/resources/saReport.txt
+++ b/src/test/resources/saReport.txt
@@ -37,8 +37,8 @@
             Outer loop ReactiveLimits
             AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
          + Post-contingency simulation 'NGEN_NHV1'
-            1 buses have a voltage magnitude out of the configured realistic range [0.5, 1.5] p.u.: {VLHV1_0=1.5105659472379578}
-            AC load flow completed with error (solverStatus=UNREALISTIC_STATE, outerloopStatus=STABLE)
+            Network has no voltage regulated bus
+            AC load flow completed with error (solverStatus=SOLVER_FAILED, outerloopStatus=STABLE)
          + Post-contingency simulation 'NHV2_NLOAD'
             + Outer loop DistributedSlack
                + Outer loop iteration 1

--- a/src/test/resources/saReport.txt
+++ b/src/test/resources/saReport.txt
@@ -38,7 +38,7 @@
             AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
          + Post-contingency simulation 'NGEN_NHV1'
             Network must have at least one bus with generator voltage control enabled
-            AC load flow completed with error (solverStatus=UNREALISTIC_STATE, outerloopStatus=STABLE)
+            AC load flow completed with error (solverStatus=SOLVER_FAILED, outerloopStatus=STABLE)
          + Post-contingency simulation 'NHV2_NLOAD'
             + Outer loop DistributedSlack
                + Outer loop iteration 1

--- a/src/test/resources/saReport.txt
+++ b/src/test/resources/saReport.txt
@@ -37,7 +37,7 @@
             Outer loop ReactiveLimits
             AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
          + Post-contingency simulation 'NGEN_NHV1'
-            Network has no voltage regulated bus
+            Network must have at least one bus with generator voltage control enabled
             AC load flow completed with error (solverStatus=UNREALISTIC_STATE, outerloopStatus=STABLE)
          + Post-contingency simulation 'NHV2_NLOAD'
             + Outer loop DistributedSlack

--- a/src/test/resources/saReportOperatorStrategyNoVoltageControl.txt
+++ b/src/test/resources/saReportOperatorStrategyNoVoltageControl.txt
@@ -1,0 +1,31 @@
++ Test report of security analysis
+   + AC security analysis on network 'sim1'
+      + Network CC0 SC0
+         + Network info
+            Network has 4 buses and 4 branches
+            Network balance: active generation=607.0 MW, active load=600.0 MW, reactive generation=0.0 MVar, reactive load=200.0 MVar
+            Angle reference bus: VLHV1_0
+            Slack bus: VLHV1_0
+         + Pre-contingency simulation
+            + Outer loop DistributedSlack
+               + Outer loop iteration 1
+                  Slack bus active power (-1.4404045651219555 MW) distributed in 1 distribution iteration(s)
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'NHV1_NHV2_2'
+            + Outer loop DistributedSlack
+               + Outer loop iteration 1
+                  Slack bus active power (5.803741102800952 MW) distributed in 1 distribution iteration(s)
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy1'
+               Network must have at least one bus with generator voltage control enabled
+               AC load flow completed with error (solverStatus=UNREALISTIC_STATE, outerloopStatus=STABLE)

--- a/src/test/resources/saReportOperatorStrategyNoVoltageControl.txt
+++ b/src/test/resources/saReportOperatorStrategyNoVoltageControl.txt
@@ -28,4 +28,4 @@
             AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
             + Operator strategy simulation 'strategy1'
                Network must have at least one bus with generator voltage control enabled
-               AC load flow completed with error (solverStatus=UNREALISTIC_STATE, outerloopStatus=STABLE)
+               AC load flow completed with error (solverStatus=SOLVER_FAILED, outerloopStatus=STABLE)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->

- Exception occurring when island is a single bus with a generator on voltage control, and the contingency removes the generator (`PowsyblException: Expected to have same number of equations (2) and variables (1)`)
- Also I think something should be clarified about what happens if a contingency leaves the network without any bus under voltage control, I think it is strange to have the NR converging, why not mathematically speaking, but from a physical point of view this is surprising. Today we rely on unrealistic state check, but I think this is not correct.


**What is the new behavior (if this is a feature change)?**
`AcLoadFlowEngine` now examines the equation system and returns `SOLVER_FAILED` status in case of no `BUS_TARGET_V` equation found. Add also log and report for this situation.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Case found on real networks since the introduction of #1089 when running SA on all components.