### PR TITLE
Handle case of not found synchronous component of regulating terminal of voltage control

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
@@ -242,6 +242,10 @@ public abstract class AbstractLfGenerator extends AbstractLfInjection implements
             LOGGER.warn("Regulating terminal of LfGenerator {} is out of voltage: voltage control discarded", getId());
             return;
         }
+        if (regulatingTerminal.getBusBreakerView().getBus().getSynchronousComponent() == null) {
+            LOGGER.warn("Synchronous component of regulating terminal of LfGenerator {} is not found: voltage control discarded", getId());
+            return;
+        }
         boolean inSameSynchronousComponent = parameters.isBreakers()
                 ? regulatingTerminal.getBusBreakerView().getBus().getSynchronousComponent().getNum() == terminal.getBusBreakerView().getBus().getSynchronousComponent().getNum()
                 : regulatingTerminal.getBusView().getBus().getSynchronousComponent().getNum() == terminal.getBusView().getBus().getSynchronousComponent().getNum();

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
@@ -242,7 +242,7 @@ public abstract class AbstractLfGenerator extends AbstractLfInjection implements
             LOGGER.warn("Regulating terminal of LfGenerator {} is out of voltage: voltage control discarded", getId());
             return;
         }
-        if (regulatingTerminal.getBusBreakerView().getBus().getSynchronousComponent() == null) {
+        if (parameters.isBreakers() && regulatingTerminal.getBusBreakerView().getBus().getSynchronousComponent() == null) {
             LOGGER.warn("Synchronous component of regulating terminal of LfGenerator {} is not found: voltage control discarded", getId());
             return;
         }


### PR DESCRIPTION
Note: the problem is addessed by #1261 that provides a test to reproduce it.
Thi fix in this PR is however the same as in #1261
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
Some rare situations leads to Null Pointer Exception when running security analysis, due to synchronous component of regulating terminal being `null`.


**What is the current behavior?**
Null Pointer exception is thrown



**What is the new behavior (if this is a feature change)?**
A check is added to avoid the exception. A warning is sent in case of missing synchronous component. This should lead to investigate further to get the cause of such an exception.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

