### PR TITLE
Fix unpaired DanglingLine simulated with split shunt admittance

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
@@ -39,6 +39,8 @@ public class LfDanglingLineBranch extends AbstractImpedantLfBranch {
         Objects.requireNonNull(bus2);
         Objects.requireNonNull(parameters);
         double zb = PerUnit.zb(danglingLine.getTerminal().getVoltageLevel().getNominalV());
+        // iIDM DanglingLine shunt admittance is network side only which is always side 1.
+        // See also https://github.com/powsybl/powsybl-core/pull/3169 on powsybl-core side.
         PiModel piModel = new SimplePiModel()
                 .setR(danglingLine.getR() / zb)
                 .setX(danglingLine.getX() / zb)

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
@@ -39,8 +39,7 @@ public class LfDanglingLineBranch extends AbstractImpedantLfBranch {
         Objects.requireNonNull(bus2);
         Objects.requireNonNull(parameters);
         double zb = PerUnit.zb(danglingLine.getTerminal().getVoltageLevel().getNominalV());
-        // iIDM DanglingLine shunt admittance is network side only which is always side 1.
-        // See also https://github.com/powsybl/powsybl-core/pull/3169 on powsybl-core side.
+        // iIDM DanglingLine shunt admittance is network side only which is always side 1 (boundary is side 2).
         PiModel piModel = new SimplePiModel()
                 .setR(danglingLine.getR() / zb)
                 .setX(danglingLine.getX() / zb)

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
@@ -42,10 +42,10 @@ public class LfDanglingLineBranch extends AbstractImpedantLfBranch {
         PiModel piModel = new SimplePiModel()
                 .setR(danglingLine.getR() / zb)
                 .setX(danglingLine.getX() / zb)
-                .setG1(danglingLine.getG() / 2 * zb)
-                .setG2(danglingLine.getG() / 2 * zb)
-                .setB1(danglingLine.getB() / 2 * zb)
-                .setB2(danglingLine.getB() / 2 * zb);
+                .setG1(danglingLine.getG() * zb)
+                .setG2(0)
+                .setB1(danglingLine.getB() * zb)
+                .setB2(0);
         return new LfDanglingLineBranch(network, bus1, bus2, piModel, danglingLine, parameters);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowBoundaryTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowBoundaryTest.java
@@ -72,7 +72,6 @@ class AcLoadFlowBoundaryTest {
     void testWithVoltageRegulationOn() {
         g1.setTargetQ(0);
         g1.setVoltageRegulatorOn(false);
-        // FIXME: no targetV here?
         dl1.getGeneration().setVoltageRegulationOn(true);
         dl1.getGeneration().setMinP(0);
         dl1.getGeneration().setMaxP(10);
@@ -105,7 +104,7 @@ class AcLoadFlowBoundaryTest {
 
     @Test
     void testWithXnode() {
-        Network network = BoundaryFactory.createWithXnode();
+        network = BoundaryFactory.createWithXnode();
         parameters.setUseReactiveLimits(true);
         parameters.setDistributedSlack(true);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
@@ -119,7 +118,7 @@ class AcLoadFlowBoundaryTest {
 
     @Test
     void testWithTieLine() {
-        Network network = BoundaryFactory.createWithTieLine();
+        network = BoundaryFactory.createWithTieLine();
         parameters.setUseReactiveLimits(true);
         parameters.setDistributedSlack(true);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
@@ -140,7 +139,7 @@ class AcLoadFlowBoundaryTest {
 
     @Test
     void testEquivalentBranch() {
-        Network network = VoltageControlNetworkFactory.createNetworkWithT2wt();
+        network = VoltageControlNetworkFactory.createNetworkWithT2wt();
         network.newLine()
                 .setId("LINE_23")
                 .setBus1("BUS_2")
@@ -182,5 +181,26 @@ class AcLoadFlowBoundaryTest {
         assertTrue(result3.isFullyConverged());
         assertActivePowerEquals(101.0, dl1.getTerminal());
         assertReactivePowerEquals(Double.NaN, dl1.getTerminal());
+    }
+
+    @Test
+    void testDanglingLineShuntAdmittance() {
+        // verify dangling line shunt admittance is correctly accounted to be completely on network side (and not split with boundary side)
+
+        // setup zero flows flow at dangling line boundary side
+        dl1.setP0(0.0).setQ0(0.0).getGeneration().setTargetP(0.0).setTargetQ(0.0).setVoltageRegulationOn(false);
+
+        // set higher B and G shunt values, and also much higher series impedance, so we would get very different results if the shunt admittance were split
+        dl1.setB(1e-3).setG(1e-4).setR(3.).setX(30.);
+
+        // set g1 to regulate dl1 terminal at 400.0 kV
+        g1.setRegulatingTerminal(dl1.getTerminal()).setTargetV(400.0);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+
+        assertTrue(result.isFullyConverged());
+        assertVoltageEquals(400.0, bus2);
+        assertActivePowerEquals(16., dl1.getTerminal()); // v^2 * B_shunt
+        assertReactivePowerEquals(-160., dl1.getTerminal()); // - v^2 * G_shunt
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/solver/NewtonRaphsonStoppingCriteriaTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/solver/NewtonRaphsonStoppingCriteriaTest.java
@@ -59,7 +59,7 @@ class NewtonRaphsonStoppingCriteriaTest {
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
-        assertEquals(1, result.getComponentResults().get(0).getIterationCount());
+        assertEquals(2, result.getComponentResults().get(0).getIterationCount());
     }
 
     @Test
@@ -112,7 +112,7 @@ class NewtonRaphsonStoppingCriteriaTest {
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
-        assertEquals(5, result.getComponentResults().get(0).getIterationCount());
+        assertEquals(11, result.getComponentResults().get(0).getIterationCount());
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -458,7 +458,7 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
                 Collections.emptyList(), Collections.emptyList(), ReportNode.NO_OP);
         BranchResult preContingencyBranchResult = result.getPreContingencyResult().getNetworkResult().getBranchResult("dl1");
         assertEquals(Double.NaN, preContingencyBranchResult.getFlowTransfer(), LoadFlowAssert.DELTA_POWER);
-        assertEquals(91.293, preContingencyBranchResult.getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(91.294, preContingencyBranchResult.getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(-91.000, preContingencyBranchResult.getP2(), LoadFlowAssert.DELTA_POWER);
         assertEquals(260.511, preContingencyBranchResult.getI1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(260.970, preContingencyBranchResult.getI2(), LoadFlowAssert.DELTA_POWER);
@@ -466,7 +466,7 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(-150.000, preContingencyBranchResult.getQ2(), LoadFlowAssert.DELTA_POWER);
         BranchResult postContingencyBranchResult = getPostContingencyResult(result, "contingency").getNetworkResult().getBranchResult("dl1");
         assertEquals(Double.NaN, postContingencyBranchResult.getFlowTransfer(), LoadFlowAssert.DELTA_POWER);
-        assertEquals(91.293, postContingencyBranchResult.getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(91.294, postContingencyBranchResult.getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(-91.000, postContingencyBranchResult.getP2(), LoadFlowAssert.DELTA_POWER);
         assertEquals(260.488, postContingencyBranchResult.getI1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(260.947, postContingencyBranchResult.getI2(), LoadFlowAssert.DELTA_POWER);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Unpaired dangling lines are simulated with shunt admittance split between network side and boundary side, which is not compliant with iIDM model.


**What is the new behavior (if this is a feature change)?**
Unpaired dangling lines are simulated with shunt admittance on network side only in compliance with iIDM model.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

See also https://github.com/powsybl/powsybl-core/pull/3169 on similar subject