### PR TITLE
Add LfNetworkLoaderPostProcessor.onLfNetworkLoaded event

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/AbstractLfNetworkLoaderPostProcessor.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractLfNetworkLoaderPostProcessor.java
@@ -36,4 +36,9 @@ public abstract class AbstractLfNetworkLoaderPostProcessor implements LfNetworkL
     public void onAreaAdded(Object element, LfArea lfArea) {
         // to implement
     }
+
+    @Override
+    public void onLfNetworkLoaded(Object element, LfNetwork lfNetwork) {
+        // to implement
+    }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetworkLoaderPostProcessor.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetworkLoaderPostProcessor.java
@@ -37,4 +37,6 @@ public interface LfNetworkLoaderPostProcessor {
     void onInjectionAdded(Object element, LfBus lfBus);
 
     void onAreaAdded(Object element, LfArea lfArea);
+
+    void onLfNetworkLoaded(Object element, LfNetwork lfNetwork);
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -1028,6 +1028,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
             lfNetwork.writeGraphViz(debugDir.resolve("lfnetwork-" + dateStr + ".dot"), parameters.getLoadFlowModel());
         }
 
+        postProcessors.forEach(pp -> pp.onLfNetworkLoaded(network, lfNetwork));
         return lfNetwork;
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
`LfNetworkLoaderPostProcessor` notifies on element-per-element creation, but no global 'LfNetwork has been loaded' event is available, which could be useful for more complex post-processing tasks.


**What is the new behavior (if this is a feature change)?**
Add new  'LfNetwork has been loaded' event to `LfNetworkLoaderPostProcessor`.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
