### PR TITLE
[WIP] Remember PV-PQ switch count in SA and sensi

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/AcLoadFlowFromCache.java
+++ b/src/main/java/com/powsybl/openloadflow/AcLoadFlowFromCache.java
@@ -24,6 +24,7 @@ import com.powsybl.openloadflow.network.impl.Networks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -120,7 +121,10 @@ public class AcLoadFlowFromCache {
             context.setNetworkUpdated(false);
             return result;
         }
-        return new AcLoadFlowResult(context.getNetwork(), 0, 0, AcSolverStatus.CONVERGED, OuterLoopResult.stable(), 0d, 0d);
+        return new AcLoadFlowResult(context.getNetwork(), 0,
+                0, AcSolverStatus.CONVERGED, OuterLoopResult.stable(),
+                0d, 0d,
+                Collections.EMPTY_MAP);
     }
 
     public List<AcLoadFlowResult> run() {

--- a/src/main/java/com/powsybl/openloadflow/ac/AcLoadFlowContext.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcLoadFlowContext.java
@@ -8,6 +8,7 @@
 package com.powsybl.openloadflow.ac;
 
 import com.powsybl.openloadflow.ac.equations.asym.AsymmetricalAcEquationSystemCreator;
+import com.powsybl.openloadflow.ac.outerloop.AcOuterLoop;
 import com.powsybl.openloadflow.equations.JacobianMatrix;
 import com.powsybl.openloadflow.lf.AbstractLoadFlowContext;
 import com.powsybl.openloadflow.ac.equations.AcEquationSystemCreator;
@@ -17,6 +18,9 @@ import com.powsybl.openloadflow.equations.EquationSystem;
 import com.powsybl.openloadflow.equations.EquationVector;
 import com.powsybl.openloadflow.equations.TargetVector;
 import com.powsybl.openloadflow.network.LfNetwork;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -30,6 +34,8 @@ public class AcLoadFlowContext extends AbstractLoadFlowContext<AcVariableType, A
     private AcLoadFlowResult result;
 
     private boolean networkUpdated = true;
+
+    private Map<Class<? extends AcOuterLoop>, Object> outerLoopInitData = new HashMap<>();
 
     public AcLoadFlowContext(LfNetwork network, AcLoadFlowParameters parameters) {
         super(network, parameters);
@@ -82,6 +88,14 @@ public class AcLoadFlowContext extends AbstractLoadFlowContext<AcVariableType, A
 
     public void setNetworkUpdated(boolean networkUpdated) {
         this.networkUpdated = networkUpdated;
+    }
+
+    public Object getOuterLoopInitData(Class<? extends AcOuterLoop> outerLoopClass) {
+        return outerLoopInitData.get(outerLoopClass);
+    }
+
+    public void setOuterLoopInitData(Map<Class<? extends AcOuterLoop>, Object> outerLoopInitData) {
+        this.outerLoopInitData = outerLoopInitData;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/ac/AcLoadFlowResult.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcLoadFlowResult.java
@@ -8,6 +8,7 @@
 package com.powsybl.openloadflow.ac;
 
 import com.powsybl.loadflow.LoadFlowResult;
+import com.powsybl.openloadflow.ac.outerloop.AcOuterLoop;
 import com.powsybl.openloadflow.ac.solver.AcSolverStatus;
 import com.powsybl.openloadflow.lf.AbstractLoadFlowResult;
 import com.powsybl.openloadflow.lf.outerloop.OuterLoopResult;
@@ -15,6 +16,8 @@ import com.powsybl.openloadflow.lf.outerloop.OuterLoopStatus;
 import com.powsybl.openloadflow.network.LfNetwork;
 import com.powsybl.openloadflow.util.PerUnit;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -23,19 +26,24 @@ import java.util.Objects;
 public class AcLoadFlowResult extends AbstractLoadFlowResult {
 
     public static AcLoadFlowResult createNoCalculationResult(LfNetwork network) {
-        return new AcLoadFlowResult(network, 0, 0, AcSolverStatus.NO_CALCULATION, OuterLoopResult.stable(), Double.NaN, Double.NaN);
+        return new AcLoadFlowResult(network, 0, 0, AcSolverStatus.NO_CALCULATION, OuterLoopResult.stable(), Double.NaN, Double.NaN,
+                Collections.EMPTY_MAP);
     }
 
     private final int solverIterations;
 
     private final AcSolverStatus solverStatus;
 
+    private final Map<Class<? extends AcOuterLoop>, Object> outerLoopInitData;
+
     public AcLoadFlowResult(LfNetwork network, int outerLoopIterations, int solverIterations,
                             AcSolverStatus solverStatus, OuterLoopResult outerLoopResult,
-                            double slackBusActivePowerMismatch, double distributedActivePower) {
+                            double slackBusActivePowerMismatch, double distributedActivePower,
+                            Map<Class<? extends AcOuterLoop>, Object> outerLoopInitData) {
         super(network, slackBusActivePowerMismatch, outerLoopIterations, outerLoopResult, distributedActivePower);
         this.solverIterations = solverIterations;
         this.solverStatus = Objects.requireNonNull(solverStatus);
+        this.outerLoopInitData = outerLoopInitData;
     }
 
     public int getSolverIterations() {
@@ -77,6 +85,10 @@ public class AcLoadFlowResult extends AbstractLoadFlowResult {
                 case NO_CALCULATION -> new Status(LoadFlowResult.ComponentResult.Status.NO_CALCULATION, "No calculation");
             };
         }
+    }
+
+    public Map<Class<? extends AcOuterLoop>, Object> getOuterLoopInitData() {
+        return outerLoopInitData;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/ac/AcOuterLoopContext.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcOuterLoopContext.java
@@ -13,15 +13,23 @@ import com.powsybl.openloadflow.ac.solver.AcSolverResult;
 import com.powsybl.openloadflow.lf.outerloop.AbstractOuterLoopContext;
 import com.powsybl.openloadflow.network.LfNetwork;
 
+import java.util.Optional;
+
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AcOuterLoopContext extends AbstractOuterLoopContext<AcVariableType, AcEquationType, AcLoadFlowParameters, AcLoadFlowContext> {
 
     private AcSolverResult lastSolverResult;
+    private Object outerLoopInitData;
 
-    AcOuterLoopContext(LfNetwork network) {
+    AcOuterLoopContext(LfNetwork network, Object dataForRunFromPreviousValues) {
         super(network);
+        this.outerLoopInitData = dataForRunFromPreviousValues;
+    }
+
+    public Optional<Object> getOuterLoopInitData() {
+        return Optional.ofNullable(outerLoopInitData);
     }
 
     public AcSolverResult getLastSolverResult() {

--- a/src/main/java/com/powsybl/openloadflow/ac/AcloadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcloadFlowEngine.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -138,7 +139,7 @@ public class AcloadFlowEngine implements LoadFlowEngine<AcVariableType, AcEquati
             LOGGER.info("Network must have at least one bus with generator voltage control enabled");
             Reports.reportNetworkMustHaveAtLeastOneBusGeneratorVoltageControlEnabled(reportNode);
             runningContext.lastSolverResult = new AcSolverResult(AcSolverStatus.SOLVER_FAILED, 0, Double.NaN);
-            return buildAcLoadFlowResult(runningContext, OuterLoopResult.stable(), distributedActivePower);
+            return buildAcLoadFlowResult(runningContext, OuterLoopResult.stable(), distributedActivePower, Collections.EMPTY_LIST);
         }
 
         AcSolver solver = solverFactory.create(context.getNetwork(),
@@ -150,7 +151,7 @@ public class AcloadFlowEngine implements LoadFlowEngine<AcVariableType, AcEquati
 
         List<AcOuterLoop> outerLoops = context.getParameters().getOuterLoops();
         List<Pair<AcOuterLoop, AcOuterLoopContext>> outerLoopsAndContexts = outerLoops.stream()
-                .map(outerLoop -> Pair.of(outerLoop, new AcOuterLoopContext(context.getNetwork())))
+                .map(outerLoop -> Pair.of(outerLoop, new AcOuterLoopContext(context.getNetwork(), context.getOuterLoopInitData(outerLoop.getClass()))))
                 .toList();
 
         // outer loops initialization
@@ -218,17 +219,25 @@ public class AcloadFlowEngine implements LoadFlowEngine<AcVariableType, AcEquati
                     new OuterLoopResult(runningContext.lastOuterLoopResult.outerLoopName(), OuterLoopStatus.UNSTABLE, runningContext.lastOuterLoopResult.statusText());
         }
 
-        return buildAcLoadFlowResult(runningContext, outerLoopFinalResult, distributedActivePower);
+        return buildAcLoadFlowResult(runningContext, outerLoopFinalResult, distributedActivePower, outerLoopsAndContexts);
     }
 
-    private AcLoadFlowResult buildAcLoadFlowResult(RunningContext runningContext, OuterLoopResult outerLoopFinalResult, double distributedActivePower) {
+    private AcLoadFlowResult buildAcLoadFlowResult(RunningContext runningContext,
+                                                   OuterLoopResult outerLoopFinalResult,
+                                                   double distributedActivePower,
+                                                   List<Pair<AcOuterLoop, AcOuterLoopContext>> outerLoopsAndContexts) {
+
+        Map<Class<? extends AcOuterLoop>, Object> outerLoopInitData = new HashMap<>();
+        outerLoopsAndContexts.forEach(p -> p.getLeft().getInitData(p.getRight()).ifPresent(d -> outerLoopInitData.put(p.getLeft().getClass(), d)));
+
         AcLoadFlowResult result = new AcLoadFlowResult(context.getNetwork(),
                                                        runningContext.outerLoopTotalIterations,
                                                        runningContext.nrTotalIterations.getValue(),
                                                        runningContext.lastSolverResult.getStatus(),
                                                        outerLoopFinalResult,
                                                        runningContext.lastSolverResult.getSlackBusActivePowerMismatch(),
-                                                       distributedActivePower
+                                                       distributedActivePower,
+                                                       outerLoopInitData
                                                        );
 
         LOGGER.info("AC loadflow complete on network {} (result={})", context.getNetwork(), result);

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcOuterLoop.java
@@ -14,8 +14,17 @@ import com.powsybl.openloadflow.ac.equations.AcEquationType;
 import com.powsybl.openloadflow.ac.equations.AcVariableType;
 import com.powsybl.openloadflow.lf.outerloop.OuterLoop;
 
+import java.util.Optional;
+
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface AcOuterLoop extends OuterLoop<AcVariableType, AcEquationType, AcLoadFlowParameters, AcLoadFlowContext, AcOuterLoopContext> {
+
+    /**
+     * Returns data needed to initialize the outerloop for a rerun from previous values.
+     */
+    default Optional<Object> getInitData(AcOuterLoopContext context) {
+        return Optional.empty();
+    }
 }

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/ReactiveLimitsOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/ReactiveLimitsOuterLoop.java
@@ -56,6 +56,14 @@ public class ReactiveLimitsOuterLoop implements AcOuterLoop {
 
         private final Map<String, MutableInt> pvPqSwitchCount = new HashMap<>();
 
+        public ContextData(Optional<Object> initData) {
+            initData.ifPresent(d -> {
+                if (d instanceof Map map) {
+                    pvPqSwitchCount.putAll(map);
+                }
+            });
+        }
+
         void incrementPvPqSwitchCount(String busId) {
             pvPqSwitchCount.computeIfAbsent(busId, k -> new MutableInt(0))
                     .increment();
@@ -163,7 +171,7 @@ public class ReactiveLimitsOuterLoop implements AcOuterLoop {
 
     @Override
     public void initialize(AcOuterLoopContext context) {
-        context.setData(new ContextData());
+        context.setData(new ContextData(context.getOuterLoopInitData()));
     }
 
     private static boolean switchPqPv(List<PqToPvBus> pqToPvBuses, ContextData contextData, ReportNode reportNode, int maxPqPvSwitch) {
@@ -348,5 +356,10 @@ public class ReactiveLimitsOuterLoop implements AcOuterLoop {
             status = OuterLoopStatus.UNSTABLE;
         }
         return new OuterLoopResult(this, status);
+    }
+
+    @Override
+    public Optional<Object> getInitData(AcOuterLoopContext context) {
+        return Optional.of(Collections.unmodifiableMap(((ContextData) context.getData()).pvPqSwitchCount));
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
@@ -616,6 +616,8 @@ public abstract class AbstractSecurityAnalysis<V extends Enum<V> & Quantity, E e
 
     protected abstract LoadFlowEngine<V, E, P, R> createLoadFlowEngine(C context);
 
+    protected abstract void updateContext(R result, C context);
+
     protected void afterPreContingencySimulation(P acParameters) {
     }
 
@@ -649,6 +651,7 @@ public abstract class AbstractSecurityAnalysis<V extends Enum<V> & Quantity, E e
 
             // only run post-contingency simulations if pre-contingency simulation is ok
             if (preContingencyComputationOk) {
+                updateContext(preContingencyLoadFlowResult, context);
                 afterPreContingencySimulation(acParameters);
 
                 // update network result

--- a/src/main/java/com/powsybl/openloadflow/sa/AcSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AcSecurityAnalysis.java
@@ -112,4 +112,9 @@ public class AcSecurityAnalysis extends AbstractSecurityAnalysis<AcVariableType,
     protected void beforeActionLoadFlowRun(AcLoadFlowContext context) {
         context.getParameters().setVoltageInitializer(new PreviousValueVoltageInitializer(true));
     }
+
+    @Override
+    protected void updateContext(AcLoadFlowResult result, AcLoadFlowContext context) {
+        context.setOuterLoopInitData(result.getOuterLoopInitData());
+    }
 }

--- a/src/main/java/com/powsybl/openloadflow/sa/DcSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/DcSecurityAnalysis.java
@@ -73,4 +73,9 @@ public class DcSecurityAnalysis extends AbstractSecurityAnalysis<DcVariableType,
     protected PostContingencyComputationStatus postContingencyStatusFromLoadFlowResult(DcLoadFlowResult result) {
         return result.isSuccess() ? PostContingencyComputationStatus.CONVERGED : PostContingencyComputationStatus.FAILED;
     }
+
+    @Override
+    protected void updateContext(DcLoadFlowResult result, DcLoadFlowContext context) {
+        // Nothing to do
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -1818,7 +1818,9 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
 
     private AcLoadFlowResult buildTestAcLoadFlowResult(AcSolverStatus solverStatus, OuterLoopStatus outerLoopStatus) {
         LfNetwork lfNetwork = Mockito.mock(LfNetwork.class);
-        return new AcLoadFlowResult(lfNetwork, 0, 0, solverStatus, new OuterLoopResult("", outerLoopStatus), 0d, 0d);
+        return new AcLoadFlowResult(lfNetwork, 0, 0,
+                solverStatus, new OuterLoopResult("", outerLoopStatus),
+                0d, 0d, Collections.EMPTY_MAP);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
Accelerate security analysis or sensivity analysis for irralistic voltage plans



**What is the current behavior?**
Currently; when the voltage plan is unreaslitic and leads to many bus blocked PQ because max numer of switch is reached,
many load flows are run even for contingency because the number of past PVPQ switches is forgotten after the run in N state.



**What is the new behavior (if this is a feature change)?**
The number of PV:PQ switches is transferred from N state to contingency runs. Groups that are blocked P in N state remain blocked in the contingency runs.
This can lead in some cases to a x4 increase in computation. 


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X No


