### PR TITLE
[WIP] Reduce some log levels and send some functional log messages to reports

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -542,7 +542,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
                 lfHvdc.setConverterStation2(cs2);
                 lfNetwork.addHvdc(lfHvdc);
             } else {
-                LOGGER.warn("The converter stations of hvdc line {} are not in the same synchronous component: no hvdc link created to model active power flow.", hvdcLine.getId());
+                LOGGER.debug("The converter stations of hvdc line {} are not in the same synchronous component: no hvdc link created to model active power flow.", hvdcLine.getId());
             }
         }
     }


### PR DESCRIPTION
…between non synchrnous component. This is a normal situation. No need to tell the user.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Decrease severity of specific logs that can pollute normal log analysis or send someone troubleshooting an error to a wrong direction.

The message "The converter stations of hvdc line {} are not in the same synchronous component: no hvdc link created to model active power flow." currently displayed as a warning is actually triggerred in completely normal situations. Does even not need to be displayed at info leve. Moved to debug.

The message "Transformer {} with voltage control frozen: rounded at extreme tap position" :
  - Is sent to reports since it may have functional interrest
  - Is "deverbosed" in the logs. Only a summary is displayed at info level (number of transformers frozen at extreme position). 






**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


