### PR TITLE
Fix secondary synchronous components in main CC not computed in SA

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
@@ -252,7 +252,7 @@ public abstract class AbstractSecurityAnalysis<V extends Enum<V> & Quantity, E e
                                                          SecurityAnalysisParameters securityAnalysisParameters, List<OperatorStrategy> operatorStrategies,
                                                          List<Action> actions, List<LimitReduction> limitReductions, LoadFlowParameters lfParameters) {
 
-        List<LfNetwork> networkToSimulate = new ArrayList<>(getNetworkToSimulate(networks, lfParameters.getConnectedComponentMode()));
+        List<LfNetwork> networkToSimulate = new ArrayList<>(getNetworksToSimulate(networks, lfParameters.getConnectedComponentMode()));
 
         if (networkToSimulate.isEmpty()) {
             return createNoResult();
@@ -296,7 +296,7 @@ public abstract class AbstractSecurityAnalysis<V extends Enum<V> & Quantity, E e
         return new SecurityAnalysisResult(mergedPrecontingencyResult, postContingencyResults, operatorStrategyResults);
     }
 
-    static List<LfNetwork> getNetworkToSimulate(LfNetworkList networks, LoadFlowParameters.ConnectedComponentMode mode) {
+    static List<LfNetwork> getNetworksToSimulate(LfNetworkList networks, LoadFlowParameters.ConnectedComponentMode mode) {
 
         if (LoadFlowParameters.ConnectedComponentMode.MAIN.equals(mode)) {
             return networks.getList().stream()

--- a/src/test/java/com/powsybl/openloadflow/network/ConnectedComponentNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/ConnectedComponentNetworkFactory.java
@@ -8,6 +8,7 @@
 package com.powsybl.openloadflow.network;
 
 import com.powsybl.iidm.network.Bus;
+import com.powsybl.iidm.network.HvdcLine;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
 
@@ -753,6 +754,121 @@ public class ConnectedComponentNetworkFactory extends AbstractLoadFlowNetworkFac
         createGenerator(b5, "g3", 1);
         createLoad(b4, "d4", 3);
         createLoad(b2, "d2", 1);
+        return network;
+    }
+
+    public static Network createNoCc0Sc0() {
+        // b01 -- b02 -- b03 -- b04 connected by DC lines
+        // b11 -- b12 connected by AC line
+        Network network = Network.create("test", "code");
+        Bus b01 = createBus(network, "b01");
+        Bus b02 = createBus(network, "b02");
+        Bus b03 = createBus(network, "b03");
+        Bus b04 = createBus(network, "b04");
+        Bus b11 = createBus(network, "b11");
+        Bus b12 = createBus(network, "b12");
+
+        b01.getVoltageLevel()
+                .newVscConverterStation()
+                .setId("cs1-12")
+                .setConnectableBus(b01.getId())
+                .setBus(b01.getId())
+                .setVoltageRegulatorOn(true)
+                .setVoltageSetpoint(1.0)
+                .setReactivePowerSetpoint(0.0)
+                .setLossFactor(0.0f)
+                .add();
+        b02.getVoltageLevel()
+                .newVscConverterStation()
+                .setId("cs2-12")
+                .setConnectableBus(b02.getId())
+                .setBus(b02.getId())
+                .setVoltageRegulatorOn(true)
+                .setVoltageSetpoint(1.0)
+                .setReactivePowerSetpoint(0.0)
+                .setLossFactor(0.0f)
+                .add();
+        network.newHvdcLine()
+                .setId("hvdc12")
+                .setConverterStationId1("cs1-12")
+                .setConverterStationId2("cs2-12")
+                .setNominalV(1.)
+                .setR(0.0)
+                .setActivePowerSetpoint(1.)
+                .setConvertersMode(HvdcLine.ConvertersMode.SIDE_1_RECTIFIER_SIDE_2_INVERTER)
+                .setMaxP(5)
+                .add();
+
+        b02.getVoltageLevel()
+                .newVscConverterStation()
+                .setId("cs1-23")
+                .setConnectableBus(b02.getId())
+                .setBus(b02.getId())
+                .setVoltageRegulatorOn(true)
+                .setVoltageSetpoint(1.0)
+                .setReactivePowerSetpoint(0.0)
+                .setLossFactor(0.0f)
+                .add();
+        b03.getVoltageLevel()
+                .newVscConverterStation()
+                .setId("cs2-23")
+                .setConnectableBus(b03.getId())
+                .setBus(b03.getId())
+                .setVoltageRegulatorOn(true)
+                .setVoltageSetpoint(1.0)
+                .setReactivePowerSetpoint(0.0)
+                .setLossFactor(0.0f)
+                .add();
+        network.newHvdcLine()
+                .setId("hvdc23")
+                .setConverterStationId1("cs1-23")
+                .setConverterStationId2("cs2-23")
+                .setNominalV(1.)
+                .setR(0.0)
+                .setActivePowerSetpoint(2.)
+                .setConvertersMode(HvdcLine.ConvertersMode.SIDE_1_RECTIFIER_SIDE_2_INVERTER)
+                .setMaxP(5)
+                .add();
+
+        b03.getVoltageLevel()
+                .newVscConverterStation()
+                .setId("cs1-34")
+                .setConnectableBus(b03.getId())
+                .setBus(b03.getId())
+                .setVoltageRegulatorOn(true)
+                .setVoltageSetpoint(1.0)
+                .setReactivePowerSetpoint(0.0)
+                .setLossFactor(0.0f)
+                .add();
+        b04.getVoltageLevel()
+                .newVscConverterStation()
+                .setId("cs2-34")
+                .setConnectableBus(b04.getId())
+                .setBus(b04.getId())
+                .setVoltageRegulatorOn(true)
+                .setVoltageSetpoint(1.0)
+                .setReactivePowerSetpoint(0.0)
+                .setLossFactor(0.0f)
+                .add();
+        network.newHvdcLine()
+                .setId("hvdc34")
+                .setConverterStationId1("cs1-34")
+                .setConverterStationId2("cs2-34")
+                .setNominalV(1.)
+                .setR(0.0)
+                .setActivePowerSetpoint(3.)
+                .setConvertersMode(HvdcLine.ConvertersMode.SIDE_1_RECTIFIER_SIDE_2_INVERTER)
+                .setMaxP(5)
+                .add();
+
+        createGenerator(b01, "g01", 1);
+        createGenerator(b02, "g02", 1);
+        createGenerator(b03, "g03", 1);
+        createGenerator(b04, "g04", 1);
+        createLoad(b04, "l04", 4);
+        createGenerator(b11, "g11", 2);
+        createLoad(b12, "l11", 2);
+        createLine(network, b11, b12, "l11-12", 0.1f);
         return network;
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -3991,8 +3991,10 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(4, lfResultMain.getComponentResults().size()); // 4 SCs
 
         var saResultMain = runSecurityAnalysis(network, Collections.emptyList(), createNetworkMonitors(network), lfParametersMain);
+        assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, saResultMain.getPreContingencyResult().getStatus());
         assertEquals(4, saResultMain.getPreContingencyResult().getNetworkResult().getBusResults().size()); // 4 buses in CC0
         var saResultAll = runSecurityAnalysis(network, Collections.emptyList(), createNetworkMonitors(network), lfParametersAll);
+        assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, saResultAll.getPreContingencyResult().getStatus());
         assertEquals(6, saResultAll.getPreContingencyResult().getNetworkResult().getBusResults().size()); // 6 buses in total
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -3922,28 +3922,25 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         LfNetworkList networks = new LfNetworkList(Networks.load(network, new LfNetworkParameters().setComputeMainConnectedComponentOnly(false)));
         assertEquals(2, networks.getList().size());
 
-        assertEquals(ComponentConstants.MAIN_NUM, networks.getList().get(0).getNumCC());
-        assertEquals(ComponentConstants.MAIN_NUM, networks.getList().get(0).getNumSC());
-        assertEquals(ComponentConstants.MAIN_NUM, networks.getList().get(1).getNumCC());
+        assertEquals(0, networks.getList().get(0).getNumCC());
+        assertEquals(0, networks.getList().get(0).getNumSC());
+        assertEquals(0, networks.getList().get(1).getNumCC());
         assertEquals(1, networks.getList().get(1).getNumSC());
 
-        // Select Main CC/SC
-        Optional<LfNetwork> mainComponent = AbstractSecurityAnalysis.selectValidMainComponent(networks);
-        assertTrue(mainComponent.isPresent());
-        assertEquals(ComponentConstants.MAIN_NUM, mainComponent.get().getNumCC());
-        assertEquals(ComponentConstants.MAIN_NUM, mainComponent.get().getNumSC());
+        // Main connected component mode and all connected component mode should yield same result
+        List<LfNetwork> componentMain = AbstractSecurityAnalysis.getNetworkToSimulate(networks, LoadFlowParameters.ConnectedComponentMode.MAIN);
+        assertEquals(2, componentMain.size());
+        assertEquals(0, componentMain.get(0).getNumCC());
+        assertEquals(0, componentMain.get(0).getNumSC());
+        assertEquals(0, componentMain.get(1).getNumCC());
+        assertEquals(1, componentMain.get(1).getNumSC());
 
-        // Select secondary component of main CC
-        List<LfNetwork> secondaryComponentMain = AbstractSecurityAnalysis.selectValidSecondaryComponents(networks, LoadFlowParameters.ConnectedComponentMode.MAIN);
-        assertEquals(1, secondaryComponentMain.size());
-        assertEquals(ComponentConstants.MAIN_NUM, secondaryComponentMain.get(0).getNumCC());
-        assertEquals(1, secondaryComponentMain.get(0).getNumSC());
-
-        // Select all secondary components
-        List<LfNetwork> secondaryComponentAll = AbstractSecurityAnalysis.selectValidSecondaryComponents(networks, LoadFlowParameters.ConnectedComponentMode.ALL);
-        assertEquals(1, secondaryComponentAll.size());
-        assertEquals(ComponentConstants.MAIN_NUM, secondaryComponentAll.get(0).getNumCC());
-        assertEquals(1, secondaryComponentAll.get(0).getNumSC());
+        List<LfNetwork> componentAll = AbstractSecurityAnalysis.getNetworkToSimulate(networks, LoadFlowParameters.ConnectedComponentMode.ALL);
+        assertEquals(2, componentAll.size());
+        assertEquals(0, componentAll.get(0).getNumCC());
+        assertEquals(0, componentAll.get(0).getNumSC());
+        assertEquals(0, componentAll.get(1).getNumCC());
+        assertEquals(1, componentAll.get(1).getNumSC());
     }
 
     @Test
@@ -3952,27 +3949,24 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         LfNetworkList networks = new LfNetworkList(Networks.load(network, new LfNetworkParameters().setComputeMainConnectedComponentOnly(false)));
         assertEquals(2, networks.getList().size());
 
-        assertEquals(ComponentConstants.MAIN_NUM, networks.getList().get(0).getNumCC());
-        assertEquals(ComponentConstants.MAIN_NUM, networks.getList().get(0).getNumSC());
+        assertEquals(0, networks.getList().get(0).getNumCC());
+        assertEquals(0, networks.getList().get(0).getNumSC());
         assertEquals(1, networks.getList().get(1).getNumCC());
         assertEquals(1, networks.getList().get(1).getNumSC());
 
-        // Select Main CC/SC
-        Optional<LfNetwork> mainComponent = AbstractSecurityAnalysis.selectValidMainComponent(networks);
-        assertTrue(mainComponent.isPresent());
+        // Main connected component mode should only select component associated to main CC
+        List<LfNetwork> componentMain = AbstractSecurityAnalysis.getNetworkToSimulate(networks, LoadFlowParameters.ConnectedComponentMode.MAIN);
+        assertEquals(1, componentMain.size());
+        assertEquals(0, componentMain.get(0).getNumCC());
+        assertEquals(0, componentMain.get(0).getNumSC());
 
-        assertEquals(ComponentConstants.MAIN_NUM, mainComponent.get().getNumCC());
-        assertEquals(ComponentConstants.MAIN_NUM, mainComponent.get().getNumSC());
-
-        // Select secondary component of main CC (there is none)
-        List<LfNetwork> secondaryComponentMain = AbstractSecurityAnalysis.selectValidSecondaryComponents(networks, LoadFlowParameters.ConnectedComponentMode.MAIN);
-        assertEquals(0, secondaryComponentMain.size());
-
-        // Select secondary component of all CC (there is one)
-        List<LfNetwork> secondaryComponentAll = AbstractSecurityAnalysis.selectValidSecondaryComponents(networks, LoadFlowParameters.ConnectedComponentMode.ALL);
-        assertEquals(1, secondaryComponentAll.size());
-        assertEquals(1, secondaryComponentAll.get(0).getNumCC());
-        assertEquals(1, secondaryComponentAll.get(0).getNumSC());
+        // All connected component mode should select all component
+        List<LfNetwork> componentAll = AbstractSecurityAnalysis.getNetworkToSimulate(networks, LoadFlowParameters.ConnectedComponentMode.ALL);
+        assertEquals(2, componentAll.size());
+        assertEquals(0, componentAll.get(0).getNumCC());
+        assertEquals(0, componentAll.get(0).getNumSC());
+        assertEquals(1, componentAll.get(1).getNumCC());
+        assertEquals(1, componentAll.get(1).getNumSC());
     }
 
     @Test
@@ -3997,10 +3991,8 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(4, lfResultMain.getComponentResults().size()); // 4 SCs
 
         var saResultMain = runSecurityAnalysis(network, Collections.emptyList(), createNetworkMonitors(network), lfParametersMain);
-        // FIXME getting FAILED assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, saResultMain.getPreContingencyResult().getStatus());
         assertEquals(4, saResultMain.getPreContingencyResult().getNetworkResult().getBusResults().size()); // 4 buses in CC0
         var saResultAll = runSecurityAnalysis(network, Collections.emptyList(), createNetworkMonitors(network), lfParametersAll);
-        // FIXME getting FAILED assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, saResultAll.getPreContingencyResult().getStatus());
         assertEquals(6, saResultAll.getPreContingencyResult().getNetworkResult().getBusResults().size()); // 6 buses in total
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -3928,14 +3928,14 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(1, networks.getList().get(1).getNumSC());
 
         // Main connected component mode and all connected component mode should yield same result
-        List<LfNetwork> componentMain = AbstractSecurityAnalysis.getNetworkToSimulate(networks, LoadFlowParameters.ConnectedComponentMode.MAIN);
+        List<LfNetwork> componentMain = AbstractSecurityAnalysis.getNetworksToSimulate(networks, LoadFlowParameters.ConnectedComponentMode.MAIN);
         assertEquals(2, componentMain.size());
         assertEquals(0, componentMain.get(0).getNumCC());
         assertEquals(0, componentMain.get(0).getNumSC());
         assertEquals(0, componentMain.get(1).getNumCC());
         assertEquals(1, componentMain.get(1).getNumSC());
 
-        List<LfNetwork> componentAll = AbstractSecurityAnalysis.getNetworkToSimulate(networks, LoadFlowParameters.ConnectedComponentMode.ALL);
+        List<LfNetwork> componentAll = AbstractSecurityAnalysis.getNetworksToSimulate(networks, LoadFlowParameters.ConnectedComponentMode.ALL);
         assertEquals(2, componentAll.size());
         assertEquals(0, componentAll.get(0).getNumCC());
         assertEquals(0, componentAll.get(0).getNumSC());
@@ -3955,13 +3955,13 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(1, networks.getList().get(1).getNumSC());
 
         // Main connected component mode should only select component associated to main CC
-        List<LfNetwork> componentMain = AbstractSecurityAnalysis.getNetworkToSimulate(networks, LoadFlowParameters.ConnectedComponentMode.MAIN);
+        List<LfNetwork> componentMain = AbstractSecurityAnalysis.getNetworksToSimulate(networks, LoadFlowParameters.ConnectedComponentMode.MAIN);
         assertEquals(1, componentMain.size());
         assertEquals(0, componentMain.get(0).getNumCC());
         assertEquals(0, componentMain.get(0).getNumSC());
 
         // All connected component mode should select all component
-        List<LfNetwork> componentAll = AbstractSecurityAnalysis.getNetworkToSimulate(networks, LoadFlowParameters.ConnectedComponentMode.ALL);
+        List<LfNetwork> componentAll = AbstractSecurityAnalysis.getNetworksToSimulate(networks, LoadFlowParameters.ConnectedComponentMode.ALL);
         assertEquals(2, componentAll.size());
         assertEquals(0, componentAll.get(0).getNumCC());
         assertEquals(0, componentAll.get(0).getNumSC());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bugfix
Handle properly secondary synchronous component from main connected component in SA


**What is the current behavior?**
<!-- You can also link to an open issue here -->

Secondary synchronous component of main CC were ignored by the network selection on which we computed sa.


**What is the new behavior (if this is a feature change)?**

All component are now handled correctly and in a way similar as the load flow 👍 

MAIN component mode will compute SA on main connected and all its synchronous component.
ALL component mode will compute SA on all connected component and all synchronous component. 

**Does this PR introduce a breaking change or deprecate an API?**
- [x] No
