### PR TITLE
Fix slack distribution outerloop incorrect stable status

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/DistributedSlackOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/DistributedSlackOuterLoop.java
@@ -88,7 +88,7 @@ public class DistributedSlackOuterLoop
             contextData.addDistributedActivePower(-resultWbh.failedDistributedActivePower());
             return new OuterLoopResult(this, OuterLoopStatus.FAILED, resultWbh.failedMessage());
         } else {
-            return new OuterLoopResult(this, resultWbh.movedBuses() ? OuterLoopStatus.UNSTABLE : OuterLoopStatus.STABLE);
+            return new OuterLoopResult(this, Math.abs(distributedActivePower) > ActivePowerDistribution.P_RESIDUE_EPS || resultWbh.movedBuses() ? OuterLoopStatus.UNSTABLE : OuterLoopStatus.STABLE);
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/DistributedSlackOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/DistributedSlackOuterLoop.java
@@ -88,7 +88,7 @@ public class DistributedSlackOuterLoop
             contextData.addDistributedActivePower(-resultWbh.failedDistributedActivePower());
             return new OuterLoopResult(this, OuterLoopStatus.FAILED, resultWbh.failedMessage());
         } else {
-            return new OuterLoopResult(this, Math.abs(distributedActivePower) > ActivePowerDistribution.P_RESIDUE_EPS || resultWbh.movedBuses() ? OuterLoopStatus.UNSTABLE : OuterLoopStatus.STABLE);
+            return new OuterLoopResult(this, resultWbh.movedBuses() ? OuterLoopStatus.UNSTABLE : OuterLoopStatus.STABLE);
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
@@ -86,8 +86,10 @@ public final class ActivePowerDistribution {
             iteration++;
         }
 
-        final boolean movedBuses = Math.abs(initialP.entrySet().stream()
-                .mapToDouble(e -> e.getKey().getTargetP() - e.getValue()).sum()) > P_RESIDUE_EPS;
+        // Identify if injections moved significantly, used e.g. to establish stable/unstable outer loop status.
+        // The 0.9 magic factor is to handle potential rounding issues.
+        final boolean movedBuses = initialP.entrySet().stream()
+                .mapToDouble(e -> Math.abs(e.getKey().getTargetP() - e.getValue())).sum() > P_RESIDUE_EPS * 0.9;
 
         return new Result(iteration, remainingMismatch, movedBuses);
     }

--- a/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
+++ b/src/main/java/com/powsybl/openloadflow/network/util/ActivePowerDistribution.java
@@ -86,8 +86,8 @@ public final class ActivePowerDistribution {
             iteration++;
         }
 
-        final boolean movedBuses = initialP.entrySet().stream()
-                .anyMatch(e -> Math.abs(e.getKey().getTargetP() - e.getValue()) > P_RESIDUE_EPS);
+        final boolean movedBuses = Math.abs(initialP.entrySet().stream()
+                .mapToDouble(e -> e.getKey().getTargetP() - e.getValue()).sum()) > P_RESIDUE_EPS;
 
         return new Result(iteration, remainingMismatch, movedBuses);
     }

--- a/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
@@ -642,4 +642,14 @@ class DistributedSlackOnGenerationTest {
         assertActivePowerEquals(-90.000, g3.getTerminal());
         assertActivePowerEquals(-90.000, g4.getTerminal());
     }
+
+    @Test
+    void testEpsilonDistribution() {
+        parametersExt.setSlackBusPMaxMismatch(0.1);
+        network = DistributedSlackNetworkFactory.createWithEpsilonDistribution();
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isFullyConverged());
+        assertEquals(0.0, result.getComponentResults().get(0).getSlackBusResults().get(0).getActivePowerMismatch(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(0.15, result.getComponentResults().get(0).getDistributedActivePower(), LoadFlowAssert.DELTA_POWER);
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/network/DistributedSlackNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/DistributedSlackNetworkFactory.java
@@ -222,4 +222,15 @@ public class DistributedSlackNetworkFactory extends AbstractLoadFlowNetworkFacto
                 .add();
         return network;
     }
+
+    public static Network createWithEpsilonDistribution() {
+        // 0.15 MW slack mismatch to be distributed over 1000 generators
+        Network network = Network.create("distributed-generation-slack-bus", "code");
+        Bus b = createBus(network, "bus");
+        createLoad(b, "load", 1000.15);
+        for (int i = 0; i < 1000; i++) {
+            createGenerator(b, "g" + i, 1.0);
+        }
+        return network;
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
<del>Regression introduced in the #1148 refactoring.</del>
The root problem is not really the refactoring, actually the code before the refactor was hiding a bug. The real problem is the computation of the `movedBuses` indicator in `ActivePowerDistribution`.
In the following situation:
- the slack power to be distributed is small but above threshold, e.g. 0.15 MW vs. 0.10 MW threshold,
- and there are many elements over which we distribute the mismatch (e.g. 1000 elements)
then each element moves by only 0.000015 MW, below epsilon threshold. Consequently `ActivePowerDistribution` reports that no bus has moved.

Next Consequences:
- DistributedSlackOuterloop returns a stable status,
- no new NR is launched,
- result is not balanced at slack bus

**What is the new behavior (if this is a feature change)?**
`movedBuses` indicator in `ActivePowerDistribution` correctly accounts for many many small changes, by summing them instead of checking individual values.


**Does this PR introduce a breaking change or deprecate an API?**
- [X] No
