### PR TITLE
Fix injections ignored on first slack bus when using multiple slacks

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/AcTargetVector.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcTargetVector.java
@@ -66,8 +66,12 @@ public class AcTargetVector extends TargetVector<AcVariableType, AcEquationType>
 
     public static void init(Equation<AcVariableType, AcEquationType> equation, LfNetwork network, double[] targets) {
         switch (equation.getType()) {
-            case BUS_TARGET_P, BUS_DISTR_SLACK_P:
+            case BUS_TARGET_P :
                 targets[equation.getColumn()] = network.getBus(equation.getElementNum()).getTargetP();
+                break;
+
+            case BUS_DISTR_SLACK_P :
+                targets[equation.getColumn()] = network.getBus(equation.getElementNum()).getTargetP() - network.getSlackBuses().get(0).getTargetP();
                 break;
 
             case BUS_TARGET_Q:

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
@@ -1037,8 +1037,8 @@ public class AcEquationSystemCreator {
             for (int i = 1; i < slackBuses.size(); i++) {
                 LfBus slackBus = slackBuses.get(i);
                 // example for 3 slack buses
-                // target_p2 = slack_p2 - slack_p1
-                // target_p3 = slack_p3 - slack_p1
+                // target_p2 - target_p1 = slack_p2 - slack_p1
+                // target_p3 - target_p1 = slack_p3 - slack_p1
                 equationSystem.createEquation(slackBus, AcEquationType.BUS_DISTR_SLACK_P)
                         .addTerms(createActiveInjectionTerms(firstSlackBus, equationSystem.getVariableSet()).stream()
                                 .map(EquationTerm::minus)

--- a/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
@@ -173,8 +173,8 @@ class MultipleSlackBusesTest {
                 .setSlackBusPMaxMismatch(0.001)
                 .setPlausibleActivePowerLimit(10000); // IEEE14 Network has generators with maxP = 9999 we want to keep for distribution
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
-        double slackMismatch = result.getComponentResults().get(0).getDistributedActivePower();
-        assertEquals(ac ? -0.006 : -13.4, slackMismatch, 0.001);
+        double distributedActivePower = result.getComponentResults().get(0).getDistributedActivePower();
+        assertEquals(ac ? -0.006 : -13.4, distributedActivePower, 0.001);
         assertActivePowerEquals(ac ? -39.996 : -33.300, network.getGenerator("B2-G").getTerminal());
         assertActivePowerEquals(ac ? 156.886 : 153.453, network.getLine("L1-2-1").getTerminal1());
         assertActivePowerEquals(ac ? 56.131 : 54.768, network.getLine("L2-4-1").getTerminal1());

--- a/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
@@ -91,8 +91,8 @@ class MultipleSlackBusesTest {
     }
 
     static Stream<Arguments> allModelTypesAndNbSlackbuses() {
-        return Stream.concat(IntStream.range(1,5).mapToObj(i -> Arguments.of(true, i)),
-                IntStream.range(1,5).mapToObj(i -> Arguments.of(false, i)));
+        return Stream.concat(IntStream.range(1, 5).mapToObj(i -> Arguments.of(true, i)),
+                IntStream.range(1, 5).mapToObj(i -> Arguments.of(false, i)));
     }
 
     static Stream<Arguments> allModelTypes() {
@@ -171,14 +171,12 @@ class MultipleSlackBusesTest {
         parameters.setDc(!ac).setReadSlackBus(false);
         parametersExt.setMaxSlackBusCount(nbSlackbuses); // Testing from 1 to 4 slack buses and expecting same global mismatch
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
-        assertEquals(ac ? -0.006 : -13.4,
-                result.getComponentResults()
+        double slackMismatch = result.getComponentResults()
                 .get(0)
                 .getSlackBusResults()
                 .stream()
-                .mapToDouble(LoadFlowResult.SlackBusResult::getActivePowerMismatch).sum()
-        ,0.001);
-
+                .mapToDouble(LoadFlowResult.SlackBusResult::getActivePowerMismatch).sum();
+        assertEquals(ac ? -0.006 : -13.4, slackMismatch, 0.001);
     }
 
     @ParameterizedTest(name = "ac : {0}, switchSlacks : {1}")


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
A previous PR (https://github.com/powsybl/powsybl-open-loadflow/pull/1116) fixes injections that are ignored in slack buses when using multiple slacks. But actually, the problem is just partially solved because injections are still ignored when being in **the first** slack. This is due to the distribution equations.



**What is the current behavior?**
Example with 3 slack buses

Before the previous fix (#1116) we had these distribution equation between slacks :
slack_p2 - slack_p1 = 0
slack_p3 - slack_p1 = 0

After the previous fix (#1116) we had these distribution equation between slacks :
slack_p2 - slack_p1 = target_p2
slack_p3 - slack_p1 = target_p3

**What is the new behavior (if this is a feature change)?**

Now we have these distribution equation between slacks :
slack_p2 - slack_p1 = target_p2 - target_p1
slack_p3 - slack_p1 = target_p3 - target_p1


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
