### PR TITLE
fictive load on isolated bus keeps hvdc isolated

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/LfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBus.java
@@ -92,6 +92,8 @@ public interface LfBus extends LfElement {
 
     double getLoadTargetP();
 
+    double getNonFictitiousLoadTargetP();
+
     double getLoadTargetQ();
 
     void invalidateGenerationTargetP();

--- a/src/main/java/com/powsybl/openloadflow/network/LfLoad.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfLoad.java
@@ -30,6 +30,8 @@ public interface LfLoad extends PropertyBag {
 
     double getTargetP();
 
+    double getNonFictitiousLoadTargetP();
+
     void setTargetP(double targetP);
 
     double getTargetQ();

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -413,6 +413,13 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     }
 
     @Override
+    public double getNonFictitiousLoadTargetP() {
+        return loads.stream()
+                .mapToDouble(load -> load.getNonFictitiousLoadTargetP() * load.getLoadModel().flatMap(lm -> lm.getExpTermP(0).map(LfLoadModel.ExpTerm::c)).orElse(1d))
+                .sum();
+    }
+
+    @Override
     public double getLoadTargetQ() {
         return loads.stream()
                 .mapToDouble(load -> load.getTargetQ() * load.getLoadModel().flatMap(lm -> lm.getExpTermQ(0).map(LfLoadModel.ExpTerm::c)).orElse(1d))

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -297,7 +297,7 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     }
 
     void addLccConverterStation(LccConverterStation lccCs, LfNetworkParameters parameters) {
-        if (!HvdcConverterStations.isHvdcDanglingInIidm(lccCs, parameters)) {
+        if (!HvdcConverterStations.isHvdcDanglingInIidm(lccCs)) {
             // Note: Load is determined statically - contingencies or actions that change an LCC Station connectivity
             // will continue to give incorrect result
             getOrCreateLfLoad(null, parameters).add(lccCs, parameters);

--- a/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
@@ -58,14 +58,18 @@ public final class HvdcConverterStations {
     }
 
     private static boolean isIsolated(Terminal terminal, LfNetworkParameters parameters) {
-        Bus bus = parameters.isBreakers() ? terminal.getBusBreakerView().getBus() : terminal.getBusView().getBus();
+        Bus bus = terminal.getBusView().getBus();
         if (bus == null) {
             return true;
         }
 
-        // The criteria should as close as possible to Networks.isIsolatedBusForHvdc - only connected to the station
+        // The criteria should as close as possible to Networks.isIsolatedBusForHvdc - only connected to the station or a fictitious load
         return bus.getConnectedTerminalStream()
                 .map(Terminal::getConnectable)
-                .noneMatch(c -> !(c instanceof HvdcConverterStation<?> || c instanceof BusbarSection));
+                .noneMatch(c -> !(c instanceof HvdcConverterStation<?> || c instanceof BusbarSection || isFictitiousLoad(c)));
+    }
+
+    private static boolean isFictitiousLoad(Connectable c) {
+        return c instanceof Load load && LfLoadImpl.isLoadFictitious(load);
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
@@ -9,7 +9,6 @@ package com.powsybl.openloadflow.network.impl;
 
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.util.HvdcUtils;
-import com.powsybl.openloadflow.network.LfNetworkParameters;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -45,19 +44,19 @@ public final class HvdcConverterStations {
                 && ((HvdcConverterStation<?>) identifiable).getHvdcType() == HvdcConverterStation.HvdcType.VSC;
     }
 
-    public static boolean isHvdcDanglingInIidm(HvdcConverterStation<?> station, LfNetworkParameters parameters) {
+    public static boolean isHvdcDanglingInIidm(HvdcConverterStation<?> station) {
 
-        if (isIsolated(station.getTerminal(), parameters)) {
+        if (isIsolated(station.getTerminal())) {
             return true;
         } else {
             return station.getOtherConverterStation().map(otherConverterStation -> {
                 Terminal otherTerminal = otherConverterStation.getTerminal();
-                return isIsolated(otherTerminal, parameters);
+                return isIsolated(otherTerminal);
             }).orElse(true); // it means there is no HVDC line connected to station
         }
     }
 
-    private static boolean isIsolated(Terminal terminal, LfNetworkParameters parameters) {
+    private static boolean isIsolated(Terminal terminal) {
         Bus bus = terminal.getBusView().getBus();
         if (bus == null) {
             return true;
@@ -69,7 +68,7 @@ public final class HvdcConverterStations {
                 .noneMatch(c -> !(c instanceof HvdcConverterStation<?> || c instanceof BusbarSection || isFictitiousLoad(c)));
     }
 
-    private static boolean isFictitiousLoad(Connectable c) {
+    private static boolean isFictitiousLoad(Connectable<?> c) {
         return c instanceof Load load && LfLoadImpl.isLoadFictitious(load);
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/HvdcConverterStations.java
@@ -62,7 +62,7 @@ public final class HvdcConverterStations {
             return true;
         }
 
-        // The criteria should as close as possible to Networks.isIsolatedBusForHvdc - only connected to the station or a fictitious load
+        // The criteria should be as close as possible to Networks.isIsolatedBusForHvdc - only connected to the station or a fictitious load
         return bus.getConnectedTerminalStream()
                 .map(Terminal::getConnectable)
                 .noneMatch(c -> !(c instanceof HvdcConverterStation<?> || c instanceof BusbarSection || isFictitiousLoad(c)));

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLoadImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLoadImpl.java
@@ -272,7 +272,25 @@ public class LfLoadImpl extends AbstractLfInjection implements LfLoad {
      */
     public static boolean isLoadNotParticipating(Load load) {
         // Fictitious loads that do not participate to slack distribution.
+        return isLoadFictitious(load);
+    }
+
+    /**
+     * Returns whether the load is tagged fictitious in the grid model
+     */
+    public static boolean isLoadFictitious(Load load) {
+        // Fictitious loads that do not participate to slack distribution.
         return load.isFictitious() || LoadType.FICTITIOUS.equals(load.getLoadType());
+    }
+
+    @Override
+    public double getNonFictitiousLoadTargetP() {
+        return loadsRefs.values().stream()
+                .map(Ref::get)
+                .filter(Objects::nonNull)
+                .filter(l -> !isLoadFictitious(l))
+                .mapToDouble(Load::getP0)
+                .sum();
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfVscConverterStationImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfVscConverterStationImpl.java
@@ -37,7 +37,7 @@ public class LfVscConverterStationImpl extends AbstractLfGenerator implements Lf
 
     public LfVscConverterStationImpl(VscConverterStation station, LfNetwork network, LfNetworkParameters parameters, LfNetworkLoadingReport report) {
         super(network, HvdcUtils.getConverterStationTargetP(station) / PerUnit.SB);
-        this.hvdcDandlingInIidm = HvdcConverterStations.isHvdcDanglingInIidm(station, parameters);
+        this.hvdcDandlingInIidm = HvdcConverterStations.isHvdcDanglingInIidm(station);
         this.stationRef = Ref.create(station, parameters.isCacheEnabled());
         this.lossFactor = station.getLossFactor();
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
@@ -269,14 +269,14 @@ public final class Networks {
     public static boolean isIsolatedBusForHvdc(LfBus bus, GraphConnectivity<LfBus, LfBranch> connectivity) {
         // used only for hvdc lines.
         // this criteria can be improved later depending on use case
-        return connectivity.getConnectedComponent(bus).size() == 1 && bus.getLoadTargetP() == 0.0
+        return connectivity.getConnectedComponent(bus).size() == 1 && bus.getNonFictitiousLoadTargetP() == 0.0
                 && bus.getGenerators().stream().noneMatch(LfGeneratorImpl.class::isInstance);
     }
 
     public static boolean isIsolatedBusForHvdc(LfBus bus, Set<LfBus> disabledBuses) {
         // used only for hvdc lines for DC sensitivity analysis where we don't have the connectivity.
         // this criteria can be improved later depending on use case
-        return disabledBuses.contains(bus) && bus.getLoadTargetP() == 0.0
+        return disabledBuses.contains(bus) && bus.getNonFictitiousLoadTargetP() == 0.0
                 && bus.getGenerators().stream().noneMatch(LfGeneratorImpl.class::isInstance);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
@@ -1418,7 +1418,6 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
 
         Network network = HvdcNetworkFactory.createHvdcAndSwitch(HvdcConverterStation.HvdcType.VSC);
 
-
         LoadFlowParameters parameters = new LoadFlowParameters();
         parameters.setConnectedComponentMode(LoadFlowParameters.ConnectedComponentMode.ALL);
 
@@ -1430,7 +1429,6 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
 
         assertEquals(-250, network.getBranch("l34").getTerminal1().getP(), LoadFlowAssert.DELTA_POWER);
         assertEquals(200.0, network.getHvdcConverterStation("cs3").getTerminal().getP(), LoadFlowAssert.DELTA_POWER);
-
 
         network.getSwitch("s3").setOpen(true);
         runLoadFlow(network, parameters);

--- a/src/test/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysisContingenciesTest.java
@@ -24,6 +24,8 @@ import com.powsybl.openloadflow.util.DebugUtil;
 import com.powsybl.openloadflow.util.LoadFlowAssert;
 import com.powsybl.sensitivity.*;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -2459,9 +2461,21 @@ class DcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
         assertEquals(600.0, result.getBranchFlow1FunctionReferenceValue("NGEN", "NGEN_NHV1"), LoadFlowAssert.DELTA_POWER);
     }
 
-    @Test
-    void testVSCLoss() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testVSCLoss(boolean withFictiveLoad) {
         Network network = HvdcNetworkFactory.createHvdcLinkedByTwoLinesAndSwitch(HvdcConverterStation.HvdcType.VSC);
+        if (withFictiveLoad) {
+            network.getBusBreakerView().getBus("b2").getVoltageLevel()
+                    .newLoad()
+                    .setId("fictiveLoad")
+                    .setP0(5)
+                    .setQ0(1)
+                    .setBus("b2")
+                    .setConnectableBus("b2")
+                    .setFictitious(true)
+                    .add();
+        }
         List<Contingency> contingencies = List.of(new Contingency("contingency", new LineContingency("l12")),
                                                   new Contingency("bus", new BusContingency("b2")));
         List<SensitivityFactor> factors = List.of(createBranchFlowPerInjectionIncrease("l34", "l4"));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
In https://github.com/powsybl/powsybl-open-loadflow/pull/965 a simple criteria was added to detect an HVDC disconnection on one side : 
   A station is isolated if its merged bus is not connected to any other bus neither to a load or a group.

This criteria was meant to detect quickly contingencies that disconnect a line, while allowing simple models where one side is merely simplified as a group or a load.
But in real networks it happens that a fictive load is added to a station.

This fix considers that if an HVDC's stations contains only fictive loads it is still considered isolated.

**NOTE that this criteria for automatic HVDC disconnection in a contingncy is not documented at this time.** There is currently no good place to document how contingenices are propagated, when the propagation is not obvious.

**What is the current behavior?**
If a contingency isolates a bus that is connected to a fictive load and an HVDC station, the HVDC is considered working.



**What is the new behavior (if this is a feature change)?**
If a contingency isolates a bus that is connected to a fictive load and an HVDC station, the HVDC is is stopped.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
