### PR TITLE
[WIP] Round power values for SA power distribution reports

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/util/Reports.java
+++ b/src/main/java/com/powsybl/openloadflow/util/Reports.java
@@ -13,6 +13,7 @@ import com.powsybl.openloadflow.OpenLoadFlowReportConstants;
 import org.slf4j.Logger;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -697,9 +698,9 @@ public final class Reports {
     public static void reportContingencyActivePowerLossDistribution(ReportNode reportNode, double mismatch, double remaining) {
         reportNode.newReportNode()
                 .withMessageTemplate("contingencyActivePowerLossDistribution", "Contingency caused the loss of ${mismatch} MW injection: ${distributed} MW distributed, ${remaining} MW remaining.")
-                .withUntypedValue(MISMATCH, mismatch)
-                .withUntypedValue("distributed", mismatch - remaining)
-                .withUntypedValue("remaining", remaining)
+                .withUntypedValue(MISMATCH, String.format(Locale.UK, "%.2f", mismatch))
+                .withUntypedValue("distributed", String.format(Locale.UK, "%.2f", mismatch - remaining))
+                .withUntypedValue("remaining", String.format(Locale.UK, "%.2f", remaining))
                 .withSeverity(TypedValue.INFO_SEVERITY)
                 .add();
     }

--- a/src/test/resources/saReport.txt
+++ b/src/test/resources/saReport.txt
@@ -37,11 +37,11 @@
             Outer loop ReactiveLimits
             AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
          + Post-contingency simulation 'NGEN_NHV1'
-            Contingency caused the loss of 605.559595434878 MW injection: 0.0 MW distributed, 605.559595434878 MW remaining.
+            Contingency caused the loss of 605.56 MW injection: 0.00 MW distributed, 605.56 MW remaining.
             Network must have at least one bus with generator voltage control enabled
             AC load flow completed with error (solverStatus=SOLVER_FAILED, outerloopStatus=STABLE)
          + Post-contingency simulation 'NHV2_NLOAD'
-            Contingency caused the loss of -600.0 MW injection: -600.0 MW distributed, 0.0 MW remaining.
+            Contingency caused the loss of -600.00 MW injection: -600.00 MW distributed, 0.00 MW remaining.
             + Outer loop DistributedSlack
                + Outer loop iteration 1
                   Slack bus active power (-5.4942194604343655 MW) distributed in 1 distribution iteration(s)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


Reports for active power distribution in SA can have a 0.0 value or a very small one (like 1.654765476E-15) depending on the runs which cause uncertainty for unit tests results.
In this PR, suggestion is to format them to "%.2f"

