### PR TITLE
Fix AcSolverResult toString()

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/AcLoadFlowResult.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcLoadFlowResult.java
@@ -80,7 +80,7 @@ public class AcLoadFlowResult extends AbstractLoadFlowResult {
     @Override
     public String toString() {
         return "AcLoadFlowResult(outerLoopIterations=" + outerLoopIterations
-                + ", newtonRaphsonIterations=" + solverIterations
+                + ", solverIterations=" + solverIterations
                 + ", solverStatus=" + solverStatus
                 + ", outerLoopStatus=" + outerLoopResult.status()
                 + ", slackBusActivePowerMismatch=" + slackBusActivePowerMismatch * PerUnit.SB


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
toString() method of AcLoadFlowResult mentions `newtonRaphsonIterations` instead of `solverIterations`, resulting in an erroneous log, e.g. here with Newton-Krylov solver:

```
INFO  09:42:04.508 c.p.m.s.KinsolContext | KinSol: module='KINSOL', function='KINSol', message='Return value: 0 (KIN_SUCCESS)'
INFO  09:42:04.514 c.p.o.a.AcloadFlowEngine | AC loadflow complete on network {CC0 SC0} (result=AcLoadFlowResult(outerLoopIterations=0, newtonRaphsonIterations=11, solverStatus=CONVERGED, outerLoopStatus=STABLE, slackBusActivePowerMismatch=0.0, distributedActivePower=0.0))
```

**What is the new behavior (if this is a feature change)?**
```
INFO  09:47:00.840 c.p.m.s.KinsolContext | KinSol: module='KINSOL', function='KINSol', message='Return value: 0 (KIN_SUCCESS)'
INFO  09:47:00.846 c.p.o.a.AcloadFlowEngine | AC loadflow complete on network {CC0 SC0} (result=AcLoadFlowResult(outerLoopIterations=0, solverIterations=11, solverStatus=CONVERGED, outerLoopStatus=STABLE, slackBusActivePowerMismatch=0.0, distributedActivePower=0.0))
```


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No
