### PR TITLE
Fix parameters not read from platform config

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
@@ -1500,6 +1500,7 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
                     config.getOptionalStringProperty(AREA_INTERCHANGE_CONTROL_AREA_TYPE_PARAM_NAME).ifPresent(this::setAreaInterchangeControlAreaType);
                     config.getOptionalDoubleProperty(AREA_INTERCHANGE_P_MAX_MISMATCH_PARAM_NAME).ifPresent(this::setAreaInterchangePMaxMismatch);
                     config.getOptionalBooleanProperty(DISABLE_INCONSISTENT_VOLTAGE_CONTROLS_PARAM_NAME).ifPresent(this::setDisableInconsistentVoltageControls);
+                    config.getOptionalBooleanProperty(FORCE_TARGET_Q_IN_REACTIVE_LIMITS_PARAM_NAME).ifPresent(this::setForceTargetQInReactiveLimits);
                 });
         return this;
     }

--- a/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
+++ b/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java
@@ -1501,6 +1501,9 @@ public class OpenLoadFlowParameters extends AbstractExtension<LoadFlowParameters
                     config.getOptionalDoubleProperty(AREA_INTERCHANGE_P_MAX_MISMATCH_PARAM_NAME).ifPresent(this::setAreaInterchangePMaxMismatch);
                     config.getOptionalBooleanProperty(DISABLE_INCONSISTENT_VOLTAGE_CONTROLS_PARAM_NAME).ifPresent(this::setDisableInconsistentVoltageControls);
                     config.getOptionalBooleanProperty(FORCE_TARGET_Q_IN_REACTIVE_LIMITS_PARAM_NAME).ifPresent(this::setForceTargetQInReactiveLimits);
+                    config.getOptionalEnumProperty(FICTITIOUS_GENERATOR_VOLTAGE_CONTROL_CHECK_MODE, FictitiousGeneratorVoltageControlCheckMode.class)
+                            .ifPresent(this::setFictitiousGeneratorVoltageControlCheckMode);
+                    config.getOptionalBooleanProperty(VOLTAGE_REMOTE_CONTROL_ROBUST_MODE_PARAM_NAME).ifPresent(this::setVoltageRemoteControlRobustMode);
                 });
         return this;
     }

--- a/src/test/java/com/powsybl/openloadflow/OpenLoadFlowParametersTest.java
+++ b/src/test/java/com/powsybl/openloadflow/OpenLoadFlowParametersTest.java
@@ -368,7 +368,7 @@ class OpenLoadFlowParametersTest {
     }
 
     @Test
-    void testEqualsAndClone() {
+    void testEqualsCloneAndUpdate() {
         OpenLoadFlowProvider provider = new OpenLoadFlowProvider();
         provider.getSpecificParameters().forEach(sp -> {
             var p1 = new LoadFlowParameters();
@@ -415,6 +415,26 @@ class OpenLoadFlowParametersTest {
             assertTrue(OpenLoadFlowParameters.equals(p1, p1c), "Parameter is not handled in clone: " + sp.getName());
             var p2c = OpenLoadFlowParameters.clone(p2);
             assertTrue(OpenLoadFlowParameters.equals(p2, p2c), "Parameter is not handled in clone: " + sp.getName());
+
+            // Thes update from PlaftomConfig
+            InMemoryPlatformConfig config1 = new InMemoryPlatformConfig(fileSystem);
+            MapModuleConfig lfModuleConfig1 = config1.createModuleConfig("open-loadflow-default-parameters");
+            InMemoryPlatformConfig config2 = new InMemoryPlatformConfig(fileSystem);
+            MapModuleConfig lfModuleConfig2 = config2.createModuleConfig("open-loadflow-default-parameters");
+            lfModuleConfig1.setStringProperty(sp.getName(), newVal1);
+            lfModuleConfig2.setStringProperty(sp.getName(), newVal2);
+            OpenLoadFlowParameters p1u = new OpenLoadFlowParameters().update(config1);
+            OpenLoadFlowParameters p2u = new OpenLoadFlowParameters().update(config2);
+
+            LoadFlowParameters lfu1 = new LoadFlowParameters();
+            lfu1.addExtension(OpenLoadFlowParameters.class, p1u);
+
+            LoadFlowParameters lfu2 = new LoadFlowParameters();
+            lfu2.addExtension(OpenLoadFlowParameters.class, p2u);
+
+            // should not equal
+            assertFalse(OpenLoadFlowParameters.equals(lfu1, lfu2), "Parameter is not handled in update(platformConfig): " + sp.getName());
+
         });
     }
 

--- a/src/test/java/com/powsybl/openloadflow/OpenLoadFlowParametersTest.java
+++ b/src/test/java/com/powsybl/openloadflow/OpenLoadFlowParametersTest.java
@@ -423,14 +423,10 @@ class OpenLoadFlowParametersTest {
             MapModuleConfig lfModuleConfig2 = config2.createModuleConfig("open-loadflow-default-parameters");
             lfModuleConfig1.setStringProperty(sp.getName(), newVal1);
             lfModuleConfig2.setStringProperty(sp.getName(), newVal2);
-            OpenLoadFlowParameters p1u = new OpenLoadFlowParameters().update(config1);
-            OpenLoadFlowParameters p2u = new OpenLoadFlowParameters().update(config2);
-
             LoadFlowParameters lfu1 = new LoadFlowParameters();
-            lfu1.addExtension(OpenLoadFlowParameters.class, p1u);
-
             LoadFlowParameters lfu2 = new LoadFlowParameters();
-            lfu2.addExtension(OpenLoadFlowParameters.class, p2u);
+            OpenLoadFlowParameters.create(lfu1).update(config1);
+            OpenLoadFlowParameters.create(lfu2).update(config2);
 
             // should not equal
             assertFalse(OpenLoadFlowParameters.equals(lfu1, lfu2), "Parameter is not handled in update(platformConfig): " + sp.getName());

--- a/src/test/java/com/powsybl/openloadflow/OpenLoadFlowParametersTest.java
+++ b/src/test/java/com/powsybl/openloadflow/OpenLoadFlowParametersTest.java
@@ -416,7 +416,7 @@ class OpenLoadFlowParametersTest {
             var p2c = OpenLoadFlowParameters.clone(p2);
             assertTrue(OpenLoadFlowParameters.equals(p2, p2c), "Parameter is not handled in clone: " + sp.getName());
 
-            // Thes update from PlaftomConfig
+            // Test update from PlatformConfig
             InMemoryPlatformConfig config1 = new InMemoryPlatformConfig(fileSystem);
             MapModuleConfig lfModuleConfig1 = config1.createModuleConfig("open-loadflow-default-parameters");
             InMemoryPlatformConfig config2 = new InMemoryPlatformConfig(fileSystem);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
the following parameters are not read from a config file:
- `forceTargetQInReactiveLimits`
- `fictitiousGeneratorVoltageControlCheckMode`
- `voltageRemoteControlRobustMode`



**What kind of change does this PR introduce?**
  - read the param value from the config file
  - add a test to check that all parameters are read
  - add other parameters that were not handled in update

