### PR TITLE
Refactor access to branch limits when detecting limit violations

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
@@ -31,11 +31,15 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
     protected final LfBus bus2;
 
     private List<LfLimit> currentLimits1;
+
     private List<LfLimit> activePowerLimits1;
+
     private List<LfLimit> apparentPowerLimits1;
 
     private List<LfLimit> currentLimits2;
+
     private List<LfLimit> activePowerLimits2;
+
     private List<LfLimit> apparentPowerLimits2;
 
     protected final PiModel piModel;
@@ -161,6 +165,18 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
         }
     }
 
+    public <T extends LoadingLimits> List<LfLimit> getLimits1(LimitType type, Supplier<Optional<T>> loadingLimitsSupplier, LimitReductionManager limitReductionManager) {
+        var limits = getLimits1(type);
+        if (limits == null) {
+            // It is possible to apply the reductions here since the only supported ContingencyContext for LimitReduction is ALL.
+            var loadingLimits = loadingLimitsSupplier.get().orElse(null);
+            limits = createSortedLimitsList(loadingLimits, bus1,
+                    getLimitReductions(TwoSides.ONE, limitReductionManager, loadingLimits));
+            setLimits1(type, limits);
+        }
+        return limits;
+    }
+
     private List<LfLimit> getLimits2(LimitType type) {
         switch (type) {
             case ACTIVE_POWER -> {
@@ -183,18 +199,6 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
             case CURRENT -> currentLimits2 = limits;
             default -> throw new UnsupportedOperationException(String.format("Getting limits of type %s is not supported.", type));
         }
-    }
-
-    public <T extends LoadingLimits> List<LfLimit> getLimits1(LimitType type, Supplier<Optional<T>> loadingLimitsSupplier, LimitReductionManager limitReductionManager) {
-        var limits = getLimits1(type);
-        if (limits == null) {
-            // It is possible to apply the reductions here since the only supported ContingencyContext for LimitReduction is ALL.
-            var loadingLimits = loadingLimitsSupplier.get().orElse(null);
-            limits = createSortedLimitsList(loadingLimits, bus1,
-                    getLimitReductions(TwoSides.ONE, limitReductionManager, loadingLimits));
-            setLimits1(type, limits);
-        }
-        return limits;
     }
 
     public <T extends LoadingLimits> List<LfLimit> getLimits2(LimitType type, Supplier<Optional<T>> loadingLimitsSupplier, LimitReductionManager limitReductionManager) {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
@@ -152,7 +152,7 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
             case CURRENT -> {
                 return currentLimits1;
             }
-            default -> throw new UnsupportedOperationException(String.format("Getting limits of type %s is not supported.", type));
+            default -> throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));
         }
     }
 
@@ -161,7 +161,7 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
             case ACTIVE_POWER -> activePowerLimits1 = limits;
             case APPARENT_POWER -> apparentPowerLimits1 = limits;
             case CURRENT -> currentLimits1 = limits;
-            default -> throw new UnsupportedOperationException(String.format("Getting limits of type %s is not supported.", type));
+            default -> throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));
         }
     }
 
@@ -188,7 +188,7 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
             case CURRENT -> {
                 return currentLimits2;
             }
-            default -> throw new UnsupportedOperationException(String.format("Getting limits of type %s is not supported.", type));
+            default -> throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));
         }
     }
 
@@ -197,7 +197,7 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
             case ACTIVE_POWER -> activePowerLimits2 = limits;
             case APPARENT_POWER -> apparentPowerLimits2 = limits;
             case CURRENT -> currentLimits2 = limits;
-            default -> throw new UnsupportedOperationException(String.format("Getting limits of type %s is not supported.", type));
+            default -> throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
@@ -30,9 +30,13 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
 
     protected final LfBus bus2;
 
-    private final Map<LimitType, List<LfLimit>> limits1 = new EnumMap<>(LimitType.class);
+    private List<LfLimit> currentLimits1;
+    private List<LfLimit> activePowerLimits1;
+    private List<LfLimit> apparentPowerLimits1;
 
-    private final Map<LimitType, List<LfLimit>> limits2 = new EnumMap<>(LimitType.class);
+    private List<LfLimit> currentLimits2;
+    private List<LfLimit> activePowerLimits2;
+    private List<LfLimit> apparentPowerLimits2;
 
     protected final PiModel piModel;
 
@@ -87,7 +91,7 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
      * The resulting list will contain the permanent limit
      */
     protected static List<LfLimit> createSortedLimitsList(LoadingLimits loadingLimits, LfBus bus, double[] limitReductions) {
-        LinkedList<LfLimit> sortedLimits = new LinkedList<>();
+        List<LfLimit> sortedLimits = new ArrayList<>(3);
         if (loadingLimits != null) {
             double toPerUnit = getScaleForLimitType(loadingLimits.getLimitType(), bus);
 
@@ -99,13 +103,13 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
                     // https://javadoc.io/doc/com.powsybl/powsybl-core/latest/com/powsybl/iidm/network/CurrentLimits.html
                     double reduction = limitReductions.length == 0 ? 1d : limitReductions[i + 1]; // Temporary limit's reductions are stored starting from index 1 in `limitReductions`
                     double originalValuePerUnit = temporaryLimit.getValue() * toPerUnit;
-                    sortedLimits.addFirst(LfLimit.createTemporaryLimit(temporaryLimit.getName(), temporaryLimit.getAcceptableDuration(),
+                    sortedLimits.add(0, LfLimit.createTemporaryLimit(temporaryLimit.getName(), temporaryLimit.getAcceptableDuration(),
                             originalValuePerUnit, reduction));
                 }
                 i++;
             }
             double reduction = limitReductions.length == 0 ? 1d : limitReductions[0];
-            sortedLimits.addLast(LfLimit.createPermanentLimit(loadingLimits.getPermanentLimit() * toPerUnit, reduction));
+            sortedLimits.add(LfLimit.createPermanentLimit(loadingLimits.getPermanentLimit() * toPerUnit, reduction));
         }
         if (sortedLimits.size() > 1) {
             // we only make that fix if there is more than a permanent limit attached to the branch.
@@ -113,7 +117,7 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
                 // From the permanent limit to the most serious temporary limit.
                 sortedLimits.get(i).setAcceptableDuration(sortedLimits.get(i - 1).getAcceptableDuration());
             }
-            sortedLimits.getFirst().setAcceptableDuration(0);
+            sortedLimits.get(0).setAcceptableDuration(0);
         }
         return sortedLimits;
     }
@@ -133,22 +137,76 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
         return bus2;
     }
 
+    private List<LfLimit> getLimits1(LimitType type) {
+        switch (type) {
+            case ACTIVE_POWER -> {
+                return activePowerLimits1;
+            }
+            case APPARENT_POWER -> {
+                return apparentPowerLimits1;
+            }
+            case CURRENT -> {
+                return currentLimits1;
+            }
+            default -> throw new UnsupportedOperationException(String.format("Getting limits of type %s is not supported.", type));
+        }
+    }
+
+    private void setLimits1(LimitType type, List<LfLimit> limits) {
+        switch (type) {
+            case ACTIVE_POWER -> activePowerLimits1 = limits;
+            case APPARENT_POWER -> apparentPowerLimits1 = limits;
+            case CURRENT -> currentLimits1 = limits;
+            default -> throw new UnsupportedOperationException(String.format("Getting limits of type %s is not supported.", type));
+        }
+    }
+
+    private List<LfLimit> getLimits2(LimitType type) {
+        switch (type) {
+            case ACTIVE_POWER -> {
+                return activePowerLimits2;
+            }
+            case APPARENT_POWER -> {
+                return apparentPowerLimits2;
+            }
+            case CURRENT -> {
+                return currentLimits2;
+            }
+            default -> throw new UnsupportedOperationException(String.format("Getting limits of type %s is not supported.", type));
+        }
+    }
+
+    private void setLimits2(LimitType type, List<LfLimit> limits) {
+        switch (type) {
+            case ACTIVE_POWER -> activePowerLimits2 = limits;
+            case APPARENT_POWER -> apparentPowerLimits2 = limits;
+            case CURRENT -> currentLimits2 = limits;
+            default -> throw new UnsupportedOperationException(String.format("Getting limits of type %s is not supported.", type));
+        }
+    }
+
     public <T extends LoadingLimits> List<LfLimit> getLimits1(LimitType type, Supplier<Optional<T>> loadingLimitsSupplier, LimitReductionManager limitReductionManager) {
-        // It is possible to apply the reductions here since the only supported ContingencyContext for LimitReduction is ALL.
-        return limits1.computeIfAbsent(type, v -> {
+        var limits = getLimits1(type);
+        if (limits == null) {
+            // It is possible to apply the reductions here since the only supported ContingencyContext for LimitReduction is ALL.
             var loadingLimits = loadingLimitsSupplier.get().orElse(null);
-            return createSortedLimitsList(loadingLimits, bus1,
+            limits = createSortedLimitsList(loadingLimits, bus1,
                     getLimitReductions(TwoSides.ONE, limitReductionManager, loadingLimits));
-        });
+            setLimits1(type, limits);
+        }
+        return limits;
     }
 
     public <T extends LoadingLimits> List<LfLimit> getLimits2(LimitType type, Supplier<Optional<T>> loadingLimitsSupplier, LimitReductionManager limitReductionManager) {
-        // It is possible to apply the reductions here since the only supported ContingencyContext for LimitReduction is ALL.
-        return limits2.computeIfAbsent(type, v -> {
+        var limits = getLimits2(type);
+        if (limits == null) {
+            // It is possible to apply the reductions here since the only supported ContingencyContext for LimitReduction is ALL.
             var loadingLimits = loadingLimitsSupplier.get().orElse(null);
-            return createSortedLimitsList(loadingLimits, bus2,
+            limits = createSortedLimitsList(loadingLimits, bus2,
                     getLimitReductions(TwoSides.TWO, limitReductionManager, loadingLimits));
-        });
+            setLimits2(type, limits);
+        }
+        return limits;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBranch.java
@@ -69,6 +69,8 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
 
     protected LfAsymLine asymLine;
 
+    private static final String LIMIT_TYPE_UNSUPPORTED_TEMPLATE = "Getting %s limits is not supported.";
+
     protected AbstractLfBranch(LfNetwork network, LfBus bus1, LfBus bus2, PiModel piModel, LfNetworkParameters parameters) {
         super(network);
         this.bus1 = bus1;
@@ -152,7 +154,7 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
             case CURRENT -> {
                 return currentLimits1;
             }
-            default -> throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));
+            default -> throw new UnsupportedOperationException(String.format(LIMIT_TYPE_UNSUPPORTED_TEMPLATE, type.name()));
         }
     }
 
@@ -161,7 +163,7 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
             case ACTIVE_POWER -> activePowerLimits1 = limits;
             case APPARENT_POWER -> apparentPowerLimits1 = limits;
             case CURRENT -> currentLimits1 = limits;
-            default -> throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));
+            default -> throw new UnsupportedOperationException(String.format(LIMIT_TYPE_UNSUPPORTED_TEMPLATE, type.name()));
         }
     }
 
@@ -188,7 +190,7 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
             case CURRENT -> {
                 return currentLimits2;
             }
-            default -> throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));
+            default -> throw new UnsupportedOperationException(String.format(LIMIT_TYPE_UNSUPPORTED_TEMPLATE, type.name()));
         }
     }
 
@@ -197,7 +199,7 @@ public abstract class AbstractLfBranch extends AbstractElement implements LfBran
             case ACTIVE_POWER -> activePowerLimits2 = limits;
             case APPARENT_POWER -> apparentPowerLimits2 = limits;
             case CURRENT -> currentLimits2 = limits;
-            default -> throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));
+            default -> throw new UnsupportedOperationException(String.format(LIMIT_TYPE_UNSUPPORTED_TEMPLATE, type.name()));
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBranchImpl.java
@@ -234,14 +234,13 @@ public class LfBranchImpl extends AbstractImpedantLfBranch {
 
     @Override
     public List<LfLimit> getLimits1(final LimitType type, LimitReductionManager limitReductionManager) {
-        var branch = getBranch();
         switch (type) {
             case ACTIVE_POWER:
-                return getLimits1(type, branch::getActivePowerLimits1, limitReductionManager);
+                return getLimits1(type, () -> getBranch().getActivePowerLimits1(), limitReductionManager);
             case APPARENT_POWER:
-                return getLimits1(type, branch::getApparentPowerLimits1, limitReductionManager);
+                return getLimits1(type, () -> getBranch().getApparentPowerLimits1(), limitReductionManager);
             case CURRENT:
-                return getLimits1(type, branch::getCurrentLimits1, limitReductionManager);
+                return getLimits1(type, () -> getBranch().getCurrentLimits1(), limitReductionManager);
             case VOLTAGE:
             default:
                 throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));
@@ -250,14 +249,13 @@ public class LfBranchImpl extends AbstractImpedantLfBranch {
 
     @Override
     public List<LfLimit> getLimits2(final LimitType type, LimitReductionManager limitReductionManager) {
-        var branch = getBranch();
         switch (type) {
             case ACTIVE_POWER:
-                return getLimits2(type, branch::getActivePowerLimits2, limitReductionManager);
+                return getLimits2(type, () -> getBranch().getActivePowerLimits2(), limitReductionManager);
             case APPARENT_POWER:
-                return getLimits2(type, branch::getApparentPowerLimits2, limitReductionManager);
+                return getLimits2(type, () -> getBranch().getApparentPowerLimits2(), limitReductionManager);
             case CURRENT:
-                return getLimits2(type, branch::getCurrentLimits2, limitReductionManager);
+                return getLimits2(type, () -> getBranch().getCurrentLimits2(), limitReductionManager);
             case VOLTAGE:
             default:
                 throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfDanglingLineBranch.java
@@ -80,14 +80,13 @@ public class LfDanglingLineBranch extends AbstractImpedantLfBranch {
 
     @Override
     public List<LfLimit> getLimits1(final LimitType type, LimitReductionManager limitReductionManager) {
-        var danglingLine = getDanglingLine();
         switch (type) {
             case ACTIVE_POWER:
-                return getLimits1(type, danglingLine::getActivePowerLimits, limitReductionManager);
+                return getLimits1(type, () -> getDanglingLine().getActivePowerLimits(), limitReductionManager);
             case APPARENT_POWER:
-                return getLimits1(type, danglingLine::getApparentPowerLimits, limitReductionManager);
+                return getLimits1(type, () -> getDanglingLine().getApparentPowerLimits(), limitReductionManager);
             case CURRENT:
-                return getLimits1(type, danglingLine::getCurrentLimits, limitReductionManager);
+                return getLimits1(type, () -> getDanglingLine().getCurrentLimits(), limitReductionManager);
             case VOLTAGE:
             default:
                 throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
@@ -147,14 +147,13 @@ public final class LfLegBranch extends AbstractImpedantLfBranch {
 
     @Override
     public List<LfLimit> getLimits1(final LimitType type, LimitReductionManager limitReductionManager) {
-        var leg = getLeg();
         switch (type) {
             case ACTIVE_POWER:
-                return getLimits1(type, leg::getActivePowerLimits, limitReductionManager);
+                return getLimits1(type, () -> getLeg().getActivePowerLimits(), limitReductionManager);
             case APPARENT_POWER:
-                return getLimits1(type, leg::getApparentPowerLimits, limitReductionManager);
+                return getLimits1(type, () -> getLeg().getApparentPowerLimits(), limitReductionManager);
             case CURRENT:
-                return getLimits1(type, leg::getCurrentLimits, limitReductionManager);
+                return getLimits1(type, () -> getLeg().getCurrentLimits(), limitReductionManager);
             case VOLTAGE:
             default:
                 throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));

--- a/src/main/java/com/powsybl/openloadflow/sa/LimitViolationManager.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/LimitViolationManager.java
@@ -110,21 +110,23 @@ public class LimitViolationManager {
         List<LfBranch.LfLimit> limits = limitsGetter.apply(branch, LimitType.CURRENT, limitReductionManager);
         if (!limits.isEmpty()) {
             double i = iGetter.apply(branch).eval();
-            limits.stream()
-                    .filter(temporaryLimit -> i > temporaryLimit.getReducedValue())
-                    .findFirst()
-                    .map(temporaryLimit -> createLimitViolation(branch, temporaryLimit, LimitViolationType.CURRENT, PerUnit.ib(bus.getNominalV()), i, side))
-                    .ifPresent(this::addBranchLimitViolation);
+            for (LfBranch.LfLimit temporaryLimit : limits) {
+                if (i > temporaryLimit.getReducedValue()) {
+                    addBranchLimitViolation(createLimitViolation(branch, temporaryLimit, LimitViolationType.CURRENT, PerUnit.ib(bus.getNominalV()), i, side));
+                    break;
+                }
+            }
         }
 
         limits = limitsGetter.apply(branch, LimitType.ACTIVE_POWER, limitReductionManager);
         if (!limits.isEmpty()) {
             double p = pGetter.apply(branch).eval();
-            limits.stream()
-                    .filter(temporaryLimit -> Math.abs(p) > temporaryLimit.getReducedValue())
-                    .findFirst()
-                    .map(temporaryLimit -> createLimitViolation(branch, temporaryLimit, LimitViolationType.ACTIVE_POWER, PerUnit.SB, p, side))
-                    .ifPresent(this::addBranchLimitViolation);
+            for (LfBranch.LfLimit temporaryLimit : limits) {
+                if (Math.abs(p) > temporaryLimit.getReducedValue()) {
+                    addBranchLimitViolation(createLimitViolation(branch, temporaryLimit, LimitViolationType.ACTIVE_POWER, PerUnit.SB, p, side));
+                    break;
+                }
+            }
         }
 
         limits = limitsGetter.apply(branch, LimitType.APPARENT_POWER, limitReductionManager);
@@ -132,11 +134,12 @@ public class LimitViolationManager {
             //Apparent power is not relevant for fictitious branches and may be NaN
             double s = sGetter.applyAsDouble(branch);
             if (!Double.isNaN(s)) {
-                limits.stream()
-                        .filter(temporaryLimit -> s > temporaryLimit.getReducedValue())
-                        .findFirst()
-                        .map(temporaryLimit -> createLimitViolation(branch, temporaryLimit, LimitViolationType.APPARENT_POWER, PerUnit.SB, s, side))
-                        .ifPresent(this::addBranchLimitViolation);
+                for (LfBranch.LfLimit temporaryLimit : limits) {
+                    if (s > temporaryLimit.getReducedValue()) {
+                        addBranchLimitViolation(createLimitViolation(branch, temporaryLimit, LimitViolationType.APPARENT_POWER, PerUnit.SB, s, side));
+                        break;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No, but the development is based on the collaborative work of #1169 , aiming to improve the performance of the fast DC SA. 

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
The access to branch limits is refactored, for better performances.


**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->
The branch limits are stored in Maps, indexed by `LimitType`. 


**What is the new behavior (if this is a feature change)?**

There is a list of limits for each `LimitType`. Some method references are also replaced by lambdas.
With this refactoring, the time spent on detection of limit violations is reduced, improving the performances of the fast DC SA.

<img width="902" alt="diff-perfs-before-after-refactor-fast-dc-sa" src="https://github.com/user-attachments/assets/e15437b8-6dbb-4e88-9b6d-fc6863ae4333" />

Same with slow DC SA.

<img width="910" alt="diff-perfs-before-after-refactor-slow-dc-sa" src="https://github.com/user-attachments/assets/7112b1f0-4ce9-4348-8b5d-1edea72ea8ac" />

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
