### PR TITLE
Fix injections ignored on slack buses when using multi slacks

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/AcTargetVector.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcTargetVector.java
@@ -66,7 +66,7 @@ public class AcTargetVector extends TargetVector<AcVariableType, AcEquationType>
 
     public static void init(Equation<AcVariableType, AcEquationType> equation, LfNetwork network, double[] targets) {
         switch (equation.getType()) {
-            case BUS_TARGET_P:
+            case BUS_TARGET_P, BUS_DISTR_SLACK_P:
                 targets[equation.getColumn()] = network.getBus(equation.getElementNum()).getTargetP();
                 break;
 
@@ -118,7 +118,6 @@ public class AcTargetVector extends TargetVector<AcVariableType, AcEquationType>
                  DISTR_SHUNT_B,
                  DUMMY_TARGET_P,
                  DUMMY_TARGET_Q,
-                 BUS_DISTR_SLACK_P,
                  BUS_TARGET_IX_ZERO,
                  BUS_TARGET_IY_ZERO,
                  BUS_TARGET_IX_NEGATIVE,

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
@@ -1037,13 +1037,13 @@ public class AcEquationSystemCreator {
             for (int i = 1; i < slackBuses.size(); i++) {
                 LfBus slackBus = slackBuses.get(i);
                 // example for 2 slack buses
-                // 0 = slack_p1 - slack_p2
-                // 0 = slack_p1 - slack_p3
+                // 0 = slack_p2 - slack_p1
+                // 0 = slack_p3 - slack_p1
                 equationSystem.createEquation(slackBus, AcEquationType.BUS_DISTR_SLACK_P)
-                        .addTerms(createActiveInjectionTerms(firstSlackBus, equationSystem.getVariableSet()))
-                        .addTerms(createActiveInjectionTerms(slackBus, equationSystem.getVariableSet()).stream()
+                        .addTerms(createActiveInjectionTerms(firstSlackBus, equationSystem.getVariableSet()).stream()
                                 .map(EquationTerm::minus)
-                                .collect(Collectors.toList()));
+                                .toList())
+                        .addTerms(createActiveInjectionTerms(slackBus, equationSystem.getVariableSet()));
                 // to update open/close terms activation
                 for (LfBranch branch : slackBus.getBranches()) {
                     updateBranchEquations(branch);

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
@@ -1036,7 +1036,7 @@ public class AcEquationSystemCreator {
             LfBus firstSlackBus = slackBuses.get(0);
             for (int i = 1; i < slackBuses.size(); i++) {
                 LfBus slackBus = slackBuses.get(i);
-                // example for 2 slack buses
+                // example for 3 slack buses
                 // 0 = slack_p2 - slack_p1
                 // 0 = slack_p3 - slack_p1
                 equationSystem.createEquation(slackBus, AcEquationType.BUS_DISTR_SLACK_P)

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
@@ -1037,8 +1037,8 @@ public class AcEquationSystemCreator {
             for (int i = 1; i < slackBuses.size(); i++) {
                 LfBus slackBus = slackBuses.get(i);
                 // example for 3 slack buses
-                // target_p2 = slack_p2 - slack_p1 + inj_p2
-                // target_p3 = slack_p3 - slack_p1 + inj_p2
+                // target_p2 = slack_p2 - slack_p1
+                // target_p3 = slack_p3 - slack_p1
                 equationSystem.createEquation(slackBus, AcEquationType.BUS_DISTR_SLACK_P)
                         .addTerms(createActiveInjectionTerms(firstSlackBus, equationSystem.getVariableSet()).stream()
                                 .map(EquationTerm::minus)

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
@@ -1037,8 +1037,8 @@ public class AcEquationSystemCreator {
             for (int i = 1; i < slackBuses.size(); i++) {
                 LfBus slackBus = slackBuses.get(i);
                 // example for 3 slack buses
-                // 0 = slack_p2 - slack_p1
-                // 0 = slack_p3 - slack_p1
+                // target_p2 = slack_p2 - slack_p1 + inj_p2
+                // target_p3 = slack_p3 - slack_p1 + inj_p2
                 equationSystem.createEquation(slackBus, AcEquationType.BUS_DISTR_SLACK_P)
                         .addTerms(createActiveInjectionTerms(firstSlackBus, equationSystem.getVariableSet()).stream()
                                 .map(EquationTerm::minus)

--- a/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
@@ -19,7 +19,6 @@ import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.OpenLoadFlowProvider;
 import com.powsybl.openloadflow.ac.solver.NewtonRaphsonStoppingCriteriaType;
 import com.powsybl.openloadflow.network.EurostagFactory;
-import com.powsybl.openloadflow.network.LfBus;
 import com.powsybl.openloadflow.network.SlackBusSelectionMode;
 import com.powsybl.openloadflow.util.LoadFlowAssert;
 import org.junit.jupiter.api.BeforeEach;
@@ -121,17 +120,15 @@ class MultipleSlackBusesTest {
         LoadFlowResult.ComponentResult componentResult = result.getComponentResults().get(0);
         List<LoadFlowResult.SlackBusResult> slackBusResults = componentResult.getSlackBusResults();
 
-
         TwoWindingsTransformer t2wtLoad = network.getTwoWindingsTransformer("NHV2_NLOAD");
         Load load = network.getLoad("LOAD");
 
-        // Load is ignored by LF equations only slack goes to this bus
-        assertEquals(-301.159, t2wtLoad.getTerminal2().getP(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(-600.710, t2wtLoad.getTerminal2().getP(), LoadFlowAssert.DELTA_POWER);
         assertEquals(600.0, load.getTerminal().getP(), LoadFlowAssert.DELTA_POWER);
 
-        // Slack bus mismatch is false
+        // still small difference due to NR conv epsilon per eq
         assertEquals(2, slackBusResults.size());
-        assertEquals(-1.15940, slackBusResults.get(0).getActivePowerMismatch(), LoadFlowAssert.DELTA_POWER);
-        assertEquals(-1.15940, slackBusResults.get(1).getActivePowerMismatch(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(-0.711, slackBusResults.get(0).getActivePowerMismatch(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(-0.711, slackBusResults.get(1).getActivePowerMismatch(), LoadFlowAssert.DELTA_POWER);
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
@@ -33,6 +33,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static com.powsybl.openloadflow.util.LoadFlowAssert.assertActivePowerEquals;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -125,8 +126,8 @@ class MultipleSlackBusesTest {
         TwoWindingsTransformer t2wtLoad = network.getTwoWindingsTransformer("NHV2_NLOAD");
         Load load = network.getLoad("LOAD");
 
-        assertEquals(-600.710, t2wtLoad.getTerminal2().getP(), LoadFlowAssert.DELTA_POWER);
-        assertEquals(600.0, load.getTerminal().getP(), LoadFlowAssert.DELTA_POWER);
+        assertActivePowerEquals(-600.710, t2wtLoad.getTerminal2());
+        assertActivePowerEquals(600.0, load.getTerminal());
 
         assertEquals(2, slackBusResults.size());
         assertEquals(-0.710, slackBusResults.get(0).getActivePowerMismatch(), LoadFlowAssert.DELTA_POWER);

--- a/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
@@ -112,9 +112,11 @@ class MultipleSlackBusesTest {
     }
 
     @Test
-    void targetVectorBug() {
-        parametersExt.setSlackBusSelectionMode(SlackBusSelectionMode.NAME);
-        parametersExt.setSlackBusesIds(List.of("VLHV2", "VLLOAD"));
+    void testSlackBusWithInjection() {
+        parametersExt
+                .setSlackBusSelectionMode(SlackBusSelectionMode.NAME)
+                .setSlackBusesIds(List.of("VLHV2", "VLLOAD"))
+                .setNewtonRaphsonConvEpsPerEq(1e-6);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
         LoadFlowResult.ComponentResult componentResult = result.getComponentResults().get(0);
@@ -128,7 +130,7 @@ class MultipleSlackBusesTest {
 
         // still small difference due to NR conv epsilon per eq
         assertEquals(2, slackBusResults.size());
-        assertEquals(-0.711, slackBusResults.get(0).getActivePowerMismatch(), LoadFlowAssert.DELTA_POWER);
-        assertEquals(-0.711, slackBusResults.get(1).getActivePowerMismatch(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(-0.710, slackBusResults.get(0).getActivePowerMismatch(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(-0.710, slackBusResults.get(1).getActivePowerMismatch(), LoadFlowAssert.DELTA_POWER);
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
@@ -128,7 +128,6 @@ class MultipleSlackBusesTest {
         assertEquals(-600.710, t2wtLoad.getTerminal2().getP(), LoadFlowAssert.DELTA_POWER);
         assertEquals(600.0, load.getTerminal().getP(), LoadFlowAssert.DELTA_POWER);
 
-        // still small difference due to NR conv epsilon per eq
         assertEquals(2, slackBusResults.size());
         assertEquals(-0.710, slackBusResults.get(0).getActivePowerMismatch(), LoadFlowAssert.DELTA_POWER);
         assertEquals(-0.710, slackBusResults.get(1).getActivePowerMismatch(), LoadFlowAssert.DELTA_POWER);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When using multi slack, loads or gens on slack buses are ignored because value for P in target vector is 0. This results in the existing injections to be "mangled"/reported in the slack injection incorrectly.


**What is the new behavior (if this is a feature change)?**
Take P injection into account on slack buses equations for the multi slack case


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No
