### PR TITLE
[WIP] Returning real slack buses mismatches in SlackBusResult when using multiple slacks

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowProvider.java
@@ -191,13 +191,13 @@ public class OpenLoadFlowProvider implements LoadFlowProvider {
     private static ReferenceBusAndSlackBusesResults buildReferenceBusAndSlackBusesResults(AbstractLoadFlowResult result) {
         String referenceBusId = null;
         List<LoadFlowResult.SlackBusResult> slackBusResultList = new ArrayList<>();
-        double slackBusActivePowerMismatch = result.getSlackBusActivePowerMismatch() * PerUnit.SB;
+        //double slackBusActivePowerMismatch = result.getSlackBusActivePowerMismatch() * PerUnit.SB;
         if (result.getNetwork().getValidity() == LfNetwork.Validity.VALID) {
             referenceBusId = result.getNetwork().getReferenceBus().getId();
             List<LfBus> slackBuses = result.getNetwork().getSlackBuses();
             slackBusResultList = slackBuses.stream().map(
                     b -> (LoadFlowResult.SlackBusResult) new LoadFlowResultImpl.SlackBusResultImpl(b.getId(),
-                            slackBusActivePowerMismatch / slackBuses.size())).toList();
+                            b.getMismatchP() * PerUnit.SB)).toList();
         }
         return new ReferenceBusAndSlackBusesResults(referenceBusId, slackBusResultList);
     }

--- a/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/MultipleSlackBusesTest.java
@@ -95,8 +95,8 @@ class MultipleSlackBusesTest {
         assertEquals(expectedIterationCount, componentResult.getIterationCount());
 
         List<LoadFlowResult.SlackBusResult> slackBusResults = componentResult.getSlackBusResults();
-        double expectedSlackBusMismatch = ac ? -0.7164 : -3.5;
-        assertSlackBusResults(slackBusResults, expectedSlackBusMismatch, 2);
+        List<Double> expectedSlackBusMismatches = ac ? List.of(-0.7150, -0.7178) : List.of(-3.5, -3.5); // Mismatch values are not exactly the same between both slack buses
+        assertSlackBusResults(slackBusResults, expectedSlackBusMismatches, 2);
 
         if (ac) {
             assertActivePowerValues(302.807, 302.807, 600.868);
@@ -111,8 +111,8 @@ class MultipleSlackBusesTest {
         slackBusResults = componentResult.getSlackBusResults();
         expectedIterationCount = ac ? 4 : 0;
         assertEquals(expectedIterationCount, componentResult.getIterationCount());
-        expectedSlackBusMismatch = ac ? -0.005 : 0;
-        assertSlackBusResults(slackBusResults, expectedSlackBusMismatch, 2);
+        expectedSlackBusMismatches = ac ? List.of(-0.00576, -0.00572) : List.of(0d, 0d);
+        assertSlackBusResults(slackBusResults, expectedSlackBusMismatches, 2);
     }
 
     @ParameterizedTest(name = "ac : {0}")
@@ -128,8 +128,8 @@ class MultipleSlackBusesTest {
         int expectedIterationCount = ac ? 3 : 0;
         assertEquals(expectedIterationCount, componentResult.getIterationCount());
         List<LoadFlowResult.SlackBusResult> slackBusResults = componentResult.getSlackBusResults();
-        double expectedSlackBusMismatch = ac ? -2.755 : -3.5;
-        assertSlackBusResults(slackBusResults, expectedSlackBusMismatch, 2);
+        List<Double> expectedSlackBusMismatches = ac ? List.of(-2.7551, -2.7547) : List.of(-3.5, -3.5);
+        assertSlackBusResults(slackBusResults, expectedSlackBusMismatches, 2);
 
         if (ac) {
             assertActivePowerValues(603.567, 0.0, 600.812);
@@ -144,8 +144,8 @@ class MultipleSlackBusesTest {
         slackBusResults = componentResult.getSlackBusResults();
         expectedIterationCount = ac ? 4 : 0;
         assertEquals(expectedIterationCount, componentResult.getIterationCount());
-        expectedSlackBusMismatch = ac ? -0.005 : 0;
-        assertSlackBusResults(slackBusResults, expectedSlackBusMismatch, 2);
+        expectedSlackBusMismatches = ac ? List.of(-0.0054, -0.0056) : List.of(0d, 0d);
+        assertSlackBusResults(slackBusResults, expectedSlackBusMismatches, 2);
     }
 
     @ParameterizedTest(name = "ac : {0}")
@@ -162,8 +162,8 @@ class MultipleSlackBusesTest {
 
         List<LoadFlowResult.SlackBusResult> slackBusResults = componentResult.getSlackBusResults();
         assertEquals(List.of("VLHV2_0", "VLLOAD_0"), slackBusResults.stream().map(LoadFlowResult.SlackBusResult::getId).toList());
-        double expectedSlackBusMismatch = ac ? -0.711 : -3.5;
-        assertSlackBusResults(slackBusResults, expectedSlackBusMismatch, 2);
+        List<Double> expectedSlackBusMismatches = ac ? List.of(-0.7118, -0.7108) : List.of(-3.5, -3.5);
+        assertSlackBusResults(slackBusResults, expectedSlackBusMismatches, 2);
 
         if (ac) {
             assertActivePowerValues(303.165, 303.165, 601.58);
@@ -180,10 +180,11 @@ class MultipleSlackBusesTest {
         assertActivePowerEquals(-607, generator.getTerminal());
     }
 
-    void assertSlackBusResults(List<LoadFlowResult.SlackBusResult> slackBusResults, double expectedMismatch, int slackBusCount) {
+    void assertSlackBusResults(List<LoadFlowResult.SlackBusResult> slackBusResults, List<Double> expectedMismatches, int slackBusCount) {
         assertEquals(slackBusCount, slackBusResults.size());
+        int i = 0;
         for (LoadFlowResult.SlackBusResult slackBusResult : slackBusResults) {
-            assertEquals(expectedMismatch, slackBusResult.getActivePowerMismatch(), LoadFlowAssert.DELTA_POWER);
+            assertEquals(expectedMismatches.get(i++), slackBusResult.getActivePowerMismatch(), LoadFlowAssert.DELTA_POWER);
         }
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowTest.java
@@ -553,7 +553,7 @@ class DcLoadFlowTest {
         assertEquals(1, result.getComponentResults().size());
         assertEquals(LoadFlowResult.ComponentResult.Status.FAILED, result.getComponentResults().get(0).getStatus());
         assertEquals("Outer loop failed: Failed to distribute slack bus active power mismatch, 321.90 MW remains", result.getComponentResults().get(0).getStatusText());
-        assertEquals(321.9, result.getComponentResults().get(0).getSlackBusResults().get(0).getActivePowerMismatch(), 0.01);
+        assertEquals(-73.9, result.getComponentResults().get(0).getSlackBusResults().get(0).getActivePowerMismatch(), 0.01); // The actual slack bus mismatch is the initial mismatch since distribution has failed
         assertEquals(0, result.getComponentResults().get(0).getDistributedActivePower(), 0.01);
         assertReportContains("Failed to distribute slack bus active power mismatch, [-+]?321\\.\\d* MW remains", reportNode);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
When using multi-slack, the returned slack buses result returned the same mismatch for all the slackbuses which is. This approach can be wrong because the mismatches may not be exactly the same between slack buses depending on the solver criterias. 
Moreover, this led to hide a wrong slack distribution use case (fixed in #1160) where the global mismatch was almost zero but unequally distributed between slack buses (because of the presence of a load in the first slack and wrong equation definition in this case).

This PR proposes to display the real mismatch in each slack bus independently.

**What is the current behavior?**
Currently, the component result has a SlackBusResult list containing the same mismatch for each slack bus which equals to : SlackBusMismatch/nbSlack.

**What is the new behavior (if this is a feature change)?**
In the new behavior, each SlackBusResult has a mismatch corresponding to SlackBus.getMismatchP(). 
NB : This introduces a functional change which is the handling of SlackbusFailureBehaviour.FAIL which leads to have the initial mismatch as the displayed mismatch in each bus since no distribution has been done.

A cleaner way to do such a change would be to introduce the breaking change of having SlackBusResult list instead of a SlackBusActivePowerMismatch in the LoadFlowResult interface in order to display only data that is contained in the LoadFlow result (instead of computing each MismatchP in the final network to retreive the correct mismatches) but such a major refactoring is not done in this PR. This can be discussed.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
