### PR TITLE
Fix secondary voltage control in case of generators with remote volage control

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
@@ -38,9 +38,9 @@ public final class HvdcConverterStations {
         return 0.0;
     }
 
-    public static boolean isVsc(Connectable<?> connectable) {
-        return connectable.getType() == IdentifiableType.HVDC_CONVERTER_STATION
-                && ((HvdcConverterStation<?>) connectable).getHvdcType() == HvdcConverterStation.HvdcType.VSC;
+    public static boolean isVsc(Identifiable<?> identifiable) {
+        return identifiable.getType() == IdentifiableType.HVDC_CONVERTER_STATION
+                && ((HvdcConverterStation<?>) identifiable).getHvdcType() == HvdcConverterStation.HvdcType.VSC;
     }
 
     public static boolean isHvdcDanglingInIidm(HvdcConverterStation<?> station, LfNetworkParameters parameters) {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
@@ -11,6 +11,7 @@ import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.util.HvdcUtils;
 import com.powsybl.openloadflow.network.LfNetworkParameters;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -39,6 +40,7 @@ public final class HvdcConverterStations {
     }
 
     public static boolean isVsc(Identifiable<?> identifiable) {
+        Objects.requireNonNull(identifiable);
         return identifiable.getType() == IdentifiableType.HVDC_CONVERTER_STATION
                 && ((HvdcConverterStation<?>) identifiable).getHvdcType() == HvdcConverterStation.HvdcType.VSC;
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
@@ -62,9 +62,6 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
         minTargetP = apcHelper.minTargetP();
         maxTargetP = apcHelper.maxTargetP();
 
-        if (generator.getId().equals("PENLY7PENLYT1")) {
-            System.out.println("dddd");
-        }
         setReferencePriority(ReferencePriority.get(generator));
 
         if (!checkActivePowerControl(generator.getId(), generator.getTargetP(), generator.getMaxP(), minTargetP, maxTargetP,

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
@@ -62,6 +62,9 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
         minTargetP = apcHelper.minTargetP();
         maxTargetP = apcHelper.maxTargetP();
 
+        if (generator.getId().equals("PENLY7PENLYT1")) {
+            System.out.println("dddd");
+        }
         setReferencePriority(ReferencePriority.get(generator));
 
         if (!checkActivePowerControl(generator.getId(), generator.getTargetP(), generator.getMaxP(), minTargetP, maxTargetP,

--- a/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
@@ -281,6 +281,8 @@ public final class Networks {
     }
 
     public static Optional<Terminal> getEquipmentRegulatingTerminal(Network network, String equipmentId) {
+        Objects.requireNonNull(network);
+        Objects.requireNonNull(equipmentId);
         Identifiable<?> identifiable = network.getIdentifiable(equipmentId);
         if (identifiable != null) {
             return getEquipmentRegulatingTerminal(identifiable);
@@ -310,7 +312,9 @@ public final class Networks {
             case GENERATOR -> Optional.of(((Generator) identifiable).getRegulatingTerminal());
             case SHUNT_COMPENSATOR -> Optional.of(((ShuntCompensator) identifiable).getRegulatingTerminal());
             case STATIC_VAR_COMPENSATOR -> Optional.of(((StaticVarCompensator) identifiable).getRegulatingTerminal());
-            case HVDC_CONVERTER_STATION -> Optional.of(((VscConverterStation) identifiable).getTerminal()); // local regulation only
+            case HVDC_CONVERTER_STATION -> ((HvdcConverterStation<?>) identifiable).getHvdcType() == HvdcConverterStation.HvdcType.VSC
+                    ? Optional.of(((VscConverterStation) identifiable).getTerminal()) // local regulation only
+                    : Optional.empty();
             default -> Optional.empty();
         };
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
@@ -281,38 +281,37 @@ public final class Networks {
     }
 
     public static Optional<Terminal> getEquipmentRegulatingTerminal(Network network, String equipmentId) {
-        Generator generator = network.getGenerator(equipmentId);
-        if (generator != null) {
-            return Optional.of(generator.getRegulatingTerminal());
-        }
-        StaticVarCompensator staticVarCompensator = network.getStaticVarCompensator(equipmentId);
-        if (staticVarCompensator != null) {
-            return Optional.of(staticVarCompensator.getRegulatingTerminal());
-        }
-        TwoWindingsTransformer t2wt = network.getTwoWindingsTransformer(equipmentId);
-        if (t2wt != null) {
-            RatioTapChanger rtc = t2wt.getRatioTapChanger();
-            if (rtc != null) {
-                return Optional.of(rtc.getRegulationTerminal());
-            }
-        }
-        ThreeWindingsTransformer t3wt = network.getThreeWindingsTransformer(equipmentId);
-        if (t3wt != null) {
-            for (ThreeWindingsTransformer.Leg leg : t3wt.getLegs()) {
-                RatioTapChanger rtc = leg.getRatioTapChanger();
-                if (rtc != null && rtc.isRegulating()) {
-                    return Optional.of(rtc.getRegulationTerminal());
-                }
-            }
-        }
-        ShuntCompensator shuntCompensator = network.getShuntCompensator(equipmentId);
-        if (shuntCompensator != null) {
-            return Optional.of(shuntCompensator.getRegulatingTerminal());
-        }
-        VscConverterStation vsc = network.getVscConverterStation(equipmentId);
-        if (vsc != null) {
-            return Optional.of(vsc.getTerminal()); // local regulation only
+        Identifiable<?> identifiable = network.getIdentifiable(equipmentId);
+        if (identifiable != null) {
+            return getEquipmentRegulatingTerminal(identifiable);
         }
         return Optional.empty();
+    }
+
+    public static Optional<Terminal> getEquipmentRegulatingTerminal(Identifiable<?> identifiable) {
+        Objects.requireNonNull(identifiable);
+        return switch (identifiable.getType()) {
+            case TWO_WINDINGS_TRANSFORMER -> {
+                RatioTapChanger rtc = ((TwoWindingsTransformer) identifiable).getRatioTapChanger();
+                if (rtc != null) {
+                    yield Optional.of(rtc.getRegulationTerminal());
+                }
+                yield Optional.empty();
+            }
+            case THREE_WINDINGS_TRANSFORMER -> {
+                for (ThreeWindingsTransformer.Leg leg : ((ThreeWindingsTransformer) identifiable).getLegs()) {
+                    RatioTapChanger rtc = leg.getRatioTapChanger();
+                    if (rtc != null && rtc.isRegulating()) {
+                        yield Optional.of(rtc.getRegulationTerminal());
+                    }
+                }
+                yield Optional.empty();
+            }
+            case GENERATOR -> Optional.of(((Generator) identifiable).getRegulatingTerminal());
+            case SHUNT_COMPENSATOR -> Optional.of(((ShuntCompensator) identifiable).getRegulatingTerminal());
+            case STATIC_VAR_COMPENSATOR -> Optional.of(((StaticVarCompensator) identifiable).getRegulatingTerminal());
+            case HVDC_CONVERTER_STATION -> Optional.of(((VscConverterStation) identifiable).getTerminal()); // local regulation only
+            default -> Optional.empty();
+        };
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
@@ -405,27 +405,27 @@ class SecondaryVoltageControlTest {
     }
 
     @Test
-    void testWithDisconnectedGenerator() {
-        network.getGenerator("B6-G").disconnect();
-        parameters.setUseReactiveLimits(false);
+    void testWithDiscardedGenerator() {
+        g6.newMinMaxReactiveLimits()
+                .setMinQ(100)
+                .setMaxQ(100.00000001)
+                .add();
         parametersExt.setSecondaryVoltageControl(true);
         network.newExtension(SecondaryVoltageControlAdder.class)
                 .newControlZone()
                 .withName("z1")
                 .newPilotPoint().withTargetV(13).withBusbarSectionsOrBusesIds(List.of("B10")).add()
-                .newControlUnit().withId("B5-G").add() // this control unit is a generator with remote voltage control
+                .newControlUnit().withId("B6-G").add()
                 .newControlUnit().withId("B8-G").add()
                 .add()
                 .add();
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
-        assertEquals(6, result.getComponentResults().get(0).getIterationCount());
+        assertEquals(5, result.getComponentResults().get(0).getIterationCount());
 
         assertVoltageEquals(13, b10);
-        assertVoltageEquals(12.909, b6);
-        assertVoltageEquals(23.978, b8);
-        assertReactivePowerEquals(Double.NaN, g6.getTerminal());
-        assertReactivePowerEquals(-57.925, g8.getTerminal());
+        assertVoltageEquals(13.090, b6);
+        assertVoltageEquals(23.381, b8);
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
@@ -370,6 +370,7 @@ class SecondaryVoltageControlTest {
 
     @Test
     void testWithGeneratorRemoteVoltage() {
+        // move generator 6 to bus 5 but keep voltage control on bus 6
         network.getGenerator("B6-G").remove();
         var g5 = network.getVoltageLevel("VL5").newGenerator()
                 .setId("B5-G")
@@ -387,7 +388,7 @@ class SecondaryVoltageControlTest {
                 .newControlZone()
                 .withName("z1")
                 .newPilotPoint().withTargetV(13).withBusbarSectionsOrBusesIds(List.of("B10")).add()
-                .newControlUnit().withId("B5-G").add()
+                .newControlUnit().withId("B5-G").add() // this control unit is a generator with remote voltage control
                 .newControlUnit().withId("B8-G").add()
                 .add()
                 .add();

--- a/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
@@ -9,8 +9,13 @@ package com.powsybl.openloadflow.ac;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.ieeecdf.converter.IeeeCdfNetworkFactory;
-import com.powsybl.iidm.network.*;
-import com.powsybl.iidm.network.extensions.*;
+import com.powsybl.iidm.network.Bus;
+import com.powsybl.iidm.network.Generator;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.ReactiveLimits;
+import com.powsybl.iidm.network.extensions.PilotPoint;
+import com.powsybl.iidm.network.extensions.SecondaryVoltageControl;
+import com.powsybl.iidm.network.extensions.SecondaryVoltageControlAdder;
 import com.powsybl.loadflow.LoadFlow;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.LoadFlowResult;
@@ -361,5 +366,40 @@ class SecondaryVoltageControlTest {
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.FAILED, result.getComponentResults().get(0).getStatus());
+    }
+
+    @Test
+    void testWithGeneratorRemoteVoltage() {
+        network.getGenerator("B6-G").remove();
+        var g5 = network.getVoltageLevel("VL5").newGenerator()
+                .setId("B5-G")
+                .setBus("B5")
+                .setTargetP(0)
+                .setMinP(-9999)
+                .setMaxP(9999)
+                .setTargetV(12.8)
+                .setVoltageRegulatorOn(true)
+                .setRegulatingTerminal(network.getLoad("B6-L").getTerminal())
+                .add();
+        parameters.setUseReactiveLimits(false);
+        parametersExt.setSecondaryVoltageControl(true);
+        network.newExtension(SecondaryVoltageControlAdder.class)
+                .newControlZone()
+                .withName("z1")
+                .newPilotPoint().withTargetV(13).withBusbarSectionsOrBusesIds(List.of("B10")).add()
+                .newControlUnit().withId("B5-G").add()
+                .newControlUnit().withId("B8-G").add()
+                .add()
+                .add();
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
+        assertEquals(8, result.getComponentResults().get(0).getIterationCount());
+
+        assertVoltageEquals(13, b10);
+        assertVoltageEquals(12.682, b6);
+        assertVoltageEquals(25.311, b8);
+        assertReactivePowerEquals(82.904, g5.getTerminal());
+        assertReactivePowerEquals(-97, g8.getTerminal());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/network/impl/HvdcConverterStationsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/impl/HvdcConverterStationsTest.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.openloadflow.network.impl;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.HvdcTestNetwork;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ */
+class HvdcConverterStationsTest {
+
+    @Test
+    void testIsVsc() {
+        Network networkVsc = HvdcTestNetwork.createVsc();
+        assertFalse(HvdcConverterStations.isVsc(networkVsc.getVoltageLevel("VL1")));
+        assertTrue(HvdcConverterStations.isVsc(networkVsc.getVscConverterStation("C1")));
+        Network networkLcc = HvdcTestNetwork.createLcc();
+        assertFalse(HvdcConverterStations.isVsc(networkLcc.getLccConverterStation("C1")));
+    }
+}

--- a/src/test/java/com/powsybl/openloadflow/network/impl/NetworksTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/impl/NetworksTest.java
@@ -8,6 +8,7 @@
 package com.powsybl.openloadflow.network.impl;
 
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
 import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
 import org.junit.jupiter.api.Test;
@@ -29,9 +30,13 @@ class NetworksTest {
         assertSame(network.getGenerator("GH1").getTerminal(), Networks.getEquipmentRegulatingTerminal(network, "GH1").orElseThrow());
         assertSame(network.getShuntCompensator("SHUNT").getTerminal(), Networks.getEquipmentRegulatingTerminal(network, "SHUNT").orElseThrow());
         assertSame(network.getVscConverterStation("VSC1").getTerminal(), Networks.getEquipmentRegulatingTerminal(network, "VSC1").orElseThrow());
+        assertFalse(Networks.getEquipmentRegulatingTerminal(network, "LCC1").isPresent());
         assertSame(network.getStaticVarCompensator("SVC").getTerminal(), Networks.getEquipmentRegulatingTerminal(network, "SVC").orElseThrow());
 
         Network network3wt = ThreeWindingsTransformerNetworkFactory.create();
         assertSame(network3wt.getLoad("LOAD_33").getTerminal(), Networks.getEquipmentRegulatingTerminal(network3wt, "3WT").orElseThrow());
+
+        Network network3wtWithoutTapChanger = EurostagTutorialExample1Factory.createWith3wTransformer();
+        assertFalse(Networks.getEquipmentRegulatingTerminal(network3wtWithoutTapChanger, "NGEN_V2_NHV1").isPresent());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/network/impl/NetworksTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/impl/NetworksTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.openloadflow.network.impl;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
+import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ */
+class NetworksTest {
+
+    @Test
+    void testGetRegulatingTerminal() {
+        Network network = FourSubstationsNodeBreakerFactory.create();
+        assertFalse(Networks.getEquipmentRegulatingTerminal(network, "LD1").isPresent());
+        assertSame(network.getTwoWindingsTransformer("TWT").getTerminal1(), Networks.getEquipmentRegulatingTerminal(network, "TWT").orElseThrow());
+        assertSame(network.getTwoWindingsTransformer("TWT").getTerminal1(), Networks.getEquipmentRegulatingTerminal(network, "TWT").orElseThrow());
+        assertSame(network.getGenerator("GH1").getTerminal(), Networks.getEquipmentRegulatingTerminal(network, "GH1").orElseThrow());
+        assertSame(network.getShuntCompensator("SHUNT").getTerminal(), Networks.getEquipmentRegulatingTerminal(network, "SHUNT").orElseThrow());
+        assertSame(network.getVscConverterStation("VSC1").getTerminal(), Networks.getEquipmentRegulatingTerminal(network, "VSC1").orElseThrow());
+        assertSame(network.getStaticVarCompensator("SVC").getTerminal(), Networks.getEquipmentRegulatingTerminal(network, "SVC").orElseThrow());
+
+        Network network3wt = ThreeWindingsTransformerNetworkFactory.create();
+        assertSame(network3wt.getLoad("LOAD_33").getTerminal(), Networks.getEquipmentRegulatingTerminal(network3wt, "3WT").orElseThrow());
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Secondary voltage control does not work with generators using remote voltage control.


**What is the new behavior (if this is a feature change)?**
The issue was just some wrong checks at network loading. I rewrote theses checks and logs additionnal infos.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
