### PR TITLE
Bump parent to 20.2 (Migrate Maven upload from OSSRH to Central Portal)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent</artifactId>
-        <version>20</version>
+        <version>20.2</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
Bump bom parent to migrate Maven upload from OSSRH to Central Portal



**What is the current behavior?**
releases are uploaded to now sunset OSSRH



**What is the new behavior (if this is a feature change)?**
new sonatype plugin. releases are uploaded to Central Portal


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

