### PR TITLE
Modified exception message when initial LF fails in AC Sensi

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
@@ -23,6 +23,7 @@ import com.powsybl.openloadflow.ac.equations.AcVariableType;
 import com.powsybl.openloadflow.ac.solver.AcSolverStatus;
 import com.powsybl.openloadflow.ac.solver.AcSolverUtil;
 import com.powsybl.openloadflow.graph.GraphConnectivityFactory;
+import com.powsybl.openloadflow.lf.outerloop.OuterLoopStatus;
 import com.powsybl.openloadflow.network.*;
 import com.powsybl.openloadflow.network.impl.LfNetworkList;
 import com.powsybl.openloadflow.network.impl.Networks;
@@ -152,9 +153,15 @@ public class AcSensitivityAnalysis extends AbstractSensitivityAnalysis<AcVariabl
             return true;
         } else {
             if (throwsExceptionIfNoConvergence) {
-                throw new PowsyblException("Load flow ended with status " + result.getSolverStatus());
+                if (result.getSolverStatus() != AcSolverStatus.CONVERGED) {
+                    throw new PowsyblException("Load flow ended with solver status " + result.getSolverStatus());
+                } else if (result.getOuterLoopResult().status() != OuterLoopStatus.STABLE) {
+                    throw new PowsyblException("Load flow ended with outer loop status " + result.getOuterLoopResult().statusText());
+                } else {
+                    throw new PowsyblException("Load flow failed");
+                }
             } else {
-                LOGGER.warn("Load flow ended with status {}", result.getSolverStatus());
+                LOGGER.warn("Load flow failed with result={}", result);
                 return false;
             }
         }

--- a/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
@@ -146,17 +146,17 @@ public class AcSensitivityAnalysis extends AbstractSensitivityAnalysis<AcVariabl
         calculateSensitivityValues(lfFactors, factorGroups, factorsStates, contingencyIndex, resultWriter);
     }
 
-    private static boolean runLoadFlow(AcLoadFlowContext context, boolean throwsExceptionIfNoConvergence) {
+    private static boolean runLoadFlow(AcLoadFlowContext context, boolean isRunningBaseSituation) {
         AcLoadFlowResult result = new AcloadFlowEngine(context)
                 .run();
         if (result.isSuccess() || result.getSolverStatus() == AcSolverStatus.NO_CALCULATION) {
             return true;
         } else {
-            if (throwsExceptionIfNoConvergence) {
+            if (isRunningBaseSituation) {
                 if (result.getOuterLoopResult().status() != OuterLoopStatus.STABLE) {
-                    throw new PowsyblException("Load flow ended with outer loop status " + result.getOuterLoopResult().statusText());
+                    throw new PowsyblException("Initial load flow of base situation ended with outer loop status " + result.getOuterLoopResult().statusText());
                 } else {
-                    throw new PowsyblException("Load flow ended with solver status " + result.getSolverStatus());
+                    throw new PowsyblException("Initial load flow of base situation ended with solver status " + result.getSolverStatus());
                 }
             } else {
                 LOGGER.warn("Load flow failed with result={}", result);

--- a/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysis.java
@@ -153,12 +153,10 @@ public class AcSensitivityAnalysis extends AbstractSensitivityAnalysis<AcVariabl
             return true;
         } else {
             if (throwsExceptionIfNoConvergence) {
-                if (result.getSolverStatus() != AcSolverStatus.CONVERGED) {
-                    throw new PowsyblException("Load flow ended with solver status " + result.getSolverStatus());
-                } else if (result.getOuterLoopResult().status() != OuterLoopStatus.STABLE) {
+                if (result.getOuterLoopResult().status() != OuterLoopStatus.STABLE) {
                     throw new PowsyblException("Load flow ended with outer loop status " + result.getOuterLoopResult().statusText());
                 } else {
-                    throw new PowsyblException("Load flow failed");
+                    throw new PowsyblException("Load flow ended with solver status " + result.getSolverStatus());
                 }
             } else {
                 LOGGER.warn("Load flow failed with result={}", result);

--- a/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisTest.java
@@ -1534,12 +1534,12 @@ class AcSensitivityAnalysisTest extends AbstractSensitivityAnalysisTest {
         OpenLoadFlowParameters olfParameters = sensiParameters.getLoadFlowParameters().getExtension(OpenLoadFlowParameters.class);
         olfParameters.setMaxNewtonRaphsonIterations(1);
         CompletionException e = assertThrows(CompletionException.class, () -> sensiRunner.run(network, factors, contingencies, variableSets, sensiParameters));
-        assertEquals("Load flow ended with solver status MAX_ITERATION_REACHED", e.getCause().getMessage());
+        assertEquals("Initial load flow of base situation ended with solver status MAX_ITERATION_REACHED", e.getCause().getMessage());
 
         olfParameters.setMaxNewtonRaphsonIterations(10)
                 .setSlackBusPMaxMismatch(0.00001)
                 .setMaxOuterLoopIterations(1);
         e = assertThrows(CompletionException.class, () -> sensiRunner.run(network, factors, contingencies, variableSets, sensiParameters));
-        assertEquals("Load flow ended with outer loop status UNSTABLE", e.getCause().getMessage());
+        assertEquals("Initial load flow of base situation ended with outer loop status UNSTABLE", e.getCause().getMessage());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisTest.java
@@ -1526,19 +1526,20 @@ class AcSensitivityAnalysisTest extends AbstractSensitivityAnalysisTest {
                 "g1",
                 false,
                 ContingencyContext.all()));
-
+        List<Contingency> contingencies = Collections.emptyList();
+        List<SensitivityVariableSet> variableSets = Collections.emptyList();
         SensitivityAnalysisParameters sensiParameters = createParameters(false, "b1_vl_0");
         sensiParameters.getLoadFlowParameters().setDistributedSlack(true);
 
         OpenLoadFlowParameters olfParameters = sensiParameters.getLoadFlowParameters().getExtension(OpenLoadFlowParameters.class);
         olfParameters.setMaxNewtonRaphsonIterations(1);
-        CompletionException e = assertThrows(CompletionException.class, () -> sensiRunner.run(network, factors, Collections.emptyList(), Collections.emptyList(), sensiParameters));
+        CompletionException e = assertThrows(CompletionException.class, () -> sensiRunner.run(network, factors, contingencies, variableSets, sensiParameters));
         assertEquals("Load flow ended with solver status MAX_ITERATION_REACHED", e.getCause().getMessage());
 
         olfParameters.setMaxNewtonRaphsonIterations(10)
                 .setSlackBusPMaxMismatch(0.00001)
                 .setMaxOuterLoopIterations(1);
-        e = assertThrows(CompletionException.class, () -> sensiRunner.run(network, factors, Collections.emptyList(), Collections.emptyList(), sensiParameters));
+        e = assertThrows(CompletionException.class, () -> sensiRunner.run(network, factors, contingencies, variableSets, sensiParameters));
         assertEquals("Load flow ended with outer loop status UNSTABLE", e.getCause().getMessage());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Misleading exception message was thrown when load flow fails in AC sensi analysis. A correction is done to this message.



**What is the current behavior?**
When running an AC sensitivity analysis, if the first load flow fails because of UNSTABLE outer loop status, a PowsyblException is thrown with message : "Load flow ended with status CONVERGED"

**What is the new behavior (if this is a feature change)?**
A correct exception message is thrown depending on Load flow result.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
