### PR TITLE
Fix performance issue when accessing loading limits from IIDM

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.function.Supplier;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -132,16 +133,22 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
         return bus2;
     }
 
-    public List<LfLimit> getLimits1(LimitType type, LoadingLimits loadingLimits, LimitReductionManager limitReductionManager) {
+    public <T extends LoadingLimits> List<LfLimit> getLimits1(LimitType type, Supplier<Optional<T>> loadingLimitsSupplier, LimitReductionManager limitReductionManager) {
         // It is possible to apply the reductions here since the only supported ContingencyContext for LimitReduction is ALL.
-        return limits1.computeIfAbsent(type, v -> createSortedLimitsList(loadingLimits, bus1,
-                getLimitReductions(TwoSides.ONE, limitReductionManager, loadingLimits)));
+        return limits1.computeIfAbsent(type, v -> {
+            var loadingLimits = loadingLimitsSupplier.get().orElse(null);
+            return createSortedLimitsList(loadingLimits, bus1,
+                    getLimitReductions(TwoSides.ONE, limitReductionManager, loadingLimits));
+        });
     }
 
-    public List<LfLimit> getLimits2(LimitType type, LoadingLimits loadingLimits, LimitReductionManager limitReductionManager) {
+    public <T extends LoadingLimits> List<LfLimit> getLimits2(LimitType type, Supplier<Optional<T>> loadingLimitsSupplier, LimitReductionManager limitReductionManager) {
         // It is possible to apply the reductions here since the only supported ContingencyContext for LimitReduction is ALL.
-        return limits2.computeIfAbsent(type, v -> createSortedLimitsList(loadingLimits, bus2,
-                getLimitReductions(TwoSides.TWO, limitReductionManager, loadingLimits)));
+        return limits2.computeIfAbsent(type, v -> {
+            var loadingLimits = loadingLimitsSupplier.get().orElse(null);
+            return createSortedLimitsList(loadingLimits, bus2,
+                    getLimitReductions(TwoSides.TWO, limitReductionManager, loadingLimits));
+        });
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
@@ -237,11 +237,11 @@ public class LfBranchImpl extends AbstractImpedantLfBranch {
         var branch = getBranch();
         switch (type) {
             case ACTIVE_POWER:
-                return getLimits1(type, branch.getActivePowerLimits1().orElse(null), limitReductionManager);
+                return getLimits1(type, branch::getActivePowerLimits1, limitReductionManager);
             case APPARENT_POWER:
-                return getLimits1(type, branch.getApparentPowerLimits1().orElse(null), limitReductionManager);
+                return getLimits1(type, branch::getApparentPowerLimits1, limitReductionManager);
             case CURRENT:
-                return getLimits1(type, branch.getCurrentLimits1().orElse(null), limitReductionManager);
+                return getLimits1(type, branch::getCurrentLimits1, limitReductionManager);
             case VOLTAGE:
             default:
                 throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));
@@ -253,11 +253,11 @@ public class LfBranchImpl extends AbstractImpedantLfBranch {
         var branch = getBranch();
         switch (type) {
             case ACTIVE_POWER:
-                return getLimits2(type, branch.getActivePowerLimits2().orElse(null), limitReductionManager);
+                return getLimits2(type, branch::getActivePowerLimits2, limitReductionManager);
             case APPARENT_POWER:
-                return getLimits2(type, branch.getApparentPowerLimits2().orElse(null), limitReductionManager);
+                return getLimits2(type, branch::getApparentPowerLimits2, limitReductionManager);
             case CURRENT:
-                return getLimits2(type, branch.getCurrentLimits2().orElse(null), limitReductionManager);
+                return getLimits2(type, branch::getCurrentLimits2, limitReductionManager);
             case VOLTAGE:
             default:
                 throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
@@ -83,11 +83,11 @@ public class LfDanglingLineBranch extends AbstractImpedantLfBranch {
         var danglingLine = getDanglingLine();
         switch (type) {
             case ACTIVE_POWER:
-                return getLimits1(type, danglingLine.getActivePowerLimits().orElse(null), limitReductionManager);
+                return getLimits1(type, danglingLine::getActivePowerLimits, limitReductionManager);
             case APPARENT_POWER:
-                return getLimits1(type, danglingLine.getApparentPowerLimits().orElse(null), limitReductionManager);
+                return getLimits1(type, danglingLine::getApparentPowerLimits, limitReductionManager);
             case CURRENT:
-                return getLimits1(type, danglingLine.getCurrentLimits().orElse(null), limitReductionManager);
+                return getLimits1(type, danglingLine::getCurrentLimits, limitReductionManager);
             case VOLTAGE:
             default:
                 throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
@@ -150,11 +150,11 @@ public final class LfLegBranch extends AbstractImpedantLfBranch {
         var leg = getLeg();
         switch (type) {
             case ACTIVE_POWER:
-                return getLimits1(type, leg.getActivePowerLimits().orElse(null), limitReductionManager);
+                return getLimits1(type, leg::getActivePowerLimits, limitReductionManager);
             case APPARENT_POWER:
-                return getLimits1(type, leg.getApparentPowerLimits().orElse(null), limitReductionManager);
+                return getLimits1(type, leg::getApparentPowerLimits, limitReductionManager);
             case CURRENT:
-                return getLimits1(type, leg.getCurrentLimits().orElse(null), limitReductionManager);
+                return getLimits1(type, leg::getCurrentLimits, limitReductionManager);
             case VOLTAGE:
             default:
                 throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfTieLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfTieLineBranch.java
@@ -105,11 +105,11 @@ public class LfTieLineBranch extends AbstractImpedantLfBranch {
     public List<LfLimit> getLimits1(final LimitType type, LimitReductionManager limitReductionManager) {
         switch (type) {
             case ACTIVE_POWER:
-                return getLimits1(type, getHalf1().getActivePowerLimits().orElse(null), limitReductionManager);
+                return getLimits1(type, getHalf1()::getActivePowerLimits, limitReductionManager);
             case APPARENT_POWER:
-                return getLimits1(type, getHalf1().getApparentPowerLimits().orElse(null), limitReductionManager);
+                return getLimits1(type, getHalf1()::getApparentPowerLimits, limitReductionManager);
             case CURRENT:
-                return getLimits1(type, getHalf1().getCurrentLimits().orElse(null), limitReductionManager);
+                return getLimits1(type, getHalf1()::getCurrentLimits, limitReductionManager);
             case VOLTAGE:
             default:
                 throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));
@@ -120,11 +120,11 @@ public class LfTieLineBranch extends AbstractImpedantLfBranch {
     public List<LfLimit> getLimits2(final LimitType type, LimitReductionManager limitReductionManager) {
         switch (type) {
             case ACTIVE_POWER:
-                return getLimits2(type, getHalf2().getActivePowerLimits().orElse(null), limitReductionManager);
-            case APPARENT_POWER:
-                return getLimits2(type, getHalf2().getApparentPowerLimits().orElse(null), limitReductionManager);
+                return getLimits2(type, getHalf2()::getActivePowerLimits, limitReductionManager);
             case CURRENT:
-                return getLimits2(type, getHalf2().getCurrentLimits().orElse(null), limitReductionManager);
+                return getLimits2(type, getHalf2()::getCurrentLimits, limitReductionManager);
+            case APPARENT_POWER:
+                return getLimits2(type, getHalf2()::getApparentPowerLimits, limitReductionManager);
             case VOLTAGE:
             default:
                 throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfTieLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfTieLineBranch.java
@@ -121,10 +121,10 @@ public class LfTieLineBranch extends AbstractImpedantLfBranch {
         switch (type) {
             case ACTIVE_POWER:
                 return getLimits2(type, getHalf2()::getActivePowerLimits, limitReductionManager);
-            case CURRENT:
-                return getLimits2(type, getHalf2()::getCurrentLimits, limitReductionManager);
             case APPARENT_POWER:
                 return getLimits2(type, getHalf2()::getApparentPowerLimits, limitReductionManager);
+            case CURRENT:
+                return getLimits2(type, getHalf2()::getCurrentLimits, limitReductionManager);
             case VOLTAGE:
             default:
                 throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Performance issue


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Security analysis profiling shows that we spend a lot of time accessing limit violation from the IIDM network. 


**What is the new behavior (if this is a feature change)?**
There is an issue with the way LfLimit creation from IIDM limits and caching is done. The IIDM access is done at each call even if LfLimit has already been created and cached.
I guess this issue (already ever present) is more visible since we have added operationnal limits in IIDM because we now have an indirection when accessing an operational limit group (using the current limit group and going though a Map access).
This issus is easily solved by passing a Supplier of IIDM limit.

Example of benchmark on a 6000 buses network and a 3000 N-1 line contingencies security analysis:
before this PR: 64s
with this PR: 52s


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
