### PR TITLE
for limit reduction, duration criteria should depend on next limit's duration

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2019, RTE (http://www.rte-france.com)
+/*
+ * Copyright (c) 2019-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -297,7 +297,10 @@ public class LfBranchImpl extends AbstractImpedantLfBranch {
                     int i = 1; // temporary limit's reductions will be stored starting from index 1
                     for (LoadingLimits.TemporaryLimit temporaryLimit : limits.getTemporaryLimits()) {
                         if (terminalLimitReduction.acceptableDuration().contains(temporaryLimit.getAcceptableDuration())) {
-                            limitReductions[i] = terminalLimitReduction.reduction();
+                            limitReductions[i] = Math.min(limitReductions[i], terminalLimitReduction.reduction());
+                            // The reduction applies also to the next limit
+
+                            limitReductions[i - 1] = Math.min(limitReductions[i - 1], terminalLimitReduction.reduction());
                         }
                         i++;
                     }

--- a/src/test/java/com/powsybl/openloadflow/network/LfNetworkTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/LfNetworkTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2019, RTE (http://www.rte-france.com)
+/*
+ * Copyright (c) 2019-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -440,8 +440,8 @@ class LfNetworkTest extends AbstractSerDeTest {
         assertEquals(4, reductions.length);
         assertEquals(0.5, reductions[0], 0.001); // PATL
         assertEquals(0.8, reductions[1], 0.001); // TATL 600s
-        assertEquals(0.9, reductions[2], 0.001); // TATL 60s
-        // `terminalLimitReduction4` is declared after `terminalLimitReduction2`, so its value is used
+        assertEquals(0.87, reductions[2], 0.001); // TATL 60s // But the next tempo's reduction is stronger (than 0.9) so it is applied
+        // `terminalLimitReduction4` is stronger than`terminalLimitReduction2`, so its value is used
         assertEquals(0.87, reductions[3], 0.001); // TATL 0s
 
         limitReductionManager = new LimitReductionManager();
@@ -453,9 +453,9 @@ class LfNetworkTest extends AbstractSerDeTest {
         assertEquals(4, reductions.length);
         assertEquals(0.5, reductions[0], 0.001); // PATL
         assertEquals(0.8, reductions[1], 0.001); // TATL 600s
-        assertEquals(0.9, reductions[2], 0.001); // TATL 60s
-        // `terminalLimitReduction4` is now declared before `terminalLimitReduction2`, its value is overlapped by the one of `terminalLimitReduction2`
-        assertEquals(0.9, reductions[3], 0.001); // TATL 0s
+        assertEquals(0.87, reductions[2], 0.001); // TATL 60s
+        // `The limit reduction declaration order has no influcence. The strongest reduction is applied.
+        assertEquals(0.87, reductions[3], 0.001); // TATL 0s
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Limit reduction based on acceptable duration criteria should be applied based on the duration of the next limit.

Usually, the acceptable duration displayed in security analysis is the duration of the next limit.
When a reduction is applied to all limits with an acceptable duration of 5 minutes or less,
the expectation is that he reduction is applied also to the previous limit (with a duration just higher than 5 minutes) 
so that the operator is warned in advance.


**What is the current behavior?**
Reduction is applied to the limit with duration in range of the criteria. But this has no effect in term of detected the violation of the previous limit earlier.



**What is the new behavior (if this is a feature change)?**
- Reduction is applied to the limit with duration in range of the criteria, but also to the previous limit.

- In case two reductions appli to the same limit, the stronger reduction is used
  (previously, the reduction declared last was applied)


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

