### PR TITLE
Replace use of deprecated OperationalLimitsGroup limits creation methods

### DIFF
--- a/src/test/java/com/powsybl/openloadflow/network/BusBreakerNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/BusBreakerNetworkFactory.java
@@ -74,10 +74,10 @@ public final class BusBreakerNetworkFactory {
                 .setQ0(200.0)
                 .add();
 
-        network.getLine("L1").newCurrentLimits1().setPermanentLimit(940.0).add();
-        network.getLine("L1").newCurrentLimits2().setPermanentLimit(940.0).add();
-        network.getLine("L2").newCurrentLimits1().setPermanentLimit(940.0).add();
-        network.getLine("L2").newCurrentLimits2().setPermanentLimit(940.0).add();
+        network.getLine("L1").getOrCreateSelectedOperationalLimitsGroup1().newCurrentLimits().setPermanentLimit(940.0).add();
+        network.getLine("L1").getOrCreateSelectedOperationalLimitsGroup2().newCurrentLimits().setPermanentLimit(940.0).add();
+        network.getLine("L2").getOrCreateSelectedOperationalLimitsGroup1().newCurrentLimits().setPermanentLimit(940.0).add();
+        network.getLine("L2").getOrCreateSelectedOperationalLimitsGroup2().newCurrentLimits().setPermanentLimit(940.0).add();
 
         return network;
     }
@@ -109,7 +109,7 @@ public final class BusBreakerNetworkFactory {
             .setB1(386E-6 / 2)
             .setB2(386E-6 / 2)
             .add();
-        network.getLine(id).newCurrentLimits1().setPermanentLimit(940.0).add();
-        network.getLine(id).newCurrentLimits2().setPermanentLimit(940.0).add();
+        network.getLine(id).getOrCreateSelectedOperationalLimitsGroup1().newCurrentLimits().setPermanentLimit(940.0).add();
+        network.getLine(id).getOrCreateSelectedOperationalLimitsGroup2().newCurrentLimits().setPermanentLimit(940.0).add();
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/network/LfNetworkTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/LfNetworkTest.java
@@ -397,7 +397,7 @@ class LfNetworkTest extends AbstractSerDeTest {
         assertEquals(1., reductions[2], 0.001); // TATL 60s
 
         // No reductions because only current limits are supported
-        branch.newActivePowerLimits1().setPermanentLimit(100.).add();
+        branch.getOrCreateSelectedOperationalLimitsGroup1().newActivePowerLimits().setPermanentLimit(100.).add();
         LimitReductionManager.TerminalLimitReduction terminalLimitReduction1 =
                 new LimitReductionManager.TerminalLimitReduction(Range.of(0., Double.MAX_VALUE), true, null, 0.5);
         LimitReductionManager limitReductionManager1 = new LimitReductionManager();

--- a/src/test/java/com/powsybl/openloadflow/network/MetrixTutorialSixBusesSecurityAnalysisFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/MetrixTutorialSixBusesSecurityAnalysisFactory.java
@@ -19,11 +19,11 @@ public class MetrixTutorialSixBusesSecurityAnalysisFactory extends AbstractLoadF
         for (Line line : network.getLines()) {
             line.setR(0.2);
             if (lowLimitLines.contains(line.getId())) {
-                line.newCurrentLimits1().setPermanentLimit(350.0).add();
-                line.newCurrentLimits2().setPermanentLimit(350.0).add();
+                line.getOrCreateSelectedOperationalLimitsGroup1().newCurrentLimits().setPermanentLimit(350.0).add();
+                line.getOrCreateSelectedOperationalLimitsGroup2().newCurrentLimits().setPermanentLimit(350.0).add();
             } else {
-                line.newCurrentLimits1().setPermanentLimit(400.0).add();
-                line.newCurrentLimits2().setPermanentLimit(400.0).add();
+                line.getOrCreateSelectedOperationalLimitsGroup1().newCurrentLimits().setPermanentLimit(400.0).add();
+                line.getOrCreateSelectedOperationalLimitsGroup2().newCurrentLimits().setPermanentLimit(400.0).add();
             }
         }
 
@@ -51,12 +51,12 @@ public class MetrixTutorialSixBusesSecurityAnalysisFactory extends AbstractLoadF
         for (Line line : network.getLines()) {
             if (specialLimitLines.contains(line.getId())) {
                 line.setR(90.0);
-                line.newCurrentLimits1().setPermanentLimit(2000.0).add();
-                line.newCurrentLimits2().setPermanentLimit(2000.0).add();
+                line.getOrCreateSelectedOperationalLimitsGroup1().newCurrentLimits().setPermanentLimit(2000.0).add();
+                line.getOrCreateSelectedOperationalLimitsGroup2().newCurrentLimits().setPermanentLimit(2000.0).add();
             } else {
                 line.setR(0.2);
-                line.newCurrentLimits1().setPermanentLimit(1000.0).add();
-                line.newCurrentLimits2().setPermanentLimit(1000.0).add();
+                line.getOrCreateSelectedOperationalLimitsGroup1().newCurrentLimits().setPermanentLimit(1000.0).add();
+                line.getOrCreateSelectedOperationalLimitsGroup2().newCurrentLimits().setPermanentLimit(1000.0).add();
             }
         }
 
@@ -74,11 +74,11 @@ public class MetrixTutorialSixBusesSecurityAnalysisFactory extends AbstractLoadF
         for (Line line : network.getLines()) {
             line.setR(0.2);
             if (lowLimitLines.contains(line.getId())) {
-                line.newActivePowerLimits1().setPermanentLimit(250.0).add();
-                line.newActivePowerLimits2().setPermanentLimit(250.0).add();
+                line.getOrCreateSelectedOperationalLimitsGroup1().newActivePowerLimits().setPermanentLimit(250.0).add();
+                line.getOrCreateSelectedOperationalLimitsGroup2().newActivePowerLimits().setPermanentLimit(250.0).add();
             } else {
-                line.newActivePowerLimits1().setPermanentLimit(300.0).add();
-                line.newActivePowerLimits2().setPermanentLimit(300.0).add();
+                line.getOrCreateSelectedOperationalLimitsGroup1().newActivePowerLimits().setPermanentLimit(300.0).add();
+                line.getOrCreateSelectedOperationalLimitsGroup2().newActivePowerLimits().setPermanentLimit(300.0).add();
             }
         }
         network.getTwoWindingsTransformer("NE_NO_1")
@@ -97,11 +97,11 @@ public class MetrixTutorialSixBusesSecurityAnalysisFactory extends AbstractLoadF
         for (Line line : network.getLines()) {
             line.setR(0.2);
             if (lowLimitLines.contains(line.getId())) {
-                line.newApparentPowerLimits1().setPermanentLimit(250.0).add();
-                line.newApparentPowerLimits2().setPermanentLimit(250.0).add();
+                line.getOrCreateSelectedOperationalLimitsGroup1().newApparentPowerLimits().setPermanentLimit(250.0).add();
+                line.getOrCreateSelectedOperationalLimitsGroup2().newApparentPowerLimits().setPermanentLimit(250.0).add();
             } else {
-                line.newApparentPowerLimits1().setPermanentLimit(300.0).add();
-                line.newApparentPowerLimits2().setPermanentLimit(300.0).add();
+                line.getOrCreateSelectedOperationalLimitsGroup1().newApparentPowerLimits().setPermanentLimit(300.0).add();
+                line.getOrCreateSelectedOperationalLimitsGroup2().newApparentPowerLimits().setPermanentLimit(300.0).add();
             }
         }
         network.getTwoWindingsTransformer("NE_NO_1")

--- a/src/test/java/com/powsybl/openloadflow/sa/AbstractOpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/AbstractOpenSecurityAnalysisTest.java
@@ -79,7 +79,7 @@ public abstract class AbstractOpenSecurityAnalysisTest {
     protected static Network createNodeBreakerNetwork() {
         Network network = NodeBreakerNetworkFactory.create();
 
-        network.getLine("L1").newCurrentLimits1()
+        network.getLine("L1").getOrCreateSelectedOperationalLimitsGroup1().newCurrentLimits()
                 .setPermanentLimit(940.0)
                 .beginTemporaryLimit()
                 .setName("60")
@@ -87,10 +87,10 @@ public abstract class AbstractOpenSecurityAnalysisTest {
                 .setValue(1000)
                 .endTemporaryLimit()
                 .add();
-        network.getLine("L1").newCurrentLimits2()
+        network.getLine("L1").getOrCreateSelectedOperationalLimitsGroup2().newCurrentLimits()
                 .setPermanentLimit(940.0)
                 .add();
-        network.getLine("L2").newCurrentLimits1()
+        network.getLine("L2").getOrCreateSelectedOperationalLimitsGroup1().newCurrentLimits()
                 .setPermanentLimit(940.0)
                 .beginTemporaryLimit()
                 .setName("60")
@@ -98,7 +98,7 @@ public abstract class AbstractOpenSecurityAnalysisTest {
                 .setValue(950)
                 .endTemporaryLimit()
                 .add();
-        network.getLine("L2").newCurrentLimits2()
+        network.getLine("L2").getOrCreateSelectedOperationalLimitsGroup2().newCurrentLimits()
                 .setPermanentLimit(940.0)
                 .beginTemporaryLimit()
                 .setName("600")


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #1254 


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Refacto to no longer use deprecated methods.
