### PR TITLE
Use generator local targetV if set as local regulation - proposal

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/LfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, RTE (http://www.rte-france.com)
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -58,13 +58,6 @@ public interface LfGenerator extends PropertyBag, LfReferencePriorityInjection {
     void setGeneratorControlType(GeneratorControlType generatorControlType);
 
     double getTargetV();
-
-    /**
-     * Changes the target V to a local voltage control. If the Generator has an equivalentLocalTargetV,
-     * this target will be used, instead, the same p.u. target is than the current target V
-     * @return true if the generator has an equivalentLocalTargetV, and false otherwise.
-     */
-    boolean switchToLocalVoltageControl();
 
     OptionalDouble getRemoteControlReactiveKey();
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
@@ -133,7 +133,6 @@ public abstract class AbstractLfGenerator extends AbstractLfInjection implements
         return targetV;
     }
 
-    @Override
     public boolean switchToLocalVoltageControl() {
         switchedToLocalVoltageRegulation = true;
         return false;

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
@@ -263,7 +263,7 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
             targetV = generatorRef.get().getEquivalentLocalTargetV() / getBus().getNominalV();
             return true;
         } else {
-            // keep the same targetV i perUnit
+            // keep the same targetV in perUnit
             return false;
         }
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -111,7 +111,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
             }
             voltageControlGenerators.addAll(voltageMonitoringGenerators);
 
-            // If remote voltage control is off, move remote voltage controle generators to local control
+            // If remote voltage control is off, move remote voltage control generators to local control
             if (!parameters.isGeneratorVoltageRemoteControl()) {
                 switchGeneratorsToLocalVoltageControl(voltageControlGenerators, controllerBus, report);
             }
@@ -132,7 +132,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         for (LfGenerator g : voltageControlGenerators) {
             if (g.getControlledBus() != g.getBus()) {
                 LfBus remoteControlledBus = g.getControlledBus();
-                if (!g.switchToLocalVoltageControl()) {
+                if (g instanceof AbstractLfGenerator gen && !gen.switchToLocalVoltageControl()) {
                     report.rescaledRemoteVoltageControls += 1;
                     double remoteTargetV = g.getTargetV() * remoteControlledBus.getNominalV();
                     double localTargetV = g.getTargetV() * controllerBus.getNominalV();


### PR DESCRIPTION
proposal for #1295 not needing to expose in LfNetwork API a new LfGenerator#switchToLocalVoltageControl method.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
