### PR TITLE
Retry LU decomposition if incremental mode fails

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/equations/JacobianMatrix.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/JacobianMatrix.java
@@ -12,6 +12,7 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.math.matrix.DenseMatrix;
 import com.powsybl.math.matrix.LUDecomposition;
 import com.powsybl.math.matrix.Matrix;
+import com.powsybl.math.matrix.MatrixException;
 import com.powsybl.math.matrix.MatrixFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -141,7 +142,19 @@ public class JacobianMatrix<V extends Enum<V> & Quantity, E extends Enum<E> & Qu
 
     private void updateValues(boolean allowIncrementalUpdate) {
         updateDer();
-        updateLu(allowIncrementalUpdate);
+        try {
+            updateLu(allowIncrementalUpdate);
+        } catch (MatrixException ex) {
+            if (allowIncrementalUpdate) {
+                // Try another time without incremental
+                LOGGER.warn("Exception when updating LU matrix in incremental mode. Retrying without incremental mode");
+                updateDer();
+                updateLu(false);
+            } else {
+                // Rethrow the exception
+                throw ex;
+            }
+        }
     }
 
     public void forceUpdate() {

--- a/src/main/java/com/powsybl/openloadflow/equations/JacobianMatrix.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/JacobianMatrix.java
@@ -148,7 +148,6 @@ public class JacobianMatrix<V extends Enum<V> & Quantity, E extends Enum<E> & Qu
             if (allowIncrementalUpdate) {
                 // Try another time without incremental
                 LOGGER.warn("Exception when updating LU matrix in incremental mode. Retrying without incremental mode");
-                updateDer();
                 updateLu(false);
             } else {
                 // Rethrow the exception

--- a/src/test/java/com/powsybl/openloadflow/equations/LUDecompositionTest.java
+++ b/src/test/java/com/powsybl/openloadflow/equations/LUDecompositionTest.java
@@ -1,0 +1,121 @@
+package com.powsybl.openloadflow.equations;
+
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.math.matrix.DenseMatrix;
+import com.powsybl.math.matrix.DenseMatrixFactory;
+import com.powsybl.math.matrix.LUDecomposition;
+import com.powsybl.math.matrix.MatrixException;
+import com.powsybl.openloadflow.ac.equations.AcEquationType;
+import com.powsybl.openloadflow.ac.equations.AcVariableType;
+import com.powsybl.openloadflow.network.FirstSlackBusSelector;
+import com.powsybl.openloadflow.network.LfBus;
+import com.powsybl.openloadflow.network.LfNetwork;
+import com.powsybl.openloadflow.network.impl.Networks;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LUDecompositionTest {
+
+    class LUDecompositionMockIncrementalFailure implements LUDecomposition {
+        private final LUDecomposition delegate;
+        private final SpyMatrixFactory spy;
+
+        public LUDecompositionMockIncrementalFailure(LUDecomposition delegate, SpyMatrixFactory spy) {
+            this.delegate = delegate;
+            this.spy = spy;
+        }
+
+        @Override
+        public void update() {
+            delegate.update();
+        }
+
+        @Override
+        public void solve(double[] b) {
+            delegate.solve(b);
+        }
+
+        @Override
+        public void solveTransposed(double[] b) {
+            delegate.solveTransposed(b);
+        }
+
+        @Override
+        public void solve(DenseMatrix b) {
+            delegate.solve(b);
+        }
+
+        @Override
+        public void solveTransposed(DenseMatrix b) {
+            delegate.solveTransposed(b);
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+
+        @Override
+        public void update(boolean allowIncrementalUpdate) {
+            if (allowIncrementalUpdate) {
+                spy.exceptionThrown = true;
+                throw new MatrixException("Sorry incremental update failed");
+            } else {
+                delegate.update(allowIncrementalUpdate);
+            }
+        }
+    }
+
+    class SpyMatrixFactory extends DenseMatrixFactory {
+        boolean exceptionThrown = false;
+
+        @Override
+        public DenseMatrix create(int rowCount, int columnCount, int estimatedValueCount) {
+            return new DenseMatrix(rowCount, columnCount) {
+                @Override
+                public LUDecomposition decomposeLU() {
+                    return new LUDecompositionMockIncrementalFailure(super.decomposeLU(), SpyMatrixFactory.this);
+                }
+            };
+        }
+    }
+
+    @Test
+    public void testIncrementalLURobustification() {
+
+        // The condition that cause an incremental LU decomposition to fail is hard to reproduce on small models.
+        // It has been seen in Security Analysis, on large models, when a contingence moves an AC emulation HVDC link above PMax
+        //
+        // This test uses a mocked DenseMatrix to reproduce the condition and check that the solve succeds
+
+        SpyMatrixFactory factory = new SpyMatrixFactory();
+
+        List<LfNetwork> lfNetworks = Networks.load(EurostagTutorialExample1Factory.create(), new FirstSlackBusSelector());
+        LfNetwork network = lfNetworks.get(0);
+
+        LfBus bus = network.getBus(0);
+
+        EquationSystem<AcVariableType, AcEquationType> equationSystem = new EquationSystem<>();
+        equationSystem.createEquation(bus.getNum(), AcEquationType.BUS_TARGET_V).addTerm(equationSystem.getVariable(bus.getNum(), AcVariableType.BUS_V).createTerm())
+                .setActive(true);
+
+        double[] values = new double[] {0.1};
+
+        try (JacobianMatrix j = new JacobianMatrix(equationSystem, factory)) {
+            // First update
+            j.solve(values);
+            assertFalse(factory.exceptionThrown);
+            // second update that triggers incremental update
+            j.updateStatus(JacobianMatrix.Status.VALUES_INVALID);
+            j.solve(values);
+            // An eception should be thrown but the solve should continue
+            assertTrue(factory.exceptionThrown);
+
+        }
+
+    }
+}

--- a/src/test/java/com/powsybl/openloadflow/equations/LUDecompositionTest.java
+++ b/src/test/java/com/powsybl/openloadflow/equations/LUDecompositionTest.java
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 package com.powsybl.openloadflow.equations;
 
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
@@ -19,6 +27,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * @author Didier Vidal {@literal <didier.vidal_externe at rte-france.com>}
+ */
 class LUDecompositionTest {
 
     class LUDecompositionMockIncrementalFailure implements LUDecomposition {

--- a/src/test/java/com/powsybl/openloadflow/equations/LUDecompositionTest.java
+++ b/src/test/java/com/powsybl/openloadflow/equations/LUDecompositionTest.java
@@ -121,6 +121,11 @@ public class LUDecompositionTest {
             spyMatrixFactory.alwaysFail = true;
             j.updateStatus(JacobianMatrix.Status.VALUES_INVALID);
             assertThrows(MatrixException.class, () -> j.solve(values));
+
+            // Force always fail in non incremental case
+            spyMatrixFactory.alwaysFail = true;
+            j.updateStatus(JacobianMatrix.Status.VALUES_AND_ZEROS_INVALID);
+            assertThrows(MatrixException.class, () -> j.solve(values));
         }
 
     }

--- a/src/test/java/com/powsybl/openloadflow/equations/LUDecompositionTest.java
+++ b/src/test/java/com/powsybl/openloadflow/equations/LUDecompositionTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LUDecompositionTest {
+class LUDecompositionTest {
 
     class LUDecompositionMockIncrementalFailure implements LUDecomposition {
         private final LUDecomposition delegate;
@@ -87,7 +87,7 @@ public class LUDecompositionTest {
     }
 
     @Test
-    public void testIncrementalLURobustification() {
+    void testIncrementalLURobustification() {
 
         // The condition that cause an incremental LU decomposition to fail is hard to reproduce on small models.
         // It has been seen in Security Analysis, on large models, when a contingence moves an AC emulation HVDC link above PMax


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug Fix


**What is the current behavior?**
In some rare cases, the NR fails with a MatrixException - klu_refactor error KLU_SINGULAR
  This happens when the Jacobian Matrix uptes the LU in incremental mode.  
  But, in those cases, if the LU matrix is updated in non incremental mode the operation succeeds.

At this time, this has only be seen in large model and it has not been possible to isolate a simple case with the issue. 


**What is the new behavior (if this is a feature change)?**

When the Jacobian updates occurs in incremental mode, if the LU update fails a second try is attempted in non incremental mode.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
