### PR TITLE
Adapt engine stopping criteria to test precision

### DIFF
--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowPhaseShifterTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowPhaseShifterTest.java
@@ -498,16 +498,18 @@ class AcLoadFlowPhaseShifterTest {
 
         parameters.setPhaseShifterRegulationOn(true);
         parametersExt.setPhaseShifterControlMode(OpenLoadFlowParameters.PhaseShifterControlMode.INCREMENTAL);
+        parametersExt.setSlackBusPMaxMismatch(0.001);
+        parametersExt.setNewtonRaphsonConvEpsPerEq(1e-6);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
-        assertActivePowerEquals(50.088, t2wt.getTerminal1());
+        assertActivePowerEquals(50.084, t2wt.getTerminal1());
 
         t2wt.getPhaseTapChanger().setRegulating(true);
         result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
         assertEquals(2, t2wt.getPhaseTapChanger().getTapPosition());
-        assertActivePowerEquals(83.686, t2wt.getTerminal1());
+        assertActivePowerEquals(83.687, t2wt.getTerminal1());
 
         t2wt.getPhaseTapChanger().setRegulationTerminal(t2wt.getTerminal2());
         t2wt.getPhaseTapChanger().setRegulationValue(10);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
A test fails in https://github.com/powsybl/powsybl-open-loadflow/pull/1174 because the NR stopping criteria are larger thatn the epsilon used for result comparisons. 
This test ensures stopping criteria are small enough so that the test is independent of the computation order.



**What is the current behavior?**
Test assertions not relevant because comparison precision is smaller than algorithm stopping criteria.



**What is the new behavior (if this is a feature change)?**
Test assertion precision consitent with algorithm stopping criteria. The tests is independant of the NR implementation.



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [N] No

