### PR TITLE
Load active power target caching

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/LfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBus.java
@@ -90,6 +90,8 @@ public interface LfBus extends LfElement {
 
     double getTargetQ();
 
+    void invalidateLoadTargetP();
+
     double getLoadTargetP();
 
     double getNonFictitiousLoadTargetP();

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -386,7 +386,10 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     @Override
     public double getGenerationTargetP() {
         if (generationTargetP == null) {
-            generationTargetP = generators.stream().mapToDouble(LfGenerator::getTargetP).sum();
+            generationTargetP = 0.0;
+            for (LfGenerator generator : generators) {
+                generationTargetP += generator.getTargetP();
+            }
         }
         return generationTargetP;
     }
@@ -415,9 +418,10 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     @Override
     public double getLoadTargetP() {
         if (loadTargetP == null) {
-            loadTargetP = loads.stream()
-                    .mapToDouble(load -> load.getTargetP() * load.getLoadModel().flatMap(lm -> lm.getExpTermP(0).map(LfLoadModel.ExpTerm::c)).orElse(1d))
-                    .sum();
+            loadTargetP = 0.0;
+            for (LfLoad load : loads) {
+                loadTargetP += load.getTargetP() * load.getLoadModel().flatMap(lm -> lm.getExpTermP(0).map(LfLoadModel.ExpTerm::c)).orElse(1d);
+            }
         }
         return loadTargetP;
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -65,6 +65,8 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
 
     protected final List<LfLoad> loads = new ArrayList<>();
 
+    protected Double loadTargetP;
+
     protected final List<LfBranch> branches = new ArrayList<>();
 
     protected final List<LfHvdc> hvdcs = new ArrayList<>();
@@ -406,10 +408,18 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
     }
 
     @Override
+    public void invalidateLoadTargetP() {
+        loadTargetP = null;
+    }
+
+    @Override
     public double getLoadTargetP() {
-        return loads.stream()
-                .mapToDouble(load -> load.getTargetP() * load.getLoadModel().flatMap(lm -> lm.getExpTermP(0).map(LfLoadModel.ExpTerm::c)).orElse(1d))
-                .sum();
+        if (loadTargetP == null) {
+            loadTargetP = loads.stream()
+                    .mapToDouble(load -> load.getTargetP() * load.getLoadModel().flatMap(lm -> lm.getExpTermP(0).map(LfLoadModel.ExpTerm::c)).orElse(1d))
+                    .sum();
+        }
+        return loadTargetP;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLoadImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLoadImpl.java
@@ -130,6 +130,7 @@ public class LfLoadImpl extends AbstractLfInjection implements LfLoad {
         if (targetP != this.targetP) {
             double oldTargetP = this.targetP;
             this.targetP = targetP;
+            bus.invalidateLoadTargetP();
             for (LfNetworkListener listener : bus.getNetwork().getListeners()) {
                 listener.onLoadActivePowerTargetChange(this, oldTargetP, targetP);
             }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Perfs improvement


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When profiling a DC security analysis we get 2.8% if the time spent in calculating bus active power. Generation part is alreadu cached bu not load part.
![image](https://github.com/user-attachments/assets/108a9510-9374-4edd-a052-f5db6c7dfca4)

**What is the new behavior (if this is a feature change)?**

After caching also the load part, we get twice faster.
![image](https://github.com/user-attachments/assets/eb385a88-a4ae-43f1-ad4e-2d61cd9d755a)

After using a traditionnal loop instead of a stream, we get 0;
![image](https://github.com/user-attachments/assets/fdcf1e49-3e6d-420e-b7e8-b4a9c6d56bbc)



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
