### PR TITLE
[WIP] Ensure HVDC AC Emulation tests have an operating range of at least 4 …

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfHvdcImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfHvdcImpl.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2022, RTE (http://www.rte-france.com)
+/*
+ * Copyright (c) 2022-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -13,6 +13,8 @@ import com.powsybl.iidm.network.extensions.HvdcOperatorActivePowerRange;
 import com.powsybl.openloadflow.network.*;
 import com.powsybl.openloadflow.util.Evaluable;
 import com.powsybl.openloadflow.util.PerUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 
@@ -22,6 +24,8 @@ import static com.powsybl.openloadflow.util.EvaluableConstants.NAN;
  * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
  */
 public class LfHvdcImpl extends AbstractElement implements LfHvdc {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LfHvdcImpl.class);
 
     private final String id;
 
@@ -71,6 +75,14 @@ public class LfHvdcImpl extends AbstractElement implements LfHvdc {
         } else {
             pMaxFromCS2toCS1 = hvdcLine.getMaxP();
             pMaxFromCS1toCS2 = hvdcLine.getMaxP();
+        }
+
+        if (this.acEmulation) {
+            // power is in MW (not PU) - droop is in MW/deg
+            double operatingAngleDeg = (pMaxFromCS1toCS2 + pMaxFromCS2toCS1) / droop;
+            if (operatingAngleDeg < 4) {
+                LOGGER.warn("Small operating angle for HVDC {} : {} deg", getId(), operatingAngleDeg);
+            }
         }
     }
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowVscTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2019, RTE (http://www.rte-france.com)
+/*
+ * Copyright (c) 2019-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -151,7 +151,7 @@ class AcLoadFlowVscTest {
     void testHvdcAcEmulation2() {
         Network network = HvdcNetworkFactory.createWithHvdcInAcEmulation();
         network.getHvdcLine("hvdc34").newExtension(HvdcAngleDroopActivePowerControlAdder.class)
-                .withDroop(180)
+                .withDroop(2)
                 .withP0(0.f)
                 .withEnabled(true)
                 .add();
@@ -166,11 +166,11 @@ class AcLoadFlowVscTest {
         assertTrue(result.isFullyConverged());
 
         VscConverterStation cs3 = network.getVscConverterStation("cs3");
-        assertActivePowerEquals(-0.114, cs3.getTerminal());
+        assertActivePowerEquals(-0.108, cs3.getTerminal());
         assertReactivePowerEquals(-4.226, cs3.getTerminal());
 
         VscConverterStation cs4 = network.getVscConverterStation("cs4");
-        assertActivePowerEquals(0.1166, cs4.getTerminal());
+        assertActivePowerEquals(0.1105, cs4.getTerminal());
         assertReactivePowerEquals(-3.600, cs4.getTerminal());
 
         network.getVscConverterStation("cs3").setVoltageRegulatorOn(false);
@@ -178,9 +178,9 @@ class AcLoadFlowVscTest {
         LoadFlowResult result2 = loadFlowRunner.run(network, parameters);
         assertTrue(result2.isFullyConverged());
 
-        assertActivePowerEquals(-0.089, cs3.getTerminal());
+        assertActivePowerEquals(-0.0853, cs3.getTerminal());
         assertReactivePowerEquals(0.0, cs3.getTerminal());
-        assertActivePowerEquals(0.0914, cs4.getTerminal());
+        assertActivePowerEquals(0.0872, cs4.getTerminal());
         assertReactivePowerEquals(0.0, cs4.getTerminal());
     }
 
@@ -505,7 +505,7 @@ class AcLoadFlowVscTest {
 
     @Test
     void testAcEmuWithOperationalLimits() {
-        Network network = HvdcNetworkFactory.createHvdcLinkedByTwoLinesAndSwitch(HvdcConverterStation.HvdcType.VSC);
+        Network network = HvdcNetworkFactory.createHvdcLinkedByTwoLinesAndSwitch(HvdcConverterStation.HvdcType.VSC, 80);
         // without limit p=195
         network.getHvdcLine("hvdc23")
                 .newExtension(HvdcOperatorActivePowerRangeAdder.class)
@@ -537,7 +537,7 @@ class AcLoadFlowVscTest {
 
     @Test
     void testAcEmuAndPMax() {
-        Network network = HvdcNetworkFactory.createHvdcLinkedByTwoLinesAndSwitch(HvdcConverterStation.HvdcType.VSC);
+        Network network = HvdcNetworkFactory.createHvdcLinkedByTwoLinesAndSwitch(HvdcConverterStation.HvdcType.VSC, 80);
         // without limit p=195
         network.getHvdcLine("hvdc23")
                 .setMaxP(170);

--- a/src/test/java/com/powsybl/openloadflow/network/HvdcNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/HvdcNetworkFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2021, RTE (http://www.rte-france.com)
+/*
+ * Copyright (c) 2021-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -603,6 +603,10 @@ public class HvdcNetworkFactory extends AbstractLoadFlowNetworkFactory {
         return network;
     }
 
+    public static Network createHvdcLinkedByTwoLinesAndSwitch(HvdcConverterStation.HvdcType type) {
+        return createHvdcLinkedByTwoLinesAndSwitch(type, 180);
+    }
+
     /**
      * <pre>
      *     g1 - b1 -- l12 -- b2 -- hvdc23 -- b3 -- l34 -- b4 - l4
@@ -615,7 +619,7 @@ public class HvdcNetworkFactory extends AbstractLoadFlowNetworkFactory {
      * </pre>
      * @return
      */
-    public static Network createHvdcLinkedByTwoLinesAndSwitch(HvdcConverterStation.HvdcType type) {
+    public static Network createHvdcLinkedByTwoLinesAndSwitch(HvdcConverterStation.HvdcType type, float droopMWPerDeg) {
         Network network = Network.create("test", "code");
         Bus b1 = createBus(network, "b1", 400);
         Bus b2 = createBus(network, "b2", 400);
@@ -636,7 +640,7 @@ public class HvdcNetworkFactory extends AbstractLoadFlowNetworkFactory {
         };
         createHvdcLine(network, "hvdc23", cs2, cs3, 400, 0.1, 200)
                 .newExtension(HvdcAngleDroopActivePowerControlAdder.class)
-                .withDroop(180)
+                .withDroop(droopMWPerDeg)
                 .withP0(200)
                 .withEnabled(true)
                 .add();

--- a/src/test/java/com/powsybl/openloadflow/network/LfNetworkTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/LfNetworkTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2019, RTE (http://www.rte-france.com)
+/*
+ * Copyright (c) 2019-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -254,7 +254,7 @@ class LfNetworkTest extends AbstractSerDeTest {
     void testElements() {
         Network network = HvdcNetworkFactory.createWithHvdcInAcEmulation();
         network.getHvdcLine("hvdc34").newExtension(HvdcAngleDroopActivePowerControlAdder.class)
-                .withDroop(180)
+                .withDroop(2)
                 .withP0(0.f)
                 .withEnabled(true)
                 .add();

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -1379,7 +1379,7 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
     void testHvdcAcEmulation() {
         Network network = HvdcNetworkFactory.createWithHvdcInAcEmulation();
         network.getHvdcLine("hvdc34").newExtension(HvdcAngleDroopActivePowerControlAdder.class)
-                .withDroop(180)
+                .withDroop(2)
                 .withP0(0.f)
                 .withEnabled(true)
                 .add();
@@ -1401,11 +1401,11 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies, monitors, parameters);
 
         PreContingencyResult preContingencyResult = result.getPreContingencyResult();
-        assertEquals(-1.768, preContingencyResult.getNetworkResult().getBranchResult("l25").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(-1.780, preContingencyResult.getNetworkResult().getBranchResult("l25").getP1(), LoadFlowAssert.DELTA_POWER);
 
         // post-contingency tests
         PostContingencyResult g1ContingencyResult = getPostContingencyResult(result, "g1");
-        assertEquals(-2.783, g1ContingencyResult.getNetworkResult().getBranchResult("l25").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(-2.848, g1ContingencyResult.getNetworkResult().getBranchResult("l25").getP1(), LoadFlowAssert.DELTA_POWER);
 
         List<Contingency> contingencies2 = new ArrayList<>();
         contingencies2.add(Contingency.hvdcLine("hvdc34"));
@@ -1417,7 +1417,7 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(-2.000, hvdcContingencyResult.getNetworkResult().getBranchResult("l25").getP1(), LoadFlowAssert.DELTA_POWER);
 
         PostContingencyResult g1ContingencyResult2 = getPostContingencyResult(result, "g1");
-        assertEquals(-2.783, g1ContingencyResult2.getNetworkResult().getBranchResult("l25").getP1(), LoadFlowAssert.DELTA_POWER);
+        assertEquals(-2.848, g1ContingencyResult2.getNetworkResult().getBranchResult("l25").getP1(), LoadFlowAssert.DELTA_POWER);
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisWithActionsTest.java
@@ -1131,7 +1131,7 @@ class OpenSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnalysisTe
     void testHvdcAction() {
         Network network = HvdcNetworkFactory.createWithHvdcInAcEmulation();
         network.getHvdcLine("hvdc34").newExtension(HvdcAngleDroopActivePowerControlAdder.class)
-                .withDroop(180)
+                .withDroop(2)
                 .withP0(0.f)
                 .withEnabled(true)
                 .add();

--- a/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisContingenciesTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisContingenciesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2020, RTE (http://www.rte-france.com)
+/*
+ * Copyright (c) 2020-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -973,7 +973,7 @@ class AcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
     void testContingencyOnHvdcVsc2() {
         Network network = HvdcNetworkFactory.createWithHvdcInAcEmulation();
         network.getHvdcLine("hvdc34").newExtension(HvdcAngleDroopActivePowerControlAdder.class)
-                .withDroop(180)
+                .withDroop(2)
                 .withP0(0.f)
                 .withEnabled(true)
                 .add();
@@ -1220,7 +1220,7 @@ class AcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
     void testRestoreAfterContingencyOnHvdc() {
         Network network = HvdcNetworkFactory.createWithHvdcInAcEmulation();
         network.getHvdcLine("hvdc34").newExtension(HvdcAngleDroopActivePowerControlAdder.class)
-                .withDroop(180)
+                .withDroop(2)
                 .withP0(0.f)
                 .withEnabled(true)
                 .add();
@@ -1236,9 +1236,9 @@ class AcSensitivityAnalysisContingenciesTest extends AbstractSensitivityAnalysis
 
         SensitivityAnalysisResult result = sensiRunner.run(network, factors, contingencies, Collections.emptyList(), sensiParameters);
 
-        assertEquals(0.269, result.getBranchFlow1SensitivityValue("l45", "g1", "l12", SensitivityVariableType.INJECTION_ACTIVE_POWER), LoadFlowAssert.DELTA_POWER);
-        assertEquals(0.356, result.getBranchFlow1SensitivityValue("l45", "g1", "l25", SensitivityVariableType.INJECTION_ACTIVE_POWER), LoadFlowAssert.DELTA_POWER);
-        assertEquals(-0.144, result.getBranchFlow1SensitivityValue("l45", "g1", "l56", SensitivityVariableType.INJECTION_ACTIVE_POWER), LoadFlowAssert.DELTA_POWER);
+        assertEquals(0.270, result.getBranchFlow1SensitivityValue("l45", "g1", "l12", SensitivityVariableType.INJECTION_ACTIVE_POWER), LoadFlowAssert.DELTA_POWER);
+        assertEquals(0.360, result.getBranchFlow1SensitivityValue("l45", "g1", "l25", SensitivityVariableType.INJECTION_ACTIVE_POWER), LoadFlowAssert.DELTA_POWER);
+        assertEquals(-0.139, result.getBranchFlow1SensitivityValue("l45", "g1", "l56", SensitivityVariableType.INJECTION_ACTIVE_POWER), LoadFlowAssert.DELTA_POWER);
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2020, RTE (http://www.rte-france.com)
+/*
+ * Copyright (c) 2020-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -1087,7 +1087,7 @@ class AcSensitivityAnalysisTest extends AbstractSensitivityAnalysisTest {
     void testWithHvdcAcEmulation() {
         Network network = HvdcNetworkFactory.createWithHvdcInAcEmulation();
         network.getHvdcLine("hvdc34").newExtension(HvdcAngleDroopActivePowerControlAdder.class)
-                .withDroop(180)
+                .withDroop(2)
                 .withP0(0.f)
                 .withEnabled(true)
                 .add();
@@ -1103,7 +1103,7 @@ class AcSensitivityAnalysisTest extends AbstractSensitivityAnalysisTest {
         List<SensitivityFactor> factors = List.of(createBranchFlowPerInjectionIncrease("l25", "d2"));
 
         SensitivityAnalysisResult result = sensiRunner.run(network, factors, Collections.emptyList(), Collections.emptyList(), sensiParameters);
-        assertEquals(0.442, result.getBranchFlow1SensitivityValue("d2", "l25", SensitivityVariableType.INJECTION_ACTIVE_POWER), LoadFlowAssert.DELTA_POWER);
+        assertEquals(0.445, result.getBranchFlow1SensitivityValue("d2", "l25", SensitivityVariableType.INJECTION_ACTIVE_POWER), LoadFlowAssert.DELTA_POWER);
     }
 
     @Test


### PR DESCRIPTION
…degres between PMin and PMax

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Some tests about HVDC in AC emulation have unrealistic settings, with a very large droop (MW per degree) and a small operational limit. As a result the angle range in which the HVDC is not at PMax or at PMin is very small, leading to an unstable network and artiificial numerical difficulties for the Solver.

This PR ensure that the operating range of HVDC in AC emulation is at least of 2 degrees in all test.
  - HVDC configuration has been changed test with AC emulation
  - Expected resulsts have been adjusted


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No
