### PR TITLE
Refactor separation of post contingency calculations in Woodbury DC Security Analysis

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysis.java
@@ -235,28 +235,26 @@ public class WoodburyDcSecurityAnalysis extends DcSecurityAnalysis {
             NetworkState networkState = NetworkState.save(lfNetwork);
 
             List<PostContingencyResult> postContingencyResults = new ArrayList<>();
-            BiConsumer<PropagatedContingency, Supplier<double[]>> postContingencyResultAdder = (contingency, postContingencyStatesSupplier) -> {
-                contingency.toLfContingency(lfNetwork, false).ifPresent(lfContingency -> {
-                    ReportNode postContSimReportNode = Reports.createPostContingencySimulation(context.getNetwork().getReportNode(), contingency.getContingency().getId());
-                    context.getNetwork().setReportNode(postContSimReportNode);
+            BiConsumer<PropagatedContingency, Supplier<double[]>> postContingencyResultAdder = (contingency, postContingencyStatesSupplier) -> contingency.toLfContingency(lfNetwork, false).ifPresent(lfContingency -> {
+                ReportNode postContSimReportNode = Reports.createPostContingencySimulation(context.getNetwork().getReportNode(), contingency.getContingency().getId());
+                context.getNetwork().setReportNode(postContSimReportNode);
 
-                    logPostContingencyStart(context.getNetwork(), lfContingency);
-                    Stopwatch stopwatch = Stopwatch.createStarted();
+                logPostContingencyStart(context.getNetwork(), lfContingency);
+                Stopwatch stopwatch = Stopwatch.createStarted();
 
-                    double[] postContingencyStates = postContingencyStatesSupplier.get();
-                    // compute post contingency result with post contingency states
-                    PostContingencyResult postContingencyResult = computePostContingencyResult(context, contingency.getContingency(),
-                            lfContingency, preContingencyLimitViolationManager, preContingencyNetworkResult, createResultExtension,
-                            securityAnalysisParameters.getIncreasedViolationsParameters(), postContingencyStates, limitReductions);
+                double[] postContingencyStates = postContingencyStatesSupplier.get();
+                // compute post contingency result with post contingency states
+                PostContingencyResult postContingencyResult = computePostContingencyResult(context, contingency.getContingency(),
+                        lfContingency, preContingencyLimitViolationManager, preContingencyNetworkResult, createResultExtension,
+                        securityAnalysisParameters.getIncreasedViolationsParameters(), postContingencyStates, limitReductions);
 
-                    stopwatch.stop();
-                    logPostContingencyEnd(context.getNetwork(), lfContingency, stopwatch);
+                stopwatch.stop();
+                logPostContingencyEnd(context.getNetwork(), lfContingency, stopwatch);
 
-                    postContingencyResults.add(postContingencyResult);
-                    // restore pre contingency state for next post contingency computation
-                    networkState.restore();
-                });
-            };
+                postContingencyResults.add(postContingencyResult);
+                // restore pre contingency state for next post contingency computation
+                networkState.restore();
+            });
 
             LOGGER.info("Processing post contingency results for contingencies with no connectivity break");
             connectivityBreakAnalysisResults.nonBreakingConnectivityContingencies().forEach(

--- a/src/main/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysis.java
@@ -149,10 +149,13 @@ public class WoodburyDcSecurityAnalysis extends DcSecurityAnalysis {
                 connectivityAnalysisResult.getPartialDisabledBranches());
     }
 
-    private PostContingencyResult computePostContingencyResult(DcLoadFlowContext loadFlowContext, Contingency contingency, LfContingency lfContingency,
-                                                               LimitViolationManager preContingencyLimitViolationManager, PreContingencyNetworkResult preContingencyNetworkResult,
-                                                               boolean createResultExtension, SecurityAnalysisParameters.IncreasedViolationsParameters violationsParameters,
-                                                               double[] postContingencyStates, List<LimitReduction> limitReductions) {
+    /**
+     * Returns the post contingency result associated to given contingency and post contingency states.
+     */
+    private PostContingencyResult computePostContingencyResultFromPostContingencyStates(DcLoadFlowContext loadFlowContext, Contingency contingency, LfContingency lfContingency,
+                                                                                        LimitViolationManager preContingencyLimitViolationManager, PreContingencyNetworkResult preContingencyNetworkResult,
+                                                                                        boolean createResultExtension, SecurityAnalysisParameters.IncreasedViolationsParameters violationsParameters,
+                                                                                        double[] postContingencyStates, List<LimitReduction> limitReductions) {
 
         // update network state with post contingency states
         LfNetwork lfNetwork = loadFlowContext.getNetwork();
@@ -185,10 +188,14 @@ public class WoodburyDcSecurityAnalysis extends DcSecurityAnalysis {
                 connectivityResult);
     }
 
+    /**
+     * Returns post contingency result associated to the given contingency if it impacts the network.
+     * Otherwise, returns an empty Optional.
+     */
     private Optional<PostContingencyResult> processPostContingencyResult(DcLoadFlowContext context, PropagatedContingency contingency, Supplier<double[]> postContingencyStatesSupplier,
-                                                          LimitViolationManager preContingencyLimitViolationManager, PreContingencyNetworkResult preContingencyNetworkResult,
-                                                          boolean createResultExtension, SecurityAnalysisParameters.IncreasedViolationsParameters violationsParameters,
-                                                          List<LimitReduction> limitReductions) {
+                                                                         LimitViolationManager preContingencyLimitViolationManager, PreContingencyNetworkResult preContingencyNetworkResult,
+                                                                         boolean createResultExtension, SecurityAnalysisParameters.IncreasedViolationsParameters violationsParameters,
+                                                                         List<LimitReduction> limitReductions) {
         LfNetwork lfNetwork = context.getNetwork();
         Optional<LfContingency> lfContingencyOptional = contingency.toLfContingency(lfNetwork, false);
         // only process contingencies that impact the network
@@ -202,8 +209,7 @@ public class WoodburyDcSecurityAnalysis extends DcSecurityAnalysis {
             Stopwatch stopwatch = Stopwatch.createStarted();
 
             double[] postContingencyStates = postContingencyStatesSupplier.get();
-            // compute post contingency result with post contingency states
-            PostContingencyResult postContingencyResult = computePostContingencyResult(context, contingency.getContingency(),
+            PostContingencyResult postContingencyResult = computePostContingencyResultFromPostContingencyStates(context, contingency.getContingency(),
                     lfContingency, preContingencyLimitViolationManager, preContingencyNetworkResult, createResultExtension,
                     violationsParameters, postContingencyStates, limitReductions);
 
@@ -264,7 +270,6 @@ public class WoodburyDcSecurityAnalysis extends DcSecurityAnalysis {
             NetworkState networkState = NetworkState.save(lfNetwork);
 
             List<PostContingencyResult> postContingencyResults = new ArrayList<>();
-
             LOGGER.info("Processing post contingency results for contingencies with no connectivity break");
             connectivityBreakAnalysisResults.nonBreakingConnectivityContingencies().forEach(
                     nonBreakingConnectivityContingency -> {

--- a/src/main/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysis.java
@@ -122,6 +122,7 @@ public class WoodburyDcSecurityAnalysis extends DcSecurityAnalysis {
             engine.toPostContingencyStates(newFlowStates);
             networkState.restore();
         }
+
         return newFlowStates;
     }
 
@@ -234,7 +235,6 @@ public class WoodburyDcSecurityAnalysis extends DcSecurityAnalysis {
             NetworkState networkState = NetworkState.save(lfNetwork);
 
             List<PostContingencyResult> postContingencyResults = new ArrayList<>();
-
             BiConsumer<PropagatedContingency, Supplier<double[]>> postContingencyResultAdder = (contingency, postContingencyStatesSupplier) -> {
                 contingency.toLfContingency(lfNetwork, false).ifPresent(lfContingency -> {
                     ReportNode postContSimReportNode = Reports.createPostContingencySimulation(context.getNetwork().getReportNode(), contingency.getContingency().getId());
@@ -253,9 +253,7 @@ public class WoodburyDcSecurityAnalysis extends DcSecurityAnalysis {
                     logPostContingencyEnd(context.getNetwork(), lfContingency, stopwatch);
 
                     postContingencyResults.add(postContingencyResult);
-                    // restore pre contingency states for next post contingency computation
-                    // FIXME : not sure this is mandatory to copy preContingency in workingContingency in case of connectivity break
-                    System.arraycopy(preContingencyStates, 0, workingContingencyStates, 0, preContingencyStates.length);
+                    // restore pre contingency state for next post contingency computation
                     networkState.restore();
                 });
             };
@@ -266,6 +264,8 @@ public class WoodburyDcSecurityAnalysis extends DcSecurityAnalysis {
                         Supplier<double[]> toPostContingencyStates = () -> calculatePostContingencyStatesForAContingency(context, connectivityBreakAnalysisResults.contingenciesStates(), workingContingencyStates, nonBreakingConnectivityContingency, connectivityBreakAnalysisResults.contingencyElementByBranch(),
                                         Collections.emptySet(), Collections.emptySet(), reportNode, Collections.emptySet());
                         postContingencyResultAdder.accept(nonBreakingConnectivityContingency, toPostContingencyStates);
+                        // update workingContingencyStates as it may have been updated by post contingency states calculation
+                        System.arraycopy(preContingencyStates, 0, workingContingencyStates, 0, preContingencyStates.length);
                     }
             );
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
The distinction between post contingency result computation is refactored in Woodbury DC Security Analysis.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
In current behavior, code is duplicated. The only difference between the two calculations is the method used to calculate post contingency states (conditionned by post contingency connectivity result).


**What is the new behavior (if this is a feature change)?**
The code is mutualized. 


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
