### PR TITLE
Fix SA reports in MT 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <jafama.version>2.3.2</jafama.version>
         <slf4jtoys.version>1.6.3</slf4jtoys.version>
         <asciitable.version>0.3.2</asciitable.version>
-        
+
         <powsybl-core.version>6.7.0-RC1</powsybl-core.version>
     </properties>
 

--- a/src/main/java/com/powsybl/openloadflow/network/action/LfActionUtils.java
+++ b/src/main/java/com/powsybl/openloadflow/network/action/LfActionUtils.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (c) 2025, Coreso SA (https://www.coreso.eu/) and TSCNET Services GmbH (https://www.tscnet.eu/)
- * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * Copyright (c) 2022-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -9,10 +9,10 @@
 package com.powsybl.openloadflow.network.action;
 
 import com.powsybl.action.*;
-import com.powsybl.commons.report.ReportNode;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.openloadflow.graph.GraphConnectivity;
 import com.powsybl.openloadflow.network.*;
+import com.powsybl.openloadflow.util.Reports;
 
 import java.util.*;
 
@@ -24,10 +24,6 @@ import static com.powsybl.openloadflow.network.action.AbstractLfBranchAction.upd
  * @author Jean-Luc Bouchot {@literal <jlbouchot at gmail.com>}
  */
 public final class LfActionUtils {
-
-    private static final String ACTION_ID = "actionId";
-
-    private static final String CONTINGENCY_ID = "contingencyId";
 
     private LfActionUtils() {
     }
@@ -55,7 +51,7 @@ public final class LfActionUtils {
         };
     }
 
-    public static void applyListOfActions(List<LfAction> actions, LfNetwork network, LfContingency contingency, LfNetworkParameters networkParameters, ReportNode node) {
+    public static void applyListOfActions(List<LfAction> actions, LfNetwork network, LfContingency contingency, LfNetworkParameters networkParameters) {
         Objects.requireNonNull(actions);
         Objects.requireNonNull(network);
 
@@ -63,19 +59,19 @@ public final class LfActionUtils {
         List<LfAction> branchActions = actions.stream()
             .filter(action -> action instanceof AbstractLfBranchAction<?>)
             .toList();
-        updateConnectivity(branchActions, network, contingency, node);
+        updateConnectivity(branchActions, network, contingency);
 
         // then process remaining changes of actions
         actions.stream()
             .filter(action -> !(action instanceof AbstractLfBranchAction<?>))
             .forEach(action -> {
                 if (!action.apply(network, contingency, networkParameters)) {
-                    reportActionApplicationFailure(action.getId(), contingency.getId(), node);
+                    Reports.reportActionApplicationFailure(action.getId(), contingency.getId(), network.getReportNode());
                 }
             });
     }
 
-    private static void updateConnectivity(List<LfAction> branchActions, LfNetwork network, LfContingency contingency, ReportNode node) {
+    private static void updateConnectivity(List<LfAction> branchActions, LfNetwork network, LfContingency contingency) {
         GraphConnectivity<LfBus, LfBranch> connectivity = network.getConnectivity();
 
         // re-update connectivity according to post contingency state (revert after LfContingency apply)
@@ -87,7 +83,7 @@ public final class LfActionUtils {
 
         branchActions.forEach(action -> {
             if (!((AbstractLfBranchAction<?>) action).applyOnConnectivity(network, connectivity)) {
-                reportActionApplicationFailure(action.getId(), contingency.getId(), node);
+                Reports.reportActionApplicationFailure(action.getId(), contingency.getId(), network.getReportNode());
             }
         });
 
@@ -96,14 +92,6 @@ public final class LfActionUtils {
         // reset connectivity to discard post contingency connectivity and post action connectivity
         connectivity.undoTemporaryChanges();
         connectivity.undoTemporaryChanges();
-    }
-
-    private static void reportActionApplicationFailure(String actionId, String contingencyId, ReportNode node) {
-        node.newReportNode()
-            .withMessageTemplate("LfActionUtils", "Action '${actionId}': may not have been applied successfully on contingency '${contingencyId}'")
-            .withUntypedValue(ACTION_ID, actionId)
-            .withUntypedValue(CONTINGENCY_ID, contingencyId)
-            .add();
     }
 
 }

--- a/src/main/java/com/powsybl/openloadflow/network/action/LfActionUtils.java
+++ b/src/main/java/com/powsybl/openloadflow/network/action/LfActionUtils.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2025, Coreso SA (https://www.coreso.eu/) and TSCNET Services GmbH (https://www.tscnet.eu/)
  * Copyright (c) 2022-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
@@ -172,10 +172,10 @@ public abstract class AbstractSecurityAnalysis<V extends Enum<V> & Quantity, E e
             operatorStrategies.stream()
                     .filter(o -> !hasValidContingency(o, contingencyIds))
                     .findAny()
-                    .ifPresent(o -> throwMissingOperatorStrategyContingency(o));
+                    .ifPresent(AbstractSecurityAnalysis::throwMissingOperatorStrategyContingency);
             // Check action ids to report exception to the main thread
             final Set<String> actionIds = actions.stream().map(Action::getId).collect(Collectors.toSet());
-            operatorStrategies.stream()
+            operatorStrategies
                     .forEach(o -> findMissingActionId(o, actionIds)
                             .ifPresent(id -> throwMissingOperatorStrategyAction(o, id)));
 
@@ -183,6 +183,7 @@ public abstract class AbstractSecurityAnalysis<V extends Enum<V> & Quantity, E e
             // so that we always get results in the same order whatever threads completion order is.
             List<SecurityAnalysisResult> partitionResults = Collections.synchronizedList(new ArrayList<>(Collections.nCopies(contingenciesPartitions.size(), createNoResult()))); // init to no result in case of cancel
             List<LfNetworkList> lfNetworksList = new ArrayList<>();
+            List<ReportNode> reportNodes = Collections.synchronizedList(new ArrayList<>(Collections.nCopies(contingenciesPartitions.size(), ReportNode.NO_OP)));
 
             boolean oldAllowVariantMultiThreadAccess = network.getVariantManager().isVariantMultiThreadAccessAllowed();
             network.getVariantManager().allowVariantMultiThreadAccess(true);
@@ -216,8 +217,14 @@ public abstract class AbstractSecurityAnalysis<V extends Enum<V> & Quantity, E e
 
                             parameters = createParameters(lfParameters, lfParametersExt, partitionTopoConfig.isBreaker(), isAreaInterchangeControl(lfParametersExt, contingencies));
 
+                            ReportNode threadRootNode = partitionNum == 0 ? saReportNode :
+                                    ReportNode.newRootReportNode()
+                                            .withMessageTemplate("threadRoot", "threadRoot")
+                                            .build();
+                            reportNodes.set(partitionNum, threadRootNode);
+
                             // create networks including all necessary switches
-                            lfNetworks = Networks.load(network, parameters.getNetworkParameters(), partitionTopoConfig, saReportNode);
+                            lfNetworks = Networks.load(network, parameters.getNetworkParameters(), partitionTopoConfig, threadRootNode);
                             lfNetworksList.add(0, lfNetworks); // FIXME to workaround variant removal bug, to fix in core
                         } finally {
                             networkLock.unlock();
@@ -246,8 +253,13 @@ public abstract class AbstractSecurityAnalysis<V extends Enum<V> & Quantity, E e
                 network.getVariantManager().allowVariantMultiThreadAccess(oldAllowVariantMultiThreadAccess);
             }
 
+            int networkRank = 0;
             for (var lfNetworks : lfNetworksList) {
+                if (networkRank != 0) {
+                    mergeReportThreadResults(saReportNode, reportNodes.get(networkRank));
+                }
                 lfNetworks.close();
+                networkRank += 1;
             }
 
             // we just need to merge post contingency and operator strategy results, all pre contingency are the same
@@ -265,6 +277,39 @@ public abstract class AbstractSecurityAnalysis<V extends Enum<V> & Quantity, E e
                 stopwatch.elapsed(TimeUnit.MILLISECONDS));
 
         return new SecurityAnalysisReport(finalResult);
+    }
+
+    private record LfNetworkId(Object numCC, Object numSC) {
+    }
+
+    private void mergeReportThreadResults(ReportNode mainReport, ReportNode toMerge) {
+
+        Map<LfNetworkId, ReportNode> mainNodes = mainReport.getChildren().stream()
+                .filter(r -> r.getMessageKey().equals(Reports.LF_NETWORK_KEY))
+                .collect(Collectors.toMap(
+                        n -> new LfNetworkId(n.getValue(Reports.NETWORK_NUM_CC).orElseThrow().getValue(),
+                                                       n.getValue(Reports.NETWORK_NUM_SC).orElseThrow().getValue()),
+                                  n -> n));
+
+        Map<LfNetworkId, ReportNode> toMergeNodes = toMerge.getChildren().stream()
+                .filter(r -> r.getMessageKey().equals(Reports.LF_NETWORK_KEY))
+                .collect(Collectors.toMap(
+                        n -> new LfNetworkId(n.getValue(Reports.NETWORK_NUM_CC).orElseThrow().getValue(),
+                                n.getValue(Reports.NETWORK_NUM_SC).orElseThrow().getValue()),
+                        n -> n));
+
+        // By construction all threads should have the same lfNetwork List
+        // So the merge is just about appending relevant data to lfNetwork nodes of the
+        // main thread
+
+        for (LfNetworkId key : mainNodes.keySet()) {
+            // Both should exist
+            ReportNode mainReportNode = mainNodes.get(key);
+            ReportNode toMergeNode = toMergeNodes.get(key);
+            toMergeNode.getChildren().stream()
+                    .filter(n -> n.getMessageKey().equals(Reports.POST_CONTINGENCY_SIMULATION_KEY))
+                    .forEach(mainReportNode::addCopy);
+        }
     }
 
     SecurityAnalysisResult runSimulationsOnAllComponents(LfNetworkList networks, List<PropagatedContingency> propagatedContingencies, P parameters,
@@ -536,6 +581,7 @@ public abstract class AbstractSecurityAnalysis<V extends Enum<V> & Quantity, E e
                                                                                               Map<String, Action> actionsById,
                                                                                               Set<Action> neededActions,
                                                                                               boolean checkOperatorStrategies) {
+
         Set<String> contingencyIds = propagatedContingencies.stream().map(propagatedContingency -> propagatedContingency.getContingency().getId()).collect(Collectors.toSet());
         Map<String, List<OperatorStrategy>> operatorStrategiesByContingencyId = new HashMap<>();
         Set<String> actionIds = actionsById.keySet();
@@ -692,6 +738,7 @@ public abstract class AbstractSecurityAnalysis<V extends Enum<V> & Quantity, E e
         Map<String, List<OperatorStrategy>> operatorStrategiesByContingencyId =
                 indexOperatorStrategiesByContingencyId(propagatedContingencies, operatorStrategies, actionsById, neededActions,
                         checkOperatorStrategies);
+
         Map<String, LfAction> lfActionById = createLfActions(lfNetwork, neededActions, network, acParameters.getNetworkParameters()); // only convert needed actions
 
         LoadFlowParameters loadFlowParameters = securityAnalysisParameters.getLoadFlowParameters();
@@ -905,7 +952,7 @@ public abstract class AbstractSecurityAnalysis<V extends Enum<V> & Quantity, E e
                 .filter(Objects::nonNull)
                 .toList();
 
-        LfActionUtils.applyListOfActions(operatorStrategyLfActions, network, contingency, networkParameters, reportNode);
+        LfActionUtils.applyListOfActions(operatorStrategyLfActions, network, contingency, networkParameters);
 
         Stopwatch stopwatch = Stopwatch.createStarted();
 

--- a/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AbstractSecurityAnalysis.java
@@ -302,10 +302,10 @@ public abstract class AbstractSecurityAnalysis<V extends Enum<V> & Quantity, E e
         // So the merge is just about appending relevant data to lfNetwork nodes of the
         // main thread
 
-        for (LfNetworkId key : mainNodes.keySet()) {
+        for (Map.Entry<LfNetworkId, ReportNode> entry : mainNodes.entrySet()) {
             // Both should exist
-            ReportNode mainReportNode = mainNodes.get(key);
-            ReportNode toMergeNode = toMergeNodes.get(key);
+            ReportNode mainReportNode = entry.getValue();
+            ReportNode toMergeNode = toMergeNodes.get(entry.getKey());
             toMergeNode.getChildren().stream()
                     .filter(n -> n.getMessageKey().equals(Reports.POST_CONTINGENCY_SIMULATION_KEY))
                     .forEach(mainReportNode::addCopy);

--- a/src/main/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysis.java
@@ -274,7 +274,7 @@ public class WoodburyDcSecurityAnalysis extends DcSecurityAnalysis {
 
         // apply modifications to compute results
         lfContingency.apply(loadFlowContext.getParameters().getBalanceType());
-        LfActionUtils.applyListOfActions(operatorStrategyLfActions, lfNetwork, lfContingency, loadFlowContext.getParameters().getNetworkParameters(), reportNode);
+        LfActionUtils.applyListOfActions(operatorStrategyLfActions, lfNetwork, lfContingency, loadFlowContext.getParameters().getNetworkParameters());
 
         // update network result
         var postActionsNetworkResult = new PreContingencyNetworkResult(lfNetwork, monitorIndex, createResultExtension);

--- a/src/main/java/com/powsybl/openloadflow/util/Reports.java
+++ b/src/main/java/com/powsybl/openloadflow/util/Reports.java
@@ -20,8 +20,8 @@ import java.util.Map;
  */
 public final class Reports {
 
-    private static final String NETWORK_NUM_CC = "networkNumCc";
-    private static final String NETWORK_NUM_SC = "networkNumSc";
+    public static final String NETWORK_NUM_CC = "networkNumCc";
+    public static final String NETWORK_NUM_SC = "networkNumSc";
     private static final String ITERATION = "iteration";
     private static final String ITERATION_COUNT = "iterationCount";
     private static final String NETWORK_ID = "networkId";
@@ -34,7 +34,12 @@ public final class Reports {
     private static final String GENERATORS_ID = "generatorIds";
     private static final String CONTROLLER_BUS_ID = "controllerBusId";
     private static final String CONTROLLED_BUS_ID = "controlledBusId";
+    private static final String ACTION_ID = "actionId";
+    private static final String CONTINGENCY_ID = "contingencyId";
     public static final String MISMATCH = "mismatch";
+
+    public static final String LF_NETWORK_KEY = "lfNetwork";
+    public static final String POST_CONTINGENCY_SIMULATION_KEY = "postContingencySimulation";
 
     public record BusReport(String busId, double mismatch, double nominalV, double v, double phi, double p, double q) {
     }
@@ -455,7 +460,7 @@ public final class Reports {
 
     public static ReportNode createRootLfNetworkReportNode(int networkNumCc, int networkNumSc) {
         return ReportNode.newRootReportNode()
-                .withMessageTemplate("lfNetwork", "Network CC${networkNumCc} SC${networkNumSc}")
+                .withMessageTemplate(LF_NETWORK_KEY, "Network CC${networkNumCc} SC${networkNumSc}")
                 .withUntypedValue(NETWORK_NUM_CC, networkNumCc)
                 .withUntypedValue(NETWORK_NUM_SC, networkNumSc)
                 .build();
@@ -522,7 +527,7 @@ public final class Reports {
 
     public static ReportNode createPostContingencySimulation(ReportNode reportNode, String contingencyId) {
         return reportNode.newReportNode()
-                .withMessageTemplate("postContingencySimulation", "Post-contingency simulation '${contingencyId}'")
+                .withMessageTemplate(POST_CONTINGENCY_SIMULATION_KEY, "Post-contingency simulation '${contingencyId}'")
                 .withUntypedValue("contingencyId", contingencyId)
                 .add();
     }
@@ -701,6 +706,14 @@ public final class Reports {
                 .withUntypedValue("distributed", mismatch - remaining)
                 .withUntypedValue("remaining", remaining)
                 .withSeverity(TypedValue.INFO_SEVERITY)
+                .add();
+    }
+
+    public static void reportActionApplicationFailure(String actionId, String contingencyId, ReportNode node) {
+        node.newReportNode()
+                .withMessageTemplate("LfActionUtils", "Action '${actionId}': may not have been applied successfully on contingency '${contingencyId}'")
+                .withUntypedValue(ACTION_ID, actionId)
+                .withUntypedValue(CONTINGENCY_ID, contingencyId)
                 .add();
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -3556,6 +3556,10 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
 
         // The two report nodes should be equals
         assertEquals(swOneThread.toString(), swTwoThreads.toString());
+
+        // test with mt and no report
+        securityAnalysisParametersExt.setThreadCount(2);
+        runSecurityAnalysis(network, contingencies, Collections.emptyList(), securityAnalysisParameters, ReportNode.NO_OP);
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -3760,17 +3760,19 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(8389, reportString.length());
         // Check also that the preCont report is before the postContResults in the second CC
         String expected =
-                  "      + Network CC1 SC1\n" +
-                        "         + Network info\n" +
-                        "            Network has 2 buses and 2 branches\n" +
-                        "            Network balance: active generation=2.0 MW, active load=2.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar\n" +
-                        "            Angle reference bus: c1_vl_0\n" +
-                        "            Slack bus: c1_vl_0\n" +
-                        "         + Pre-contingency simulation\n" +
-                        "            Outer loop DistributedSlack\n" +
-                        "            Outer loop VoltageMonitoring\n" +
-                        "            Outer loop ReactiveLimits\n" +
-                        "            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)";
+                """
+                              + Network CC1 SC1
+                                 + Network info
+                                    Network has 2 buses and 2 branches
+                                    Network balance: active generation=2.0 MW, active load=2.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
+                                    Angle reference bus: c1_vl_0
+                                    Slack bus: c1_vl_0
+                                 + Pre-contingency simulation
+                                    Outer loop DistributedSlack
+                                    Outer loop VoltageMonitoring
+                                    Outer loop ReactiveLimits
+                                    AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)\
+                        """;
 
         assertTrue(reportString.contains(expected));
     }
@@ -3853,11 +3855,6 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(0.499, operatorStrategyResult.getBranchResult("lc12").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(0.499, operatorStrategyResult.getBranchResult("lc12Bis").getP1(), LoadFlowAssert.DELTA_POWER);
 
-        StringWriter sw = new StringWriter();
-        reportNode.print(sw);
-        // Remove Windows EOL
-        String reportString = TestUtil.normalizeLineSeparator(sw.toString());
-        // The purpose of this test is to check that the report is the same with one or two threads
         assertReportEquals("/saMtReport.txt", reportNode);
     }
 

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -13,6 +13,7 @@ import com.powsybl.action.LoadActionBuilder;
 import com.powsybl.action.TerminalsConnectionAction;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.test.TestUtil;
 import com.powsybl.contingency.*;
 import com.powsybl.ieeecdf.converter.IeeeCdfNetworkFactory;
 import com.powsybl.iidm.criteria.AtLeastOneNominalVoltageCriterion;
@@ -55,6 +56,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.util.*;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
@@ -3514,7 +3516,7 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
     }
 
     @Test
-    void testMultiThreads() {
+    void testMultiThreads() throws IOException {
         Network network = createNodeBreakerNetwork();
         assertFalse(network.getVariantManager().isVariantMultiThreadAccessAllowed());
 
@@ -3529,12 +3531,31 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
                 .map(id -> new Contingency(id, new BranchContingency(id)))
                 .toList();
 
-        SecurityAnalysisResult resultOneThread = runSecurityAnalysis(network, contingencies, Collections.emptyList(), securityAnalysisParameters);
+        ReportNode reportNodeOneThread = ReportNode.newRootReportNode()
+                .withMessageTemplate("MT_SA_TEST", "MT SA Report Node")
+                .build();
+        SecurityAnalysisResult resultOneThread =
+                runSecurityAnalysis(network, contingencies, Collections.emptyList(), securityAnalysisParameters, reportNodeOneThread);
+
         securityAnalysisParametersExt.setThreadCount(2);
-        SecurityAnalysisResult resultTwoThreads = runSecurityAnalysis(network, contingencies, Collections.emptyList(), securityAnalysisParameters);
+        ReportNode reportNodeTwoThreads = ReportNode.newRootReportNode()
+                .withMessageTemplate("MT_SA_TEST", "MT SA Report Node")
+                .build();
+        SecurityAnalysisResult resultTwoThreads =
+                runSecurityAnalysis(network, contingencies, Collections.emptyList(), securityAnalysisParameters, reportNodeOneThread);
+
         assertFalse(network.getVariantManager().isVariantMultiThreadAccessAllowed());
         assertEquals(resultOneThread.getPostContingencyResults().size(), resultTwoThreads.getPostContingencyResults().size());
         assertEquals(resultOneThread.getOperatorStrategyResults().size(), resultTwoThreads.getOperatorStrategyResults().size());
+
+        StringWriter swOneThread = new StringWriter();
+        reportNodeTwoThreads.print(swOneThread);
+
+        StringWriter swTwoThreads = new StringWriter();
+        reportNodeTwoThreads.print(swTwoThreads);
+
+        // The two report nodes should be equals
+        assertEquals(swOneThread.toString(), swTwoThreads.toString());
     }
 
     @Test
@@ -3658,8 +3679,9 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(network.getLine("l34").getTerminal1().getP(), networkResultContingency0.getBranchResult("l34").getP1(), LoadFlowAssert.DELTA_POWER);
     }
 
-    @Test
-    void multiComponentSaTest() {
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2})
+    void multiComponentSaTest(int threadCount) throws IOException {
         Network network = FourBusNetworkFactory.createWithTwoScs();
         // Add a load on small component
         network.getBusBreakerView().getBus("c1")
@@ -3672,20 +3694,41 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
                 .add();
 
         SecurityAnalysisParameters securityAnalysisParameters = new SecurityAnalysisParameters();
+        OpenSecurityAnalysisParameters securityAnalysisParametersExt = new OpenSecurityAnalysisParameters()
+                .setThreadCount(threadCount);
+        securityAnalysisParameters.addExtension(OpenSecurityAnalysisParameters.class, securityAnalysisParametersExt);
         securityAnalysisParameters.getLoadFlowParameters().setConnectedComponentMode(LoadFlowParameters.ConnectedComponentMode.ALL);
 
-        List<Contingency> contingencies = List.of(new Contingency("l13", new BranchContingency("l13")),
+        List<Contingency> checkedContingencies = List.of(new Contingency("l13", new BranchContingency("l13")),
                 new Contingency("dummyLoad", new LoadContingency("dummyLoad")));
+
+        // Add more contingencies to activate multi thread
+        List<Contingency> contingencies = new ArrayList<>(checkedContingencies);
+        for (int i = 0; i < 10; i++) {
+            contingencies.add(new Contingency("l13_" + i, new BranchContingency("l13")));
+            contingencies.add(new Contingency("dummyLoad_" + i, new LoadContingency("dummyLoad")));
+        }
 
         // Monitor branch in both components
         List<StateMonitor> monitors = List.of(
                 new StateMonitor(ContingencyContext.all(), Set.of("l14", "l12", "l23", "lc12", "lc12Bis"), emptySet(), emptySet())
         );
 
-        SecurityAnalysisResult results = runSecurityAnalysis(network, contingencies, monitors, securityAnalysisParameters);
+        ReportNode testReport = ReportNode.newRootReportNode()
+                .withMessageTemplate("TEST", "TEST Report Node")
+                .build();
+
+        SecurityAnalysisResult results = runSecurityAnalysis(network, contingencies, monitors, securityAnalysisParameters, testReport);
         NetworkResult preContingencyResults = results.getPreContingencyResult().getNetworkResult();
-        NetworkResult postContingencyResultsl13 = results.getPostContingencyResults().get(0).getNetworkResult();
-        NetworkResult postContingencyResultslc12Bis = results.getPostContingencyResults().get(1).getNetworkResult();
+        NetworkResult postContingencyResultsl13 = results.getPostContingencyResults().stream()
+                .filter(r -> r.getContingency().getId().equals("l13"))
+                .findAny()
+                .map(AbstractContingencyResult::getNetworkResult).orElseThrow();
+
+        NetworkResult postContingencyResultsDummyLoad = results.getPostContingencyResults().stream()
+                .filter(r -> r.getContingency().getId().equals("dummyLoad"))
+                .findAny()
+                .map(AbstractContingencyResult::getNetworkResult).orElseThrow();
 
         // Result for base case is available for all components
         assertEquals(0.084, preContingencyResults.getBranchResult("l14").getP1(), LoadFlowAssert.DELTA_POWER);
@@ -3704,13 +3747,37 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertNull(postContingencyResultsl13.getBranchResult("lc12Bis"));
 
         // Result for post contingency on dummyLoad is available for part of the network on which the contingency has an impact
-        assertEquals(0.498, postContingencyResultslc12Bis.getBranchResult("lc12").getP1(), LoadFlowAssert.DELTA_POWER);
-        assertEquals(0.498, postContingencyResultslc12Bis.getBranchResult("lc12Bis").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(0.498, postContingencyResultsDummyLoad.getBranchResult("lc12").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(0.498, postContingencyResultsDummyLoad.getBranchResult("lc12Bis").getP1(), LoadFlowAssert.DELTA_POWER);
+
+        StringWriter sw = new StringWriter();
+        testReport.print(sw);
+        // Remove Windows EOL
+        String reportString = TestUtil.normalizeLineSeparator(sw.toString());
+
+        // The report should be the same with one or two threads
+        // Let's just check the size here
+        assertEquals(8389, reportString.length());
+        // Check also that the preCont report is before the postContResults in the second CC
+        String expected =
+                  "      + Network CC1 SC1\n" +
+                        "         + Network info\n" +
+                        "            Network has 2 buses and 2 branches\n" +
+                        "            Network balance: active generation=2.0 MW, active load=2.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar\n" +
+                        "            Angle reference bus: c1_vl_0\n" +
+                        "            Slack bus: c1_vl_0\n" +
+                        "         + Pre-contingency simulation\n" +
+                        "            Outer loop DistributedSlack\n" +
+                        "            Outer loop VoltageMonitoring\n" +
+                        "            Outer loop ReactiveLimits\n" +
+                        "            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)";
+
+        assertTrue(reportString.contains(expected));
     }
 
     @ParameterizedTest
     @ValueSource(ints = {1, 2})
-    void multiComponentSaTestContingencyBothComponentsAndOperatorStrategy(int threadCount) {
+    void multiComponentSaTestContingencyBothComponentsAndOperatorStrategy(int threadCount) throws IOException {
 
         Network network = FourBusNetworkFactory.createWithTwoScs();
         // Add a load on small component
@@ -3786,6 +3853,12 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(0.499, operatorStrategyResult.getBranchResult("lc12").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(0.499, operatorStrategyResult.getBranchResult("lc12Bis").getP1(), LoadFlowAssert.DELTA_POWER);
 
+        StringWriter sw = new StringWriter();
+        reportNode.print(sw);
+        // Remove Windows EOL
+        String reportString = TestUtil.normalizeLineSeparator(sw.toString());
+        // The purpose of this test is to check that the report is the same with one or two threads
+        assertReportEquals("/saMtReport.txt", reportNode);
     }
 
 

--- a/src/test/resources/saMtReport.txt
+++ b/src/test/resources/saMtReport.txt
@@ -1,0 +1,282 @@
++ Test Report Node
+   + AC security analysis on network 'test'
+      + Network CC0 SC0
+         + Network info
+            Network has 4 buses and 5 branches
+            Network balance: active generation=3 MW, active load=5 MW, reactive generation=0 MVar, reactive load=0 MVar
+            Angle reference bus: b1_vl_0
+            Slack bus: b1_vl_0
+         + Pre-contingency simulation
+            + Outer loop DistributedSlack
+               + Outer loop iteration 1
+                  Slack bus active power (1.998967 MW) distributed in 1 distribution iteration(s)
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency'
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency'
+               Action 'dc2': may not have been applied successfully on contingency 'compositeContingency'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_0'
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_0'
+               Action 'dc2': may not have been applied successfully on contingency 'compositeContingency_0'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_1'
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_1'
+               Action 'dc2': may not have been applied successfully on contingency 'compositeContingency_1'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_2'
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_2'
+               Action 'dc2': may not have been applied successfully on contingency 'compositeContingency_2'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_3'
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_3'
+               Action 'dc2': may not have been applied successfully on contingency 'compositeContingency_3'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_4'
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_4'
+               Action 'dc2': may not have been applied successfully on contingency 'compositeContingency_4'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_5'
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_5'
+               Action 'dc2': may not have been applied successfully on contingency 'compositeContingency_5'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_6'
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_6'
+               Action 'dc2': may not have been applied successfully on contingency 'compositeContingency_6'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_7'
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_7'
+               Action 'dc2': may not have been applied successfully on contingency 'compositeContingency_7'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_8'
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_8'
+               Action 'dc2': may not have been applied successfully on contingency 'compositeContingency_8'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_9'
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_9'
+               Action 'dc2': may not have been applied successfully on contingency 'compositeContingency_9'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+      + Network CC1 SC1
+         + Network info
+            Network has 2 buses and 2 branches
+            Network balance: active generation=2 MW, active load=2 MW, reactive generation=0 MVar, reactive load=0 MVar
+            Angle reference bus: c1_vl_0
+            Slack bus: c1_vl_0
+         + Pre-contingency simulation
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency'
+            Contingency caused the loss of -1 MW injection: -1 MW distributed, 0 MW remaining.
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency'
+               Action 'open_l13': may not have been applied successfully on contingency 'compositeContingency'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_0'
+            Contingency caused the loss of -1 MW injection: -1 MW distributed, 0 MW remaining.
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_0'
+               Action 'open_l13': may not have been applied successfully on contingency 'compositeContingency_0'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_1'
+            Contingency caused the loss of -1 MW injection: -1 MW distributed, 0 MW remaining.
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_1'
+               Action 'open_l13': may not have been applied successfully on contingency 'compositeContingency_1'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_2'
+            Contingency caused the loss of -1 MW injection: -1 MW distributed, 0 MW remaining.
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_2'
+               Action 'open_l13': may not have been applied successfully on contingency 'compositeContingency_2'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_3'
+            Contingency caused the loss of -1 MW injection: -1 MW distributed, 0 MW remaining.
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_3'
+               Action 'open_l13': may not have been applied successfully on contingency 'compositeContingency_3'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_4'
+            Contingency caused the loss of -1 MW injection: -1 MW distributed, 0 MW remaining.
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_4'
+               Action 'open_l13': may not have been applied successfully on contingency 'compositeContingency_4'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_5'
+            Contingency caused the loss of -1 MW injection: -1 MW distributed, 0 MW remaining.
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_5'
+               Action 'open_l13': may not have been applied successfully on contingency 'compositeContingency_5'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_6'
+            Contingency caused the loss of -1 MW injection: -1 MW distributed, 0 MW remaining.
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_6'
+               Action 'open_l13': may not have been applied successfully on contingency 'compositeContingency_6'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_7'
+            Contingency caused the loss of -1 MW injection: -1 MW distributed, 0 MW remaining.
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_7'
+               Action 'open_l13': may not have been applied successfully on contingency 'compositeContingency_7'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_8'
+            Contingency caused the loss of -1 MW injection: -1 MW distributed, 0 MW remaining.
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_8'
+               Action 'open_l13': may not have been applied successfully on contingency 'compositeContingency_8'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+         + Post-contingency simulation 'compositeContingency_9'
+            Contingency caused the loss of -1 MW injection: -1 MW distributed, 0 MW remaining.
+            Outer loop DistributedSlack
+            Outer loop VoltageMonitoring
+            Outer loop ReactiveLimits
+            AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
+            + Operator strategy simulation 'strategy_compositeContingency_9'
+               Action 'open_l13': may not have been applied successfully on contingency 'compositeContingency_9'
+               Outer loop DistributedSlack
+               Outer loop VoltageMonitoring
+               Outer loop ReactiveLimits
+               AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)


### PR DESCRIPTION
**NOTE**: needs this PR to build: https://github.com/powsybl/powsybl-core/pull/3303

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ X ] The commit message follows our guidelines
- [ X ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
Some issues are reported in [#1167](https://github.com/powsybl/powsybl-open-loadflow/issues/1167)



**What kind of change does this PR introduce?**
There are some issues with Security Analysis in MT:
   * Reports contain duplicated entries for network loading and precontingency run
   * PostContingency results are split in different node (one per thread)
   * Operator Strategies are not supported (an exception is thrown because a contingency is not in the partition of a given thread)

This PR fixes those issues



**What is the new behavior (if this is a feature change)?**

One report node per CC that contains in order:
   One instance of network loading
   One instance of precontingency run
   All postcontingency results for that CC

The report is the same in single thread or multithread except that the contingency order may change.

In multi-thread mode, the check to verify that an operator strategy is associated to a contingency is not performed. 


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


