### PR TITLE
Bump powsybl-core to 6.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ dependencies to respectively have access to network model, IEEE test networks an
 <dependency>
     <groupId>com.powsybl</groupId>
     <artifactId>powsybl-iidm-impl</artifactId>
-    <version>6.8.0</version>
+    <version>6.8.1</version>
 </dependency>
 <dependency>
     <groupId>com.powsybl</groupId>
     <artifactId>powsybl-ieee-cdf-converter</artifactId>
-    <version>6.8.0</version>
+    <version>6.8.1</version>
 </dependency>
 <dependency>
     <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <slf4jtoys.version>1.6.3</slf4jtoys.version>
         <asciitable.version>0.3.2</asciitable.version>
 
-        <powsybl-core.version>6.8.0</powsybl-core.version>
+        <powsybl-core.version>6.8.1</powsybl-core.version>
 
         <!--  This is required for later correct replacement of argline -->
         <argLine/>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**


**What kind of change does this PR introduce?**
Bump powsybl-core to published version 6.8.1



**What is the current behavior?**
The powsybl-core dependency references a version with known vulenrabily from dependency
https://mvnrepository.com/artifact/com.powsybl/powsybl-core/6.8.0



**What is the new behavior (if this is a feature change)?**
OpenLoadFlow references powsyb-core 6.8.1 that addresses the issue.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

