### PR TITLE
Reduce time consumed by Equation.rhs()

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/equations/Equation.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/Equation.java
@@ -35,6 +35,8 @@ public class Equation<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity
      */
     private boolean active = true;
 
+    private boolean hasRhs = false;
+
     private final List<EquationTerm<V, E>> terms = new ArrayList<>();
 
     private final Map<Variable<V>, List<EquationTerm<V, E>>> termsByVariable = new TreeMap<>();
@@ -112,6 +114,9 @@ public class Equation<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity
         term.setEquation(this);
         equationSystem.addEquationTerm(term);
         equationSystem.notifyEquationTermChange(term, EquationTermEventType.EQUATION_TERM_ADDED);
+        if (term.hasRhs()) {
+            hasRhs = true;
+        }
         return this;
     }
 
@@ -203,6 +208,9 @@ public class Equation<V extends Enum<V> & Quantity, E extends Enum<E> & Quantity
     }
 
     public double rhs() {
+        if (!hasRhs) {
+            return 0;
+        }
         double rhs = 0;
         for (var term : terms) {
             if (term.isActive() && term.hasRhs()) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)

**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
For most of the studied networks, in AC mode, most of the equations have no right hand side (they only concern branches in DC calculation). Yet a significant time is consumed by `Equation.rhs()`

(Example with an AC Security analysis for a country sized network)
<img width="943" height="335" alt="image" src="https://github.com/user-attachments/assets/16ae00c2-c998-4196-9864-3d3d801323a4" />

This PR adresses this problem. After the fix, for such cases, `Equation.rhs()` has an almost zero time consumption.

**What is the current behavior?**
Each term of each equation is iterated to check if RHS has to be calculated.


**What is the new behavior (if this is a feature change)?**
Each equation is iterated to check if RHS has to be calculated (we do not iterate over terms if it is not necessary)


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
