### PR TITLE
Fix Q dispatch not meeting requested reactive power mismatch threshold

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfBus.java
@@ -27,7 +27,10 @@ public abstract class AbstractLfBus extends AbstractElement implements LfBus {
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(AbstractLfBus.class);
 
-    private static final double Q_DISPATCH_EPSILON = 1e-3;
+    /**
+     * Reactive power residue epsilon: 10^-5 in p.u => 10^-3 in MVar
+     */
+    private static final double Q_DISPATCH_EPSILON = 1e-5;
 
     private static final double PLAUSIBLE_REACTIVE_LIMITS = 1000 / PerUnit.SB;
 

--- a/src/test/java/com/powsybl/openloadflow/ac/AcloadFlowReactiveLimitsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcloadFlowReactiveLimitsTest.java
@@ -224,6 +224,6 @@ class AcloadFlowReactiveLimitsTest {
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
         assertReactivePowerEquals(0.05, ngen2Nhv1.getTerminal1());
-        assertReactivePowerEquals(-0.05, gen2.getTerminal()); // FIXME getting 0 MVAr, bus balance not honoring 0.01 MVAr threshold
+        assertReactivePowerEquals(-0.05, gen2.getTerminal());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/ac/AcloadFlowReactiveLimitsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcloadFlowReactiveLimitsTest.java
@@ -15,6 +15,7 @@ import com.powsybl.loadflow.LoadFlowResult;
 import com.powsybl.math.matrix.DenseMatrixFactory;
 import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.OpenLoadFlowProvider;
+import com.powsybl.openloadflow.ac.solver.NewtonRaphsonStoppingCriteriaType;
 import com.powsybl.openloadflow.network.*;
 import com.powsybl.openloadflow.network.impl.Networks;
 import org.junit.jupiter.api.BeforeEach;
@@ -202,5 +203,27 @@ class AcloadFlowReactiveLimitsTest {
         assertTrue(result.isFullyConverged());
         assertActivePowerEquals(-100.0, gen2.getTerminal());
         assertReactivePowerEquals(extrapolate ? -200.0 : -300, gen2.getTerminal()); // reaching gen2 minQ
+    }
+
+    @Test
+    void testQDispatchEpsilon() {
+        // gen2 on voltage control, small reactive range at targetP = 100 MW
+        gen2.newReactiveCapabilityCurve()
+            .beginPoint().setP(0).setMinQ(-0.05).setMaxQ(+0.05).endPoint()
+            .beginPoint().setP(200).setMinQ(-0.05).setMaxQ(+0.05).endPoint()
+            .beginPoint().setP(300).setMinQ(-100).setMaxQ(+100).endPoint()
+            .add();
+
+        // Set reactive range check mode so that gen2 is not excluded from V control
+        // Set reactive power tolerance smaller than the small gen2 reactive power capability.
+        parametersExt
+            .setReactiveRangeCheckMode(OpenLoadFlowParameters.ReactiveRangeCheckMode.MAX)
+            .setNewtonRaphsonStoppingCriteriaType(NewtonRaphsonStoppingCriteriaType.PER_EQUATION_TYPE_CRITERIA)
+            .setMaxReactivePowerMismatch(0.01);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isFullyConverged());
+        assertReactivePowerEquals(0.05, ngen2Nhv1.getTerminal1());
+        assertReactivePowerEquals(-0.05, gen2.getTerminal()); // FIXME getting 0 MVAr, bus balance not honoring 0.01 MVAr threshold
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Q dispatch uses an internal hardcoded threshold of 1e-3 pu @ 100 MVA (hence 0.1 MVAr) when dispatching Q.

In some situations this may leave a bus imbalance above requested convergence threshold.

Issue was observed on real data for a generator with reactive limits at +/- 0.1 MVAr. Depending on NR solution path and solution precision we end up with either  Q being dispatched (then KCL check OK), or not dispatched (KCL check failing).


**What is the new behavior (if this is a feature change)?**

- Test case added, with a generator at +/- 0.05 MVAr limit so that numerical precision issues do not show up around the existing 0.1 MVar limitation.
- Lowered AbstractLfBus Q_DISPATCH_EPSILON hardcode from 1e-3 pu (0.1 MVar) to 1e-5 pu (0.001 MVar)  (to be aligned with active power distribution which has also an 1e-5 pu threshold in ActivePowerDistribution#P_RESIDUE_EPS)

**Does this PR introduce a breaking change or deprecate an API?**
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
