### PR TITLE
Fix SA exception "No slack bus for network"

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -214,14 +214,14 @@ public class LfNetwork extends AbstractPropertyBag implements PropertyBag {
 
     public void updateSlackBusesAndReferenceBus() {
         if (slackBuses == null && referenceBus == null) {
-            SelectedSlackBus selectedSlackBus = slackBusSelector.select(busesByIndex, maxSlackBusCount);
-            slackBuses = selectedSlackBus.getBuses().stream()
-                    .filter(bus -> !excludedSlackBuses.contains(bus))
-                    .toList();
+            List<LfBus> selectableBus = busesByIndex.stream()
+                .filter(bus -> !excludedSlackBuses.contains(bus))
+                .toList();
+            SelectedSlackBus selectedSlackBus = slackBusSelector.select(selectableBus, maxSlackBusCount);
+            slackBuses = selectedSlackBus.getBuses();
             if (slackBuses.isEmpty()) { // ultimate fallback
-                selectedSlackBus = SLACK_BUS_SELECTOR_FALLBACK.select(busesByIndex, excludedSlackBuses.size() + maxSlackBusCount);
+                selectedSlackBus = SLACK_BUS_SELECTOR_FALLBACK.select(selectableBus, excludedSlackBuses.size() + maxSlackBusCount);
                 slackBuses = selectedSlackBus.getBuses().stream()
-                        .filter(bus -> !excludedSlackBuses.contains(bus))
                         .limit(maxSlackBusCount)
                         .toList();
             }

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -223,7 +223,7 @@ public class LfNetwork extends AbstractPropertyBag implements PropertyBag {
             if (slackBuses.isEmpty()) { // ultimate fallback
                 selectedSlackBus = SLACK_BUS_SELECTOR_FALLBACK.select(selectableBus, maxSlackBusCount);
                 if (selectedSlackBus.getBuses().isEmpty()) {
-                    throw new PowsyblException("Slack bus selection process has failed after multiple fallback");
+                    throw new PowsyblException("No slack bus could be selected");
                 }
                 slackBuses = selectedSlackBus.getBuses();
             }

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -220,10 +220,8 @@ public class LfNetwork extends AbstractPropertyBag implements PropertyBag {
             SelectedSlackBus selectedSlackBus = slackBusSelector.select(selectableBus, maxSlackBusCount);
             slackBuses = selectedSlackBus.getBuses();
             if (slackBuses.isEmpty()) { // ultimate fallback
-                selectedSlackBus = SLACK_BUS_SELECTOR_FALLBACK.select(selectableBus, excludedSlackBuses.size() + maxSlackBusCount);
-                slackBuses = selectedSlackBus.getBuses().stream()
-                        .limit(maxSlackBusCount)
-                        .toList();
+                selectedSlackBus = SLACK_BUS_SELECTOR_FALLBACK.select(selectableBus, maxSlackBusCount);
+                slackBuses = selectedSlackBus.getBuses();
             }
             LOGGER.info("Network {}, slack buses are {} (method='{}')", this, slackBuses, selectedSlackBus.getSelectionMethod());
             for (var slackBus : slackBuses) {

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -10,6 +10,7 @@ package com.powsybl.openloadflow.network;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.google.common.base.Stopwatch;
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
 import com.powsybl.openloadflow.graph.GraphConnectivity;
 import com.powsybl.openloadflow.graph.GraphConnectivityFactory;
@@ -221,6 +222,9 @@ public class LfNetwork extends AbstractPropertyBag implements PropertyBag {
             slackBuses = selectedSlackBus.getBuses();
             if (slackBuses.isEmpty()) { // ultimate fallback
                 selectedSlackBus = SLACK_BUS_SELECTOR_FALLBACK.select(selectableBus, maxSlackBusCount);
+                if (selectedSlackBus.getBuses().isEmpty()) {
+                    throw new PowsyblException("Slack bus selection process has failed after multiple fallback");
+                }
                 slackBuses = selectedSlackBus.getBuses();
             }
             LOGGER.info("Network {}, slack buses are {} (method='{}')", this, slackBuses, selectedSlackBus.getSelectionMethod());

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -215,13 +215,13 @@ public class LfNetwork extends AbstractPropertyBag implements PropertyBag {
 
     public void updateSlackBusesAndReferenceBus() {
         if (slackBuses == null && referenceBus == null) {
-            List<LfBus> selectableBus = busesByIndex.stream()
-                .filter(bus -> !excludedSlackBuses.contains(bus))
-                .toList();
-            SelectedSlackBus selectedSlackBus = slackBusSelector.select(selectableBus, maxSlackBusCount);
+            List<LfBus> selectableBuses =
+                excludedSlackBuses.isEmpty() ? busesByIndex :
+                    busesByIndex.stream().filter(bus -> !excludedSlackBuses.contains(bus)).toList();
+            SelectedSlackBus selectedSlackBus = slackBusSelector.select(selectableBuses, maxSlackBusCount);
             slackBuses = selectedSlackBus.getBuses();
             if (slackBuses.isEmpty()) { // ultimate fallback
-                selectedSlackBus = SLACK_BUS_SELECTOR_FALLBACK.select(selectableBus, maxSlackBusCount);
+                selectedSlackBus = SLACK_BUS_SELECTOR_FALLBACK.select(selectableBuses, maxSlackBusCount);
                 if (selectedSlackBus.getBuses().isEmpty()) {
                     throw new PowsyblException("No slack bus could be selected");
                 }

--- a/src/main/java/com/powsybl/openloadflow/network/SelectedSlackBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/SelectedSlackBus.java
@@ -21,9 +21,6 @@ public class SelectedSlackBus {
 
     public SelectedSlackBus(List<LfBus> buses, String selectionMethod) {
         this.buses = Objects.requireNonNull(buses);
-        if (buses.isEmpty()) {
-            throw new IllegalArgumentException("Empty slack bus list");
-        }
         this.selectionMethod = Objects.requireNonNull(selectionMethod);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/network/LfNetworkTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/LfNetworkTest.java
@@ -459,14 +459,16 @@ class LfNetworkTest extends AbstractSerDeTest {
     @Test
     void slackBusSelectionFallback() {
         Network network = FourBusNetworkFactory.createBaseNetwork();
+        network.getSubstations().forEach(substation -> substation.setCountry(Country.FR));
 
         LoadFlow.Runner loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
         LoadFlowParameters parameters = new LoadFlowParameters();
+        parameters.setReadSlackBus(false);
         OpenLoadFlowParameters parametersExt = OpenLoadFlowParameters.create(parameters);
 
-        // Setup a slack bus selection method with an unknown bus to test fallback mechanism
-        parametersExt.setSlackBusSelectionMode(SlackBusSelectionMode.NAME);
-        parametersExt.setSlackBusesIds(List.of("Dummy"));
+        // Setup a slack bus selection method with a filter on country that we do not have in the network (for it to fail)
+        parametersExt.setSlackBusSelectionMode(SlackBusSelectionMode.FIRST);
+        parametersExt.setSlackBusCountryFilter(Set.of(Country.BE));
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());

--- a/src/test/java/com/powsybl/openloadflow/network/LfNetworkTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/LfNetworkTest.java
@@ -18,6 +18,7 @@ import com.powsybl.loadflow.LoadFlow;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.LoadFlowResult;
 import com.powsybl.math.matrix.DenseMatrixFactory;
+import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.OpenLoadFlowProvider;
 import com.powsybl.openloadflow.network.impl.Networks;
 import com.powsybl.openloadflow.sa.LimitReductionManager;
@@ -453,5 +454,21 @@ class LfNetworkTest extends AbstractSerDeTest {
         assertEquals(0.9, reductions[2], 0.001); // TATL 60s
         // `terminalLimitReduction4` is now declared before `terminalLimitReduction2`, its value is overlapped by the one of `terminalLimitReduction2`
         assertEquals(0.9, reductions[3], 0.001); // TATL 0s
+    }
+
+    @Test
+    void slackBusSelectionFallback() {
+        Network network = FourBusNetworkFactory.createBaseNetwork();
+
+        LoadFlow.Runner loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
+        LoadFlowParameters parameters = new LoadFlowParameters();
+        OpenLoadFlowParameters parametersExt = OpenLoadFlowParameters.create(parameters);
+
+        // Setup a slack bus selection method with an unknown bus to test fallback mechanism
+        parametersExt.setSlackBusSelectionMode(SlackBusSelectionMode.NAME);
+        parametersExt.setSlackBusesIds(List.of("Dummy"));
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isFullyConverged());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/network/TwoBusNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/TwoBusNetworkFactory.java
@@ -56,4 +56,13 @@ public class TwoBusNetworkFactory extends AbstractLoadFlowNetworkFactory {
                 .add();
         return network;
     }
+
+    public static Network createWithAThirdBus() {
+        Network network = create();
+        // On a different and higher voltage level then b1 and b2
+        Bus b3 = createBus(network, "b3", 1.5);
+        Bus b2 = network.getBusBreakerView().getBus("b2");
+        createLine(network, b2, b3, "l23", 0.1f);
+        return network;
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -3771,6 +3771,7 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertNotNull(operatorStrategyResult.getBranchResult("LB3C1"));
     }
 
+    @Test
     void testSlackBusSelectionExcludeBusWithHighestVoltage() {
         Network network = TwoBusNetworkFactory.createWithAThirdBus();
 

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -3770,4 +3770,16 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertNotNull(operatorStrategyResult.getBranchResult("lc12"));
         assertNotNull(operatorStrategyResult.getBranchResult("LB3C1"));
     }
+
+    void testSlackBusSelectionExcludeBusWithHighestVoltage() {
+        Network network = TwoBusNetworkFactory.createWithAThirdBus();
+
+        SecurityAnalysisParameters securityAnalysisParameters = new SecurityAnalysisParameters();
+        OpenLoadFlowParameters.create(securityAnalysisParameters.getLoadFlowParameters())
+            .setSlackBusSelectionMode(SlackBusSelectionMode.MOST_MESHED);
+
+        // This contingency will cut off bus with highest voltage level
+        List<Contingency> contingencies = List.of(new Contingency("contingency", List.of(new BranchContingency("l23"))));
+        assertDoesNotThrow(() -> runSecurityAnalysis(network, contingencies, Collections.emptyList(), securityAnalysisParameters, Collections.emptyList(), Collections.emptyList(), ReportNode.NO_OP));
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

updateSlackBusesAndReferenceBus implements a slack bus selection algorithm using an exclude list of buses in excludedSlackBuses.

Some time a bus is selected because it is the one and only with the highest voltage. If this bus is also in the exclude list then we have no solution available.

I changed a bit the algorithm by filtering the bus list with the exclude list before applying the selection algorithm so it is not able to base its selection on buses that will not be available anyway.

To illustrate the bug surfaced on a small network similar to this : 

B1(vl 150) ---- B2(vl 150) ---- B3 (vl380)

A contingency cut the line between B2 and B3. B3 is  then put in the exclude listof selectable slack bus because it is no longer in the main connected component after contingency.
But B3 is also the one with the highest voltage level. So it was selected by the algorithm but ultimately discarded because of the exclude list.

Filtering the list of buses with the exclude list before the selection process fix the issue.

**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Bug fix

**What is the current behavior?**
<!-- You can also link to an open issue here -->

IllegalStateException : "No slack bus for network " thrown

**What is the new behavior (if this is a feature change)?**

Correct slack bus is selected and no exception thrown


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
