### PR TITLE
fix: split in sub-reports for a list of elements that could be too big

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/util/Reports.java
+++ b/src/main/java/com/powsybl/openloadflow/util/Reports.java
@@ -606,14 +606,25 @@ public final class Reports {
     }
 
     public static void reportNewtonRaphsonBusesOutOfRealisticVoltageRange(ReportNode reportNode, Map<String, Double> busesOutOfRealisticVoltageRange, double minRealisticVoltage, double maxRealisticVoltage) {
-        reportNode.newReportNode()
-                .withMessageTemplate("newtonRaphsonBusesOutOfRealisticVoltageRange", "${busCountOutOfRealisticVoltageRange} buses have a voltage magnitude out of the configured realistic range [${minRealisticVoltage}, ${maxRealisticVoltage}] p.u.: ${busesOutOfRealisticVoltageRange}")
+        ReportNode voltageOutOfRangeReport = reportNode.newReportNode()
+            .withMessageTemplate("busesOutOfVoltageRealisticRange", "Buses have a voltage magnitude out of the configured realistic range")
+            .add();
+
+        voltageOutOfRangeReport.newReportNode()
+                .withMessageTemplate("busesOutOfVoltageRealisticRangeSummary", "${busCountOutOfRealisticVoltageRange} buses have a voltage magnitude out of the configured realistic range [${minRealisticVoltage}, ${maxRealisticVoltage}]")
                 .withUntypedValue("busCountOutOfRealisticVoltageRange", busesOutOfRealisticVoltageRange.size())
                 .withUntypedValue("minRealisticVoltage", minRealisticVoltage)
                 .withUntypedValue("maxRealisticVoltage", maxRealisticVoltage)
                 .withUntypedValue("busesOutOfRealisticVoltageRange", busesOutOfRealisticVoltageRange.toString())
                 .withSeverity(TypedValue.ERROR_SEVERITY)
                 .add();
+
+        busesOutOfRealisticVoltageRange.forEach((id, voltage) -> voltageOutOfRangeReport.newReportNode()
+            .withMessageTemplate("busesOutOfVoltageRealisticRangeDetail", "Bus ${id} has an unrealistic voltage magnitude: ${voltage} pu")
+            .withUntypedValue("id", id)
+            .withUntypedValue("voltage", voltage)
+            .withSeverity(TypedValue.TRACE_SEVERITY)
+            .add());
     }
 
     public static void reportAngleReferenceBusAndSlackBuses(ReportNode reportNode, String referenceBus, List<String> slackBuses) {

--- a/src/test/resources/saReport.txt
+++ b/src/test/resources/saReport.txt
@@ -37,7 +37,9 @@
             Outer loop ReactiveLimits
             AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
          + Post-contingency simulation 'NGEN_NHV1'
-            1 buses have a voltage magnitude out of the configured realistic range [0.5, 1.5] p.u.: {VLHV1_0=1.5105659472379578}
+            + Buses have a voltage magnitude out of the configured realistic range
+               1 buses have a voltage magnitude out of the configured realistic range [0.5, 1.5]
+               Bus VLHV1_0 has an unrealistic voltage magnitude: 1.5105659472379578 pu
             AC load flow completed with error (solverStatus=UNREALISTIC_STATE, outerloopStatus=STABLE)
          + Post-contingency simulation 'NHV2_NLOAD'
             + Outer loop DistributedSlack


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
Split a report where a message can be really big into smaller sub-reports



**What is the current behavior?**
We're creating a report with a message based on a map that gathers all the network elements that are in error. This list can be really big and we feel this is not a good practice to do so.



**What is the new behavior (if this is a feature change)?**
Instead of one report gathering all the detailed information we split it into sub-reports with TRACE level and one summary message with ERROR level


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
