### PR TITLE
Fix secondary voltage control in case of generator remote voltage control

### DIFF
--- a/docs/loadflow/parameters.md
+++ b/docs/loadflow/parameters.md
@@ -152,7 +152,15 @@ The default value is `false`.
 
 **secondaryVoltageControl**  
 Whether simulation of secondary voltage control should be enabled.  
+Modeling of secondary voltage control has been designed to provide a fast, static, approximation of the equilibrium state of the generator reactive power 
+alignment process that controls the voltage of a remote pilot point.
+This reactive power alignment process typically takes several minutes on the network.
 The default value is `false`.
+
+Please note that the secondaryVoltageControl implementation has the folowing limitation:
+Generators that belongs to a secondary voltage control zone should be in local voltage control only.
+If secondaryVoltageControl is set to `true`, generators that belongs to a secondary voltage control zone and that are configured 
+for remote voltage control are switched to local voltage control with an initial local target equals to remoteTarget / remoteNominalV * localNominalV . 
 
 **reactiveLimitsMaxPqPvSwitch**  
 When `useReactiveLimits` is set to `true`, this parameter is used to limit the number of times an equipment performing voltage control

--- a/docs/loadflow/parameters.md
+++ b/docs/loadflow/parameters.md
@@ -157,7 +157,7 @@ alignment process that controls the voltage of a remote pilot point.
 This reactive power alignment process typically takes several minutes on the network.
 The default value is `false`.
 
-Please note that the secondaryVoltageControl implementation has the folowing limitation:
+Please note that the secondaryVoltageControl implementation has the folowing limitation:  
 Generators that belongs to a secondary voltage control zone should be in local voltage control only.
 If secondaryVoltageControl is set to `true`, generators that belongs to a secondary voltage control zone and that are configured 
 for remote voltage control are switched to local voltage control with an initial local target equals to remoteTarget / remoteNominalV * localNominalV . 

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
@@ -275,8 +275,12 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
         // replace last row for each of the secondary voltage control block
         for (LfSecondaryVoltageControl secondaryVoltageControl : secondaryVoltageControls) {
             List<LfBus> controllerBuses = secondaryVoltageControl.getEnabledControllerBuses();
-            LfBus lastControllerBus = controllerBuses.get(controllerBuses.size() - 1);
-            int i = controllerBusIndex.get(lastControllerBus.getNum());
+            List<LfBus> controlledBuses = controllerBuses.stream()
+                    .map(bus -> bus.getGeneratorVoltageControl().orElseThrow().getControlledBus())
+                    .distinct()
+                    .toList();
+            LfBus lastControlledBus = controlledBuses.get(controlledBuses.size() - 1);
+            int i = controlledBusIndex.get(lastControlledBus.getNum());
 
             DenseMatrix jVpp = createJvpp(sensitivityContext, secondaryVoltageControl.getPilotBus(), allControlledBuses, controlledBusIndex);
             for (int j = 0; j < b.getColumnCount(); j++) {

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
@@ -21,7 +21,6 @@ import com.powsybl.openloadflow.lf.outerloop.OuterLoopResult;
 import com.powsybl.openloadflow.lf.outerloop.OuterLoopStatus;
 import com.powsybl.openloadflow.network.*;
 import org.apache.commons.lang3.mutable.MutableDouble;
-import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,22 +64,20 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
 
     static class SensitivityContext {
 
-        private final Map<Integer, Integer> busNumToSensiColumn;
+        private final Map<Integer, Integer> controlledBusIndex;
 
         private final DenseMatrix sensitivities;
 
-        SensitivityContext(Map<Integer, Integer> busNumToSensiColumn, DenseMatrix sensitivities) {
-            this.busNumToSensiColumn = Objects.requireNonNull(busNumToSensiColumn);
+        SensitivityContext(Map<Integer, Integer> controlledBusIndex, DenseMatrix sensitivities) {
+            this.controlledBusIndex = Objects.requireNonNull(controlledBusIndex);
             this.sensitivities = Objects.requireNonNull(sensitivities);
         }
 
-        static SensitivityContext create(List<LfBus> controlledBuses, AcLoadFlowContext context) {
-            var busNumToSensiColumn = buildBusIndex(controlledBuses);
-
-            DenseMatrix sensitivities = calculateSensitivityValues(controlledBuses, busNumToSensiColumn, context.getEquationSystem(),
+        static SensitivityContext create(List<LfBus> controlledBuses, Map<Integer, Integer> controlledBusIndex, AcLoadFlowContext context) {
+            DenseMatrix sensitivities = calculateSensitivityValues(controlledBuses, controlledBusIndex, context.getEquationSystem(),
                                                                    context.getJacobianMatrix());
 
-            return new SensitivityContext(busNumToSensiColumn, sensitivities);
+            return new SensitivityContext(controlledBusIndex, sensitivities);
         }
 
         private static DenseMatrix calculateSensitivityValues(List<LfBus> controlledBuses, Map<Integer, Integer> busNumToSensiColumn,
@@ -124,7 +121,7 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
          * Calculate controlled bus voltage to controller bus reactive power injection sensitivity.
          */
         double calculateSensiQ(LfBus controllerBus, LfBus controlledBus) {
-            int controlledBusSensiColumn = busNumToSensiColumn.get(controlledBus.getNum());
+            int controlledBusSensiColumn = controlledBusIndex.get(controlledBus.getNum());
 
             MutableDouble sq = new MutableDouble();
             for (LfBranch branch : controllerBus.getBranches()) {
@@ -147,7 +144,7 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
          * Calculate controlled buses voltage to pilot bus voltage sensitivities.
          */
         double calculateSensiVpp(LfBus controlledBus, LfBus pilotBus) {
-            int controlledBusSensiColumn = busNumToSensiColumn.get(controlledBus.getNum());
+            int controlledBusSensiColumn = controlledBusIndex.get(controlledBus.getNum());
             return getCalculatedV(pilotBus).calculateSensi(sensitivities, controlledBusSensiColumn);
         }
     }
@@ -162,12 +159,12 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
         return qToK(q, controllerBus);
     }
 
-    private static DenseMatrix createA(List<LfSecondaryVoltageControl> secondaryVoltageControls, Map<Integer, Integer> controllerBusIndex) {
-        int n = controllerBusIndex.size();
-        DenseMatrix a = new DenseMatrix(n, n);
+    private static DenseMatrix createA(List<LfSecondaryVoltageControl> secondaryVoltageControls,
+                                       List<LfBus> allControllerBuses, Map<Integer, Integer> controllerBusIndex) {
+        DenseMatrix a = new DenseMatrix(allControllerBuses.size(), allControllerBuses.size());
         // build a block in the global matrix for each of the secondary voltage control
         for (LfSecondaryVoltageControl secondaryVoltageControl : secondaryVoltageControls) {
-            List<LfBus> controllerBuses = secondaryVoltageControl.getControllerBuses();
+            List<LfBus> controllerBuses = secondaryVoltageControl.getEnabledControllerBuses();
             int nControl = controllerBuses.size();
             for (LfBus controllerBusI : controllerBuses) {
                 for (LfBus controllerBusJ : controllerBuses) {
@@ -181,8 +178,7 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
     }
 
     private static DenseMatrix createK0(List<LfBus> controllerBuses, Map<Integer, Integer> controllerBusIndex) {
-        int n = controllerBuses.size();
-        DenseMatrix k0 = new DenseMatrix(n, 1);
+        DenseMatrix k0 = new DenseMatrix(controllerBuses.size(), 1);
         for (LfBus controllerBus : controllerBuses) {
             int i = controllerBusIndex.get(controllerBus.getNum());
             k0.set(i, 0, calculateK(controllerBus));
@@ -190,26 +186,25 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
         return k0;
     }
 
-    private static DenseMatrix createJk(SensitivityContext sensitivityContext, List<LfBus> controllerBuses, Map<Integer, Integer> controllerBusIndex) {
-        int n = controllerBuses.size();
-        DenseMatrix jK = new DenseMatrix(n, n);
-        for (LfBus controllerBusI : controllerBuses) {
+    private static DenseMatrix createJk(SensitivityContext sensitivityContext,
+                                        List<LfBus> controllerBuses, List<LfBus> controlledBuses,
+                                        Map<Integer, Integer> controllerBusIndex, Map<Integer, Integer> controlledBusIndex) {
+        DenseMatrix jK = new DenseMatrix(controlledBuses.size(), controllerBuses.size());
+        for (LfBus controlledBusI : controlledBuses) {
             for (LfBus controllerBusJ : controllerBuses) {
-                int i = controllerBusIndex.get(controllerBusI.getNum());
+                int i = controlledBusIndex.get(controlledBusI.getNum());
                 int j = controllerBusIndex.get(controllerBusJ.getNum());
-                LfBus controlledBus2 = controllerBusJ.getGeneratorVoltageControl().orElseThrow().getControlledBus();
-                jK.set(i, j, sensitivityContext.calculateSensiK(controllerBusI, controlledBus2));
+                jK.set(i, j, sensitivityContext.calculateSensiK(controllerBusJ, controlledBusI));
             }
         }
         return jK;
     }
 
-    private static DenseMatrix createJvpp(SensitivityContext sensitivityContext, LfBus pilotBus, List<LfBus> controllerBuses, Map<Integer, Integer> controllerBusIndex) {
-        int n = controllerBuses.size();
-        DenseMatrix jVpp = new DenseMatrix(n, 1);
-        for (LfBus controllerBus : controllerBuses) {
-            int i = controllerBusIndex.get(controllerBus.getNum());
-            LfBus controlledBus = controllerBus.getGeneratorVoltageControl().orElseThrow().getControlledBus();
+    private static DenseMatrix createJvpp(SensitivityContext sensitivityContext, LfBus pilotBus,
+                                          List<LfBus> controlledBuses, Map<Integer, Integer> controlledBusIndex) {
+        DenseMatrix jVpp = new DenseMatrix(controlledBuses.size(), 1);
+        for (LfBus controlledBus : controlledBuses) {
+            int i = controlledBusIndex.get(controlledBus.getNum());
             jVpp.set(i, 0, sensitivityContext.calculateSensiVpp(controlledBus, pilotBus));
         }
         return jVpp;
@@ -231,7 +226,7 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
     }
 
     private Optional<List<String>> processSecondaryVoltageControl(List<LfSecondaryVoltageControl> secondaryVoltageControls,
-                                                                  SensitivityContext sensitivityContext) {
+                                                                  AcLoadFlowContext loadFlowContext) {
         List<String> adjustedZoneNames = new ArrayList<>();
 
         for (LfSecondaryVoltageControl secondaryVoltageControl : secondaryVoltageControls) {
@@ -257,25 +252,33 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
                 .flatMap(control -> control.getEnabledControllerBuses().stream())
                 .toList();
 
-        var controllerBusIndex = buildBusIndex(allControllerBuses);
+        List<LfBus> allControlledBuses = allControllerBuses.stream()
+                .map(b -> b.getGeneratorVoltageControl().orElseThrow().getControlledBus())
+                .distinct()
+                .toList();
 
-        DenseMatrix a = createA(secondaryVoltageControls, controllerBusIndex);
+        var controllerBusIndex = buildBusIndex(allControllerBuses);
+        var controlledBusIndex = buildBusIndex(allControlledBuses);
+
+        // compute target voltage sensitivities for all controlled buses
+        SensitivityContext sensitivityContext = SensitivityContext.create(allControlledBuses, controlledBusIndex, loadFlowContext);
+
+        DenseMatrix a = createA(secondaryVoltageControls, allControllerBuses, controllerBusIndex);
 
         DenseMatrix k0 = createK0(allControllerBuses, controllerBusIndex);
 
         DenseMatrix rhs = a.times(k0, -1);
 
-        DenseMatrix jK = createJk(sensitivityContext, allControllerBuses, controllerBusIndex);
-
+        DenseMatrix jK = createJk(sensitivityContext, allControllerBuses, allControlledBuses, controllerBusIndex, controlledBusIndex).transpose();
         DenseMatrix b = a.times(jK);
 
         // replace last row for each of the secondary voltage control block
         for (LfSecondaryVoltageControl secondaryVoltageControl : secondaryVoltageControls) {
-            List<LfBus> controllerBuses = secondaryVoltageControl.getControllerBuses();
+            List<LfBus> controllerBuses = secondaryVoltageControl.getEnabledControllerBuses();
             LfBus lastControllerBus = controllerBuses.get(controllerBuses.size() - 1);
             int i = controllerBusIndex.get(lastControllerBus.getNum());
 
-            DenseMatrix jVpp = createJvpp(sensitivityContext, secondaryVoltageControl.getPilotBus(), allControllerBuses, controllerBusIndex);
+            DenseMatrix jVpp = createJvpp(sensitivityContext, secondaryVoltageControl.getPilotBus(), allControlledBuses, controlledBusIndex);
             for (int j = 0; j < b.getColumnCount(); j++) {
                 b.set(i, j, jVpp.get(j, 0));
             }
@@ -292,10 +295,9 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
 
         // compute new controlled bus target voltages
         Map<LfBus, Double> newControlledBusTargetV = new HashMap<>(allControllerBuses.size());
-        for (LfBus controllerBus : allControllerBuses) {
-            int i = controllerBusIndex.get(controllerBus.getNum());
-            var vc = controllerBus.getGeneratorVoltageControl().orElseThrow();
-            LfBus controlledBus = vc.getControlledBus();
+        for (LfBus controlledBus : allControlledBuses) {
+            int i = controlledBusIndex.get(controlledBus.getNum());
+            var vc = controlledBus.getGeneratorVoltageControl().orElseThrow();
             double newTargetV = vc.getTargetValue() + dv.get(i, 0);
             newControlledBusTargetV.put(controlledBus, newTargetV);
         }
@@ -306,13 +308,7 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
                     double newTargetV = e.getValue();
                     return !VoltageControl.isTargetVoltagePlausible(newTargetV, minPlausibleTargetVoltage, maxPlausibleTargetVoltage);
                 })
-                .map(e -> {
-                    // convert target to Kv for better display
-                    LfBus controlledBus = e.getKey();
-                    double newTargetV = e.getValue();
-                    return Pair.of(controlledBus, newTargetV * controlledBus.getNominalV());
-                })
-                .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         if (notPlausibleNewControlledBusTargetV.isEmpty()) {
             for (var e : newControlledBusTargetV.entrySet()) {
                 LfBus controlledBus = e.getKey();
@@ -369,15 +365,9 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
             return new OuterLoopResult(this, OuterLoopStatus.STABLE);
         }
 
-        // compute target voltage sensitivities for all controlled buses
-        List<LfBus> allControlledBuses = secondaryVoltageControls.stream()
-                .flatMap(control -> control.getControlledBuses().stream())
-                .toList();
-        SensitivityContext sensitivityContext = SensitivityContext.create(allControlledBuses, context.getLoadFlowContext());
-
         OuterLoopStatus status = OuterLoopStatus.STABLE;
 
-        List<String> adjustedZoneNames = processSecondaryVoltageControl(secondaryVoltageControls, sensitivityContext).orElse(null);
+        List<String> adjustedZoneNames = processSecondaryVoltageControl(secondaryVoltageControls, context.getLoadFlowContext()).orElse(null);
         if (adjustedZoneNames == null) {
             status = OuterLoopStatus.FAILED;
         } else {

--- a/src/main/java/com/powsybl/openloadflow/network/GeneratorVoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/GeneratorVoltageControl.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.openloadflow.network;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -78,6 +79,25 @@ public class GeneratorVoltageControl extends VoltageControl<LfBus> {
         for (int i = 0; i < controllerBuses.size(); i++) {
             LfBus controllerBus = controllerBuses.get(i);
             controllerBus.setRemoteControlReactivePercent(reactiveKeysSum == 0 ? 0 : reactiveKeys[i] / reactiveKeysSum);
+        }
+    }
+
+    /**
+     * Returns itself in case of local control, split into several local voltage controls in case of remote control.
+     */
+    public List<GeneratorVoltageControl> split() {
+        if (isLocalControl()) {
+            return List.of(this);
+        } else {
+            List<GeneratorVoltageControl> generatorVoltageControls = new ArrayList<>(controllerElements.size());
+            // create one (local) generator control per controller bus and remove this one
+            controlledBus.setGeneratorVoltageControl(null);
+            for (LfBus controllerBus : controllerElements) {
+                var generatorVoltageControl = new GeneratorVoltageControl(controllerBus, targetPriority, targetValue);
+                generatorVoltageControl.addControllerElement(controllerBus);
+                generatorVoltageControls.add(generatorVoltageControl);
+            }
+            return generatorVoltageControls;
         }
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/GeneratorVoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/GeneratorVoltageControl.java
@@ -85,7 +85,7 @@ public class GeneratorVoltageControl extends VoltageControl<LfBus> {
     /**
      * Returns itself in case of local control, split into several local voltage controls in case of remote control.
      */
-    public List<GeneratorVoltageControl> split() {
+    public List<GeneratorVoltageControl> toLocalVoltageControls() {
         if (isLocalControl()) {
             return List.of(this);
         } else {

--- a/src/main/java/com/powsybl/openloadflow/network/LfSecondaryVoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfSecondaryVoltageControl.java
@@ -73,7 +73,7 @@ public class LfSecondaryVoltageControl {
     public Set<GeneratorVoltageControl> getGeneratorVoltageControls() {
         return generatorVoltageControls.stream()
                 .filter(this::hasAtLeastOneParticipatingControlUnit) // only keep voltage controls where there is at list one enabled control unit
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private boolean hasAtLeastOneParticipatingControlUnit(GeneratorVoltageControl vc) {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -185,11 +185,15 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
 
     @Override
     public void setGeneratorVoltageControl(GeneratorVoltageControl generatorVoltageControl) {
-        this.generatorVoltageControl = Objects.requireNonNull(generatorVoltageControl);
-        if (hasGeneratorVoltageControllerCapability()) {
-            this.generatorVoltageControlEnabled = true;
-        } else if (!isGeneratorVoltageControlled()) {
-            throw new PowsyblException("Setting inconsistent voltage control to bus " + getId());
+        this.generatorVoltageControl = generatorVoltageControl;
+        if (generatorVoltageControl != null) {
+            if (hasGeneratorVoltageControllerCapability()) {
+                this.generatorVoltageControlEnabled = true;
+            } else if (!isGeneratorVoltageControlled()) {
+                throw new PowsyblException("Setting inconsistent voltage control to bus " + getId());
+            }
+        } else {
+            this.generatorVoltageControlEnabled = false;
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -1111,7 +1111,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
                         //   for a given shared voltage control as a unique controlled bus cannot help to align reactive
                         //   power of generators)
                         Set<GeneratorVoltageControl> splitGeneratorVoltageControls = generatorVoltageControls.stream()
-                                .flatMap(vc -> vc.split().stream())
+                                .flatMap(vc -> vc.toLocalVoltageControls().stream())
                                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
                         Set<String> participatingControlUnitIds = controlZone.getControlUnits().stream()

--- a/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
@@ -513,5 +513,16 @@ class SecondaryVoltageControlTest {
         assertVoltageEquals(4.93, b992);
         assertReactivePowerEquals(-9.172, g991.getTerminal());
         assertReactivePowerEquals(4.742, g992.getTerminal());
+
+        // With secondary voltage set to false, check that the remote control remains active
+        parametersExt.setSecondaryVoltageControl(false);
+        result = loadFlowRunner.run(network, parameters);
+        assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
+        assertEquals(4, result.getComponentResults().get(0).getIterationCount());
+        assertVoltageEquals(12.8, b6);
+        assertVoltageEquals(5.52, b991);
+        // Compare voltage in pu
+        assertEquals(1.066, b6.getV() / b6.getVoltageLevel().getNominalV(), 1e-3);
+        assertEquals(0.92, b991.getV() / b991.getVoltageLevel().getNominalV(), 1e-3);
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
@@ -9,10 +9,7 @@ package com.powsybl.openloadflow.ac;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.ieeecdf.converter.IeeeCdfNetworkFactory;
-import com.powsybl.iidm.network.Bus;
-import com.powsybl.iidm.network.Generator;
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.ReactiveLimits;
+import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.PilotPoint;
 import com.powsybl.iidm.network.extensions.SecondaryVoltageControl;
 import com.powsybl.iidm.network.extensions.SecondaryVoltageControlAdder;
@@ -427,5 +424,94 @@ class SecondaryVoltageControlTest {
         assertVoltageEquals(13, b10);
         assertVoltageEquals(13.090, b6);
         assertVoltageEquals(23.381, b8);
+    }
+
+    @Test
+    void testWithGeneratorSharedRemoteVoltage() {
+        // remove generator 6 and create 2 new generators controlling voltage on bus 6
+        network.getGenerator("B6-G").remove();
+
+        var s5 = network.getSubstation("S5");
+        var vl99 = s5.newVoltageLevel()
+                .setId("VL99")
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setNominalV(6)
+                .add();
+        var b991 = vl99.getBusBreakerView().newBus()
+                .setId("B99-1")
+                .add();
+        var b992 = vl99.getBusBreakerView().newBus()
+                .setId("B99-2")
+                .add();
+        var g991 = vl99.newGenerator()
+                .setId("B99-G1")
+                .setBus("B99-1")
+                .setTargetP(1)
+                .setMinP(-1000)
+                .setMaxP(1000)
+                .setTargetV(12.8)
+                .setVoltageRegulatorOn(true)
+                .setRegulatingTerminal(network.getLoad("B6-L").getTerminal())
+                .add();
+        g991.newMinMaxReactiveLimits()
+                .setMinQ(-30)
+                .setMaxQ(70)
+                .add();
+        var g992 = vl99.newGenerator()
+                .setId("B99-G2")
+                .setBus("B99-2")
+                .setTargetP(2)
+                .setMinP(-1000)
+                .setMaxP(1000)
+                .setTargetV(12.8)
+                .setVoltageRegulatorOn(true)
+                .setRegulatingTerminal(network.getLoad("B6-L").getTerminal())
+                .add();
+        g992.newMinMaxReactiveLimits()
+                .setMinQ(-40)
+                .setMaxQ(50)
+                .add();
+        s5.newTwoWindingsTransformer()
+                .setId("B99-T1")
+                .setVoltageLevel1("VL99")
+                .setBus1("B99-1")
+                .setVoltageLevel2("VL6")
+                .setBus2("B6")
+                .setRatedU1(5)
+                .setRatedU2(12)
+                .setR(0.1)
+                .setX(1)
+                .add();
+        s5.newTwoWindingsTransformer()
+                .setId("B99-T2")
+                .setVoltageLevel1("VL99")
+                .setBus1("B99-2")
+                .setVoltageLevel2("VL6")
+                .setBus2("B6")
+                .setRatedU1(5)
+                .setRatedU2(12)
+                .setR(0.2)
+                .setX(2)
+                .add();
+
+        parametersExt.setSecondaryVoltageControl(true);
+        network.newExtension(SecondaryVoltageControlAdder.class)
+                .newControlZone()
+                .withName("z1")
+                .newPilotPoint().withTargetV(12.5).withBusbarSectionsOrBusesIds(List.of("B10")).add()
+                .newControlUnit().withId("B99-G1").add()
+                .newControlUnit().withId("B99-G2").add()
+                .add()
+                .add();
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
+        assertEquals(7, result.getComponentResults().get(0).getIterationCount());
+
+        assertVoltageEquals(12.5, b10);
+        assertVoltageEquals(5.548, b991);
+        assertVoltageEquals(4.93, b992);
+        assertReactivePowerEquals(-9.172, g991.getTerminal());
+        assertReactivePowerEquals(4.742, g992.getTerminal());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Secondary voltage control outer failed in case a zone has generators belonging to a shared remote control.   


**What is the new behavior (if this is a feature change)?**
All generators of a secondary voltage control, have local voltage control.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
