### PR TITLE
Refacto lhs

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
@@ -80,7 +80,8 @@ public abstract class AbstractClosedBranchDcFlowEquationTerm extends AbstractEle
         double dph1 = dx.get(ph1Var.getRow(), column);
         double dph2 = dx.get(ph2Var.getRow(), column);
         double da1 = a1Var != null ? dx.get(a1Var.getRow(), column) : 0;
-        return eval(dph1, dph2, da1);
+        // - eval(0,0,0) to have an exact epression and remove the constant term of the affine function (wich is 0 in practe because A2 = 0)
+        return eval(dph1, dph2, da1) - eval(0, 0, 0);
     }
 
     protected double ph1(StateVector sv) {

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
@@ -80,7 +80,7 @@ public abstract class AbstractClosedBranchDcFlowEquationTerm extends AbstractEle
         double dph1 = dx.get(ph1Var.getRow(), column);
         double dph2 = dx.get(ph2Var.getRow(), column);
         double da1 = a1Var != null ? dx.get(a1Var.getRow(), column) : 0;
-        return calculateSensi(dph1, dph2, da1);
+        return eval(dph1, dph2, da1);
     }
 
     protected double ph1(StateVector sv) {
@@ -99,16 +99,17 @@ public abstract class AbstractClosedBranchDcFlowEquationTerm extends AbstractEle
         return ph2(sv);
     }
 
-    protected abstract double calculateSensi(double ph1, double ph2, double a1);
+    protected abstract double eval(double ph1, double ph2, double a1);
 
     @Override
     public double eval() {
-        return calculateSensi(ph1(), ph2(), a1());
+        return eval(ph1(), ph2(), a1());
     }
 
+    // TODO: Rename or REMOVE
     @Override
     public double eval(StateVector sv) {
-        return calculateSensi(ph1(sv), ph2(sv), a1(sv));
+        return eval(ph1(sv), ph2(sv), a1(sv));
     }
 
     protected double a1(StateVector sv) {

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/AbstractClosedBranchDcFlowEquationTerm.java
@@ -106,12 +106,6 @@ public abstract class AbstractClosedBranchDcFlowEquationTerm extends AbstractEle
         return eval(ph1(), ph2(), a1());
     }
 
-    // TODO: Rename or REMOVE
-    @Override
-    public double eval(StateVector sv) {
-        return eval(ph1(sv), ph2(sv), a1(sv));
-    }
-
     protected double a1(StateVector sv) {
         return a1Var != null ? sv.get(a1Var.getRow()) : element.getPiModel().getA1();
     }

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide1DcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide1DcFlowEquationTerm.java
@@ -36,7 +36,7 @@ public final class ClosedBranchSide1DcFlowEquationTerm extends AbstractClosedBra
     }
 
     @Override
-    protected double calculateSensi(double ph1, double ph2, double a1) {
+    protected double eval(double ph1, double ph2, double a1) {
         double deltaPhase = ph2 - ph1 + A2 - a1;
         return -power * deltaPhase;
     }

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide2DcFlowEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/ClosedBranchSide2DcFlowEquationTerm.java
@@ -36,7 +36,7 @@ public final class ClosedBranchSide2DcFlowEquationTerm extends AbstractClosedBra
     }
 
     @Override
-    protected double calculateSensi(double ph1, double ph2, double a1) {
+    protected double eval(double ph1, double ph2, double a1) {
         double deltaPhase = ph2 - ph1 + A2 - a1;
         return power * deltaPhase;
     }

--- a/src/main/java/com/powsybl/openloadflow/equations/Equation.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/Equation.java
@@ -156,9 +156,16 @@ public class Equation<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity
         for (EquationTerm<V, E> term : terms) {
             if (term.isActive()) {
                 value += term.eval();
-                if (term.hasRhs()) {
-                    value -= term.rhs();
-                }
+            }
+        }
+        return value;
+    }
+
+    public double evalLhs() {
+        double value = 0;
+        for (EquationTerm<V, E> term : terms) {
+            if (term.isActive()) {
+                value += term.evalLhs();
             }
         }
         return value;

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationTerm.java
@@ -186,14 +186,6 @@ public interface EquationTerm<V extends Enum<V> & Quantity, E extends Enum<E> & 
     }
 
     /**
-     * Evaluate the equation term with an alternative state vector.
-     * @return value of the equation term
-     */
-    default double eval(StateVector sv) {
-        throw new UnsupportedOperationException("Not implemented");
-    }
-
-    /**
      * Get partial derivative.
      *
      * @param variable the variable the partial derivative is with respect to

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationTerm.java
@@ -182,7 +182,7 @@ public interface EquationTerm<V extends Enum<V> & Quantity, E extends Enum<E> & 
      * @return value of the equation term
      */
     default double evalLhs() {
-        return eval() + (hasRhs() ? rhs() : 0);
+        return eval() - (hasRhs() ? rhs() : 0);
     }
 
     /**

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationTerm.java
@@ -178,6 +178,14 @@ public interface EquationTerm<V extends Enum<V> & Quantity, E extends Enum<E> & 
     double eval();
 
     /**
+     * Evaluate equation lhs of the equation term
+     * @return value of the equation term
+     */
+    default double evalLhs() {
+        return eval() + (hasRhs() ? rhs() : 0);
+    }
+
+    /**
      * Evaluate the equation term with an alternative state vector.
      * @return value of the equation term
      */

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationVector.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationVector.java
@@ -42,10 +42,10 @@ public class EquationVector<V extends Enum<V> & Quantity, E extends Enum<E> & Qu
         return array;
     }
 
-    private void eval(double[] array, List<Equation<V, E>> equations) {
+    private void evalLhs(double[] array, List<Equation<V, E>> equations) {
         Arrays.fill(array, 0); // necessary?
         for (Equation<V, E> equation : equations) {
-            array[equation.getColumn()] = equation.eval();
+            array[equation.getColumn()] = equation.evalLhs();
         }
     }
 
@@ -59,7 +59,7 @@ public class EquationVector<V extends Enum<V> & Quantity, E extends Enum<E> & Qu
             throw new IllegalArgumentException("Bad equation vector length: " + array.length);
         }
 
-        eval(array, equations);
+        evalLhs(array, equations);
 
         LOGGER.debug(PERFORMANCE_MARKER, "Equation vector updated in {} us", stopwatch.elapsed(TimeUnit.MICROSECONDS));
     }

--- a/src/main/java/com/powsybl/openloadflow/equations/InjectionDerivable.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/InjectionDerivable.java
@@ -62,12 +62,4 @@ public class InjectionDerivable<V extends Enum<V> & Quantity> implements Derivab
         return getBranchTermStream().anyMatch(EquationTerm::isActive);
     }
 
-    @Override
-    public double eval(StateVector sv) {
-        // The equation is
-        // rhs = VariableInjectionPart+ branchPart
-        // with rhs = - (cte injectionPart)  (for ex sum of targetQ)
-        // -branchPart = variableInjectionPart + cteInjectionPart
-        return -getBranchTermStream().mapToDouble(t -> t.eval(sv)).sum();
-    }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/util/ZeroImpedanceFlows.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ZeroImpedanceFlows.java
@@ -7,9 +7,7 @@
  */
 package com.powsybl.openloadflow.network.util;
 
-import com.powsybl.openloadflow.equations.EquationTerm;
 import com.powsybl.openloadflow.network.*;
-import com.powsybl.openloadflow.util.Evaluable;
 import org.jgrapht.Graph;
 import org.jgrapht.alg.interfaces.SpanningTreeAlgorithm;
 
@@ -165,26 +163,11 @@ public class ZeroImpedanceFlows {
         }
 
         private PQ getBranchFlow(LfBranch branch, LfBus bus) {
-            Evaluable pEvaluable;
-            Evaluable qEvaluable;
             if (branch.getBus1() != null && branch.getBus1().equals(bus)) {
-                pEvaluable = branch.getP1();
-                qEvaluable = branch.getQ1();
+                return new PQ(branch.getP1().eval(), branch.getQ1().eval());
             } else {
-                pEvaluable = branch.getP2();
-                qEvaluable = branch.getQ2();
+                return new PQ(branch.getP2().eval(), branch.getQ2().eval());
             }
-
-            double p = Double.NaN;
-            double q = Double.NaN;
-            if (pEvaluable instanceof EquationTerm equationTerm) {
-                p = equationTerm.eval();
-            }
-            if (qEvaluable instanceof EquationTerm equationTerm) {
-                q = equationTerm.eval();
-            }
-            return new PQ(p, q);
-
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/util/ZeroImpedanceFlows.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ZeroImpedanceFlows.java
@@ -178,10 +178,10 @@ public class ZeroImpedanceFlows {
             double p = Double.NaN;
             double q = Double.NaN;
             if (pEvaluable instanceof EquationTerm equationTerm) {
-                p = equationTerm.eval() - equationTerm.rhs();
+                p = equationTerm.eval();
             }
             if (qEvaluable instanceof EquationTerm equationTerm) {
-                q = equationTerm.eval() - equationTerm.rhs();
+                q = equationTerm.eval();
             }
             return new PQ(p, q);
 

--- a/src/main/java/com/powsybl/openloadflow/util/Derivable.java
+++ b/src/main/java/com/powsybl/openloadflow/util/Derivable.java
@@ -9,7 +9,6 @@ package com.powsybl.openloadflow.util;
 
 import com.powsybl.math.matrix.DenseMatrix;
 import com.powsybl.openloadflow.equations.Quantity;
-import com.powsybl.openloadflow.equations.StateVector;
 import com.powsybl.openloadflow.equations.Variable;
 
 /**
@@ -23,5 +22,4 @@ public interface Derivable <V extends Enum<V> & Quantity> extends Evaluable {
 
     boolean isActive();
 
-    double eval(StateVector sv);
 }

--- a/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowTest.java
@@ -202,32 +202,25 @@ class DcLoadFlowTest {
         Network network = PhaseShifterTestCaseFactory.create();
         network.getLine("L2").setX(0).setR(0);
         network.getTwoWindingsTransformer("PS1").getPhaseTapChanger().getStep(1).setAlpha(2);
-        // parameters.setDc(false);
         loadFlowRunner.run(network, parameters);
-
-        network.getBusBreakerView().getBusStream()
-                .forEach(b -> System.out.println(b.getId() + " " + b.getAngle()));
 
         assertEquals(16.5316, network.getLine("L1").getTerminal1().getP(), 0.01);
         assertEquals(83.4683, network.getLine("L2").getTerminal1().getP(), 0.01); // Temporary comment : P without fix = 133.87
         assertEquals(-83.4683, network.getTwoWindingsTransformer("PS1").getTerminal2().getP(), 0.01);
 
-        network.getBusBreakerView().getBusStream()
-                .forEach(b -> System.out.println(b.getId() + " " + b.getAngle()));
-
         // With e second zero impedance line and a second load
         VoltageLevel vl2 = network.getVoltageLevel("VL2");
-        Bus b2 = vl2.getBusBreakerView().newBus()
+        vl2.getBusBreakerView().newBus()
                 .setId("B2Bis")
                 .add();
-        Load ld2 = vl2.newLoad()
+        vl2.newLoad()
                 .setId("LD2Bis")
                 .setConnectableBus("B2Bis")
                 .setBus("B2Bis")
                 .setP0(100.0)
                 .setQ0(50.0)
                 .add();
-        Line l2Bis = network.newLine()
+        network.newLine()
                 .setId("L2Bis")
                 .setVoltageLevel1("VL3")
                 .setConnectableBus1("B3")
@@ -243,8 +236,8 @@ class DcLoadFlowTest {
                 .setB2(0.0)
                 .add();
         network.getGenerator("G1").setMaxP(500);
-        parameters.setDc(true);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isFullyConverged());
         assertEquals(49.86, network.getLine("L1").getTerminal1().getP(), 0.01);
         assertEquals(150.13, network.getTwoWindingsTransformer("PS1").getTerminal1().getP(), 0.01);
         assertEquals(0, network.getTwoWindingsTransformer("PS1").getTerminal2().getP() + network.getLine("L2").getTerminal1().getP() + network.getLine("L2Bis").getTerminal1().getP(), 0.01); // Temporary comment : P without fix = 133.87

--- a/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowTest.java
@@ -202,10 +202,18 @@ class DcLoadFlowTest {
         Network network = PhaseShifterTestCaseFactory.create();
         network.getLine("L2").setX(0).setR(0);
         network.getTwoWindingsTransformer("PS1").getPhaseTapChanger().getStep(1).setAlpha(2);
+        // parameters.setDc(false);
         loadFlowRunner.run(network, parameters);
+
+        network.getBusBreakerView().getBusStream()
+                .forEach(b -> System.out.println(b.getId() + " " + b.getAngle()));
+
         assertEquals(16.5316, network.getLine("L1").getTerminal1().getP(), 0.01);
         assertEquals(83.4683, network.getLine("L2").getTerminal1().getP(), 0.01); // Temporary comment : P without fix = 133.87
         assertEquals(-83.4683, network.getTwoWindingsTransformer("PS1").getTerminal2().getP(), 0.01);
+
+        network.getBusBreakerView().getBusStream()
+                .forEach(b -> System.out.println(b.getId() + " " + b.getAngle()));
 
         // With e second zero impedance line and a second load
         VoltageLevel vl2 = network.getVoltageLevel("VL2");
@@ -235,8 +243,10 @@ class DcLoadFlowTest {
                 .setB2(0.0)
                 .add();
         network.getGenerator("G1").setMaxP(500);
+        parameters.setDc(true);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
-        // assertEquals(16.5316, network.getLine("L1").getTerminal1().getP(), 0.01);
+        assertEquals(49.86, network.getLine("L1").getTerminal1().getP(), 0.01);
+        assertEquals(150.13, network.getTwoWindingsTransformer("PS1").getTerminal1().getP(), 0.01);
         assertEquals(0, network.getTwoWindingsTransformer("PS1").getTerminal2().getP() + network.getLine("L2").getTerminal1().getP() + network.getLine("L2Bis").getTerminal1().getP(), 0.01); // Temporary comment : P without fix = 133.87
         assertEquals(-200, network.getGenerator("G1").getTerminal().getP());
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
 This is another approach to fix #1137



**What kind of change does this PR introduce?**
Clairify the equation model:

     evallhs = target - rhs
and
    eval = evallhs - rhs

evallhs is used to solve equations
eval is used to get the equation or term quantity



**What is the current behavior?**
Errors seen with non impedant branches in DC near a PST or an HVDC in AC emulation with P0 non null.

Potental inconsitenscies each time a non null RHS is used



**What is the new behavior (if this is a feature change)?**
Error fixed


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ X No

