### PR TITLE
fix double slack distribution in SA DC

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowEngine.java
@@ -74,7 +74,9 @@ public class DcLoadFlowEngine implements LoadFlowEngine<DcVariableType, DcEquati
     public static double getActivePowerMismatch(Collection<LfBus> buses) {
         double mismatch = 0;
         for (LfBus b : buses) {
-            mismatch += b.getGenerationTargetP() - b.getLoadTargetP();
+            if (!b.isDisabled()) {
+                mismatch += b.getGenerationTargetP() - b.getLoadTargetP();
+            }
         }
         return -mismatch;
     }

--- a/src/test/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysisWithActionsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysisWithActionsTest.java
@@ -17,7 +17,6 @@ import com.powsybl.contingency.ContingencyContext;
 import com.powsybl.contingency.LoadContingency;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.loadflow.LoadFlowParameters;
-import com.powsybl.loadflow.LoadFlowResult;
 import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.network.PhaseControlFactory;
 import com.powsybl.openloadflow.network.SlackBusSelectionMode;

--- a/src/test/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysisWithActionsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysisWithActionsTest.java
@@ -257,7 +257,7 @@ class WoodburyDcSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnal
         // Apply remedial action
         network.getTwoWindingsTransformer("PS1").getPhaseTapChanger().setTapPosition(0);
 
-        LoadFlowResult lfResult = loadFlowRunner.run(network, parameters);
+        loadFlowRunner.run(network, parameters);
 
         // Compare results on the line L12
         assertEquals(network.getLine("L12").getTerminal1().getP(), brAbsL12.getP1(), LoadFlowAssert.DELTA_POWER);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
In DC the active power mismatch is computer on all bus whether they are enabled or disabled.
This leads to wrong computations in Security Analysis if the lost network contains unbalanced loads and generators.

**Note** that in general the slack distribution is a loss of time in DC security analysis because it was initially made extactly based on the contingency propagation. So the DC engine performs a useless iteration on all buses in SA.



**What is the current behavior?**
Slack distribution in DC security analysis (default mode) is long each time a unbalanced part of the network is lost.



**What is the new behavior (if this is a feature change)?**
Slack distribution in DC security analysis is correct.



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


