### PR TITLE
Fix jacoco report generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,9 @@
         <asciitable.version>0.3.2</asciitable.version>
 
         <powsybl-core.version>6.7.1</powsybl-core.version>
+
+        <!--  This is required for later correct replacement of argline -->
+        <argLine/>
     </properties>
 
     <build>
@@ -92,7 +95,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
-                        <argLine>-Duser.language=en -Duser.region=US</argLine>
+                        <argLine>@{argLine} -Duser.language=en -Duser.region=US</argLine>
                         <classpathDependencyExcludes>
                             <classpathDependencyExclude>com.powsybl:powsybl-config-classic</classpathDependencyExclude>
                         </classpathDependencyExcludes>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Jacoco report is not generated.


**What is the new behavior (if this is a feature change)?**
Jacoco report is generated.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

#1225 set command line arguments for the `maven-surefire-plugin`, but it ignored potential previous arguments. By doing this, it ignored the `-Pjacoco` option used to generate the test coverage report.
The current PR keeps the previously set arguments.
