### PR TITLE
Sensitivity analysis: allow to specify a battery ID as an injection variable id

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/AbstractSensitivityAnalysis.java
@@ -926,6 +926,9 @@ abstract class AbstractSensitivityAnalysis<V extends Enum<V> & Quantity, E exten
             if (injection == null) {
                 injection = network.getVscConverterStation(injectionId);
             }
+            if (injection == null) {
+                injection = network.getBattery(injectionId);
+            }
             return injection;
         }
 

--- a/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/AcSensitivityAnalysisTest.java
@@ -1084,6 +1084,21 @@ class AcSensitivityAnalysisTest extends AbstractSensitivityAnalysisTest {
     }
 
     @Test
+    void testBatterySensi() {
+        Network network = DistributedSlackNetworkFactory.createWithBattery();
+
+        SensitivityAnalysisParameters sensiParameters = createParameters(false);
+        List<SensitivityFactor> factors = List.of(createBranchFlowPerInjectionIncrease("l14", "bat1"), createBranchFlowPerInjectionIncrease("l14", "b1"));
+
+        SensitivityAnalysisResult result = sensiRunner.run(network, factors, Collections.emptyList(), Collections.emptyList(), sensiParameters);
+
+        // The battery should be found and return the same sensitivity than to an injection at its bus
+        assertEquals(result.getBranchFlow1SensitivityValue("bat1", "l14", SensitivityVariableType.INJECTION_ACTIVE_POWER),
+                result.getBranchFlow1SensitivityValue("b1", "l14", SensitivityVariableType.INJECTION_ACTIVE_POWER));
+
+    }
+
+    @Test
     void testWithHvdcAcEmulation() {
         Network network = HvdcNetworkFactory.createWithHvdcInAcEmulation();
         network.getHvdcLine("hvdc34").newExtension(HvdcAngleDroopActivePowerControlAdder.class)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
This PR resolves issue #1270 



**What kind of change does this PR introduce?**
It is now possible to compute the sensitivity to a battery inkection by specifying the battery ID.
Before, you could only specify the battery bus ID.

**What is the current behavior?**
If a sensibility analysis is run with a battery ID provided as an injection variable, OpenLoadFlow throws a PowsyblException with message "Injection '<batteryId>' not found" 



**What is the new behavior (if this is a feature change)?**
If a sensibility analysis is run with a battery ID with a battery ID provided as in injection variable, the corresponding bus is found and the sensitivities are computed correcty.



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


