### PR TITLE
fix voltage violation location

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
@@ -17,7 +17,6 @@ import com.powsybl.security.BusBreakerViolationLocation;
 import com.powsybl.security.NodeBreakerViolationLocation;
 import com.powsybl.security.ViolationLocation;
 import com.powsybl.security.results.BusResult;
-import com.powsybl.iidm.network.util.Networks;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -201,11 +200,7 @@ public class LfBusImpl extends AbstractLfBus {
         if (violationLocation == null) {
             violationLocation = switch (topologyKind) {
                 case NODE_BREAKER -> {
-                    List<Integer> nodes = new ArrayList<>();
-                    Map<String, Set<Integer>> nodesByBus = Networks.getNodesByBus(getBus().getVoltageLevel());
-                    if (nodesByBus.containsKey(getBus().getId())) {
-                        nodes = nodesByBus.get(getBus().getId()).stream().toList();
-                    }
+                    List<Integer> nodes = getBus().getConnectedTerminalStream().map(t -> t.getNodeBreakerView().getNode()).toList();
                     yield nodes.isEmpty() ? null : new NodeBreakerViolationLocation(getVoltageLevelId(), nodes);
                 }
                 case BUS_BREAKER -> {

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -185,6 +185,11 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertTrue(vl1ViolationLocation.isPresent());
         assertEquals(ViolationLocation.Type.NODE_BREAKER, vl1ViolationLocation.get().getType());
         assertEquals(List.of(0, 5), ((NodeBreakerViolationLocation) vl1ViolationLocation.get()).getNodes());
+
+        Optional<ViolationLocation> vl1ViolationLocation2 = result.getPreContingencyResult().getLimitViolationsResult().getLimitViolations().get(1).getViolationLocation();
+        assertTrue(vl1ViolationLocation2.isPresent());
+        assertEquals(ViolationLocation.Type.NODE_BREAKER, vl1ViolationLocation2.get().getType());
+        assertEquals(List.of(1, 3, 4), ((NodeBreakerViolationLocation) vl1ViolationLocation2.get()).getNodes());
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -184,7 +184,7 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         Optional<ViolationLocation> vl1ViolationLocation = result.getPreContingencyResult().getLimitViolationsResult().getLimitViolations().get(0).getViolationLocation();
         assertTrue(vl1ViolationLocation.isPresent());
         assertEquals(ViolationLocation.Type.NODE_BREAKER, vl1ViolationLocation.get().getType());
-        assertEquals(List.of(0, 1, 3, 4, 5, 6), ((NodeBreakerViolationLocation) vl1ViolationLocation.get()).getNodes());
+        assertEquals(List.of(0, 5), ((NodeBreakerViolationLocation) vl1ViolationLocation.get()).getNodes());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
Bug fix

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
the nodes gotten in violationLocation are not the ones fromthe nodebreakerview of the bus



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
