### PR TITLE
Fix busbar section minimal tripping

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/ContingencyTripping.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/ContingencyTripping.java
@@ -78,7 +78,7 @@ public class ContingencyTripping {
         Objects.requireNonNull(network);
         Objects.requireNonNull(bbs);
 
-        NodeBreakerTraverserFactory minimalTraverserFactory = (stoppingSwitches, neighbourTerminals, traversedTerminals, nbv) ->
+        NodeBreakerTraverserFactory minimalTraverserFactory = (stoppingSwitches, traversedTerminals, neighbourTerminals, nbv) ->
             // To have the minimal tripping ("no propagation") with a busbar section we still need to traverse the
             // voltage level starting from that busbar section, stopping at first switch encountered (which will be
             // marked as retained afterwards), in order to have the smallest lost bus in breaker view

--- a/src/test/java/com/powsybl/openloadflow/util/sa/ContingencyTrippingTest.java
+++ b/src/test/java/com/powsybl/openloadflow/util/sa/ContingencyTrippingTest.java
@@ -46,6 +46,19 @@ class ContingencyTrippingTest {
     }
 
     @Test
+    void testBusbarSectionTripping() {
+        Network network = NodeBreakerNetworkFactory.create();
+
+        Set<Switch> switchesToOpen = new HashSet<>();
+        Set<Terminal> terminalsToDisconnect = new HashSet<>();
+
+        ContingencyTripping.createBusbarSectionMinimalTripping(network, network.getBusbarSection("BBS3"))
+                .traverse(switchesToOpen, terminalsToDisconnect);
+        checkSwitches(switchesToOpen, "B3", "B4");
+        checkTerminalIds(terminalsToDisconnect, "LD", "BBS3");
+    }
+
+    @Test
     void testUnconnectedVoltageLevel() {
         Network network = NodeBreakerNetworkFactory.create();
         Exception unknownVl = assertThrows(PowsyblException.class,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
The tripping corresponding to a bbs contingency with no propagation adds the traversed terminals in the neigbours list.

**What is the new behavior (if this is a feature change)?**
The tripping corresponding to a bbs contingency with no propagation adds the visited terminals in the traversed terminals set.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No