### PR TITLE
In Connectivity Report do not count twice lost loads and generators that are on a contingency bus

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/LfContingency.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfContingency.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2020, RTE (http://www.rte-france.com)
+/*
+ * Copyright (c) 2020-2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -67,11 +67,15 @@ public class LfContingency {
         }
         for (Map.Entry<LfLoad, LfLostLoad> e : lostLoads.entrySet()) {
             LfLostLoad lostLoad = e.getValue();
-            disconnectedLoadActivePower += lostLoad.getPowerShift().getActive();
+            if (!disabledNetwork.getBuses().contains(e.getKey().getBus())) {
+                disconnectedLoadActivePower += lostLoad.getPowerShift().getActive();
+            }
             disconnectedElementIds.addAll(lostLoad.getOriginalIds());
         }
         for (LfGenerator generator : lostGenerators) {
-            disconnectedGenerationActivePower += generator.getTargetP();
+            if (!disabledNetwork.getBuses().contains(generator.getBus())) {
+                disconnectedGenerationActivePower += generator.getTargetP();
+            }
             disconnectedElementIds.add(generator.getOriginalId());
         }
         disconnectedElementIds.addAll(disabledNetwork.getBranches().stream().map(LfBranch::getId).toList());

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -83,6 +83,8 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
                 .collect(Collectors.toList());
         contingencies.add(new Contingency("LD", new LoadContingency("LD")));
 
+        contingencies.add(new Contingency("BBS2", new BusbarSectionContingency("BBS2")));
+
         StateMonitor stateMonitor = new StateMonitor(ContingencyContext.all(), Collections.emptySet(),
                 network.getVoltageLevelStream().map(Identifiable::getId).collect(Collectors.toSet()), Collections.emptySet());
 
@@ -90,13 +92,18 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
 
         assertSame(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getPreContingencyResult().getStatus());
         assertEquals(0, result.getPreContingencyResult().getLimitViolationsResult().getLimitViolations().size());
-        assertEquals(3, result.getPostContingencyResults().size());
+        assertEquals(4, result.getPostContingencyResults().size());
         assertSame(PostContingencyComputationStatus.CONVERGED, result.getPostContingencyResults().get(0).getStatus());
         assertEquals(2, result.getPostContingencyResults().get(0).getLimitViolationsResult().getLimitViolations().size());
+        assertEquals(0, result.getPostContingencyResults().get(0).getConnectivityResult().getDisconnectedLoadActivePower());
         assertSame(PostContingencyComputationStatus.CONVERGED, result.getPostContingencyResults().get(1).getStatus());
         assertEquals(2, result.getPostContingencyResults().get(1).getLimitViolationsResult().getLimitViolations().size());
+        assertEquals(0, result.getPostContingencyResults().get(1).getConnectivityResult().getDisconnectedLoadActivePower());
         PostContingencyResult postContingencyResult = getPostContingencyResult(result, "LD");
+        assertEquals(600, postContingencyResult.getConnectivityResult().getDisconnectedLoadActivePower());
         assertEquals(398.0, postContingencyResult.getNetworkResult().getBusResult("BBS2").getV(), LoadFlowAssert.DELTA_V);
+
+        assertEquals(603.77, getPostContingencyResult(result, "BBS2").getConnectivityResult().getDisconnectedGenerationActivePower());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X ] The commit message follows our guidelines
- [X ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix:
   In node breaker mode, loads and generators on a bus affected by a contingency are counted twice


**What is the new behavior (if this is a feature change)?**
Lost loads and generators are not counted a second time if they belong to a lost bus


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X ] No

