### PR TITLE
Refactor ComputedElement to not expose the abstract class

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/dc/fastdc/AbstractComputedElement.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/fastdc/AbstractComputedElement.java
@@ -7,27 +7,14 @@
  */
 package com.powsybl.openloadflow.dc.fastdc;
 
-import com.powsybl.commons.PowsyblException;
-import com.powsybl.math.matrix.DenseMatrix;
-import com.powsybl.math.matrix.Matrix;
-import com.powsybl.openloadflow.dc.DcLoadFlowContext;
 import com.powsybl.openloadflow.dc.equations.ClosedBranchSide1DcFlowEquationTerm;
-import com.powsybl.openloadflow.dc.equations.DcEquationType;
-import com.powsybl.openloadflow.dc.equations.DcVariableType;
-import com.powsybl.openloadflow.equations.Equation;
-import com.powsybl.openloadflow.equations.EquationSystem;
-import com.powsybl.openloadflow.graph.GraphConnectivity;
 import com.powsybl.openloadflow.network.LfBranch;
-import com.powsybl.openloadflow.network.LfBus;
-
-import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  * @author Gaël Macherel {@literal <gael.macherel@artelys.com>}
  */
-public abstract class AbstractComputedElement {
+abstract class AbstractComputedElement {
     private int computedElementIndex = -1; // index of the element in the rhs for +1-1
     private int localIndex = -1; // local index of the element : index of the element in the matrix used in the setAlphas method
     private double alphaForWoodburyComputation = Double.NaN;
@@ -51,7 +38,7 @@ public abstract class AbstractComputedElement {
         return localIndex;
     }
 
-    protected void setLocalIndex(final int index) {
+    public void setLocalIndex(final int index) {
         this.localIndex = index;
     }
 
@@ -70,76 +57,4 @@ public abstract class AbstractComputedElement {
     public ClosedBranchSide1DcFlowEquationTerm getLfBranchEquation() {
         return branchEquation;
     }
-
-    /**
-     * Set the indexes of the computed elements in the +1-1 rhs, used in Woodbury calculations.
-     * The indexes depend on the number of distinct branches affected by the elements.
-     * Those affecting the same branch share the same +1-1 rhs column.
-     */
-    public static void setComputedElementIndexes(Collection<? extends AbstractComputedElement> elements) {
-        AtomicInteger index = new AtomicInteger(0);
-        Map<LfBranch, Integer> branchesToRhsIndex = new HashMap<>();
-        for (AbstractComputedElement element : elements) {
-            LfBranch elementLfBranch = element.getLfBranch();
-            Integer elementIndex = branchesToRhsIndex.computeIfAbsent(elementLfBranch, lfBranch -> index.getAndIncrement());
-            element.setComputedElementIndex(elementIndex);
-        }
-    }
-
-    public static void setLocalIndexes(Collection<? extends AbstractComputedElement> elements) {
-        int index = 0;
-        for (AbstractComputedElement element : elements) {
-            element.setLocalIndex(index++);
-        }
-    }
-
-    /**
-     * Fills the right hand side with +1/-1 to model a branch contingency or action.
-     */
-    private static void fillRhs(EquationSystem<DcVariableType, DcEquationType> equationSystem, Collection<? extends AbstractComputedElement> computedElements, Matrix rhs) {
-        for (AbstractComputedElement element : computedElements) {
-            LfBranch lfBranch = element.getLfBranch();
-            if (lfBranch.getBus1() == null || lfBranch.getBus2() == null) {
-                continue;
-            }
-            LfBus bus1 = lfBranch.getBus1();
-            LfBus bus2 = lfBranch.getBus2();
-            if (bus1.isSlack()) {
-                Equation<DcVariableType, DcEquationType> p = equationSystem.getEquation(bus2.getNum(), DcEquationType.BUS_TARGET_P).orElseThrow(IllegalStateException::new);
-                rhs.set(p.getColumn(), element.getComputedElementIndex(), -1);
-            } else if (bus2.isSlack()) {
-                Equation<DcVariableType, DcEquationType> p = equationSystem.getEquation(bus1.getNum(), DcEquationType.BUS_TARGET_P).orElseThrow(IllegalStateException::new);
-                rhs.set(p.getColumn(), element.getComputedElementIndex(), 1);
-            } else {
-                Equation<DcVariableType, DcEquationType> p1 = equationSystem.getEquation(bus1.getNum(), DcEquationType.BUS_TARGET_P).orElseThrow(IllegalStateException::new);
-                Equation<DcVariableType, DcEquationType> p2 = equationSystem.getEquation(bus2.getNum(), DcEquationType.BUS_TARGET_P).orElseThrow(IllegalStateException::new);
-                rhs.set(p1.getColumn(), element.getComputedElementIndex(), 1);
-                rhs.set(p2.getColumn(), element.getComputedElementIndex(), -1);
-            }
-        }
-    }
-
-    public static DenseMatrix initRhs(EquationSystem<DcVariableType, DcEquationType> equationSystem, Collection<? extends AbstractComputedElement> elements) {
-        // the number of columns of the rhs equals the number of distinct branches affected by the computed elements
-        // those affecting the same branch share the same column
-        int columnCount = (int) elements.stream().map(AbstractComputedElement::getLfBranch).filter(Objects::nonNull).distinct().count();
-        // otherwise, defining the rhs matrix will result in integer overflow
-        int equationCount = equationSystem.getIndex().getColumnCount();
-        int maxElements = Integer.MAX_VALUE / (equationCount * Double.BYTES);
-        if (columnCount > maxElements) {
-            throw new PowsyblException("Too many elements " + columnCount
-                    + ", maximum is " + maxElements + " for a system with " + equationCount + " equations");
-        }
-        DenseMatrix rhs = new DenseMatrix(equationCount, columnCount);
-        fillRhs(equationSystem, elements, rhs);
-        return rhs;
-    }
-
-    public static DenseMatrix calculateElementsStates(DcLoadFlowContext loadFlowContext, Collection<? extends AbstractComputedElement> computedElements) {
-        DenseMatrix elementsStates = initRhs(loadFlowContext.getEquationSystem(), computedElements); // rhs with +1 -1 on computed elements
-        loadFlowContext.getJacobianMatrix().solveTransposed(elementsStates);
-        return elementsStates;
-    }
-
-    public abstract void applyToConnectivity(GraphConnectivity<LfBus, LfBranch> connectivity);
 }

--- a/src/main/java/com/powsybl/openloadflow/dc/fastdc/ComputedContingencyElement.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/fastdc/ComputedContingencyElement.java
@@ -22,7 +22,7 @@ import com.powsybl.openloadflow.network.LfNetwork;
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  * @author Gaël Macherel {@literal <gael.macherel@artelys.com>}
  */
-public final class ComputedContingencyElement extends AbstractComputedElement {
+public final class ComputedContingencyElement extends AbstractComputedElement implements ComputedElement {
 
     private final ContingencyElement element;
 

--- a/src/main/java/com/powsybl/openloadflow/dc/fastdc/ComputedElement.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/fastdc/ComputedElement.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.openloadflow.dc.fastdc;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.math.matrix.DenseMatrix;
+import com.powsybl.math.matrix.Matrix;
+import com.powsybl.openloadflow.dc.DcLoadFlowContext;
+import com.powsybl.openloadflow.dc.equations.ClosedBranchSide1DcFlowEquationTerm;
+import com.powsybl.openloadflow.dc.equations.DcEquationType;
+import com.powsybl.openloadflow.dc.equations.DcVariableType;
+import com.powsybl.openloadflow.equations.Equation;
+import com.powsybl.openloadflow.equations.EquationSystem;
+import com.powsybl.openloadflow.graph.GraphConnectivity;
+import com.powsybl.openloadflow.network.LfBranch;
+import com.powsybl.openloadflow.network.LfBus;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Gaël Macherel {@literal <gael.macherel@artelys.com>}
+ */
+public interface ComputedElement {
+
+    int getComputedElementIndex();
+
+    void setComputedElementIndex(final int index);
+
+    int getLocalIndex();
+
+    void setLocalIndex(final int index);
+
+    double getAlphaForWoodburyComputation();
+
+    void setAlphaForWoodburyComputation(double alphaForPostContingencyStates);
+
+    LfBranch getLfBranch();
+
+    ClosedBranchSide1DcFlowEquationTerm getLfBranchEquation();
+
+    void applyToConnectivity(GraphConnectivity<LfBus, LfBranch> connectivity);
+
+    /**
+     * Set the indexes of the computed elements in the +1-1 rhs, used in Woodbury calculations.
+     * The indexes depend on the number of distinct branches affected by the elements.
+     * Those affecting the same branch share the same +1-1 rhs column.
+     */
+    static void setComputedElementIndexes(Collection<? extends ComputedElement> elements) {
+        AtomicInteger index = new AtomicInteger(0);
+        Map<LfBranch, Integer> branchesToRhsIndex = new HashMap<>();
+        for (ComputedElement element : elements) {
+            LfBranch elementLfBranch = element.getLfBranch();
+            Integer elementIndex = branchesToRhsIndex.computeIfAbsent(elementLfBranch, lfBranch -> index.getAndIncrement());
+            element.setComputedElementIndex(elementIndex);
+        }
+    }
+
+    static void setLocalIndexes(Collection<? extends ComputedElement> elements) {
+        int index = 0;
+        for (ComputedElement element : elements) {
+            element.setLocalIndex(index++);
+        }
+    }
+
+    /**
+     * Fills the right hand side with +1/-1 to model a branch contingency or action.
+     */
+    private static void fillRhs(EquationSystem<DcVariableType, DcEquationType> equationSystem, Collection<? extends ComputedElement> computedElements, Matrix rhs) {
+        for (ComputedElement element : computedElements) {
+            LfBranch lfBranch = element.getLfBranch();
+            if (lfBranch.getBus1() == null || lfBranch.getBus2() == null) {
+                continue;
+            }
+            LfBus bus1 = lfBranch.getBus1();
+            LfBus bus2 = lfBranch.getBus2();
+            if (bus1.isSlack()) {
+                Equation<DcVariableType, DcEquationType> p = equationSystem.getEquation(bus2.getNum(), DcEquationType.BUS_TARGET_P).orElseThrow(IllegalStateException::new);
+                rhs.set(p.getColumn(), element.getComputedElementIndex(), -1);
+            } else if (bus2.isSlack()) {
+                Equation<DcVariableType, DcEquationType> p = equationSystem.getEquation(bus1.getNum(), DcEquationType.BUS_TARGET_P).orElseThrow(IllegalStateException::new);
+                rhs.set(p.getColumn(), element.getComputedElementIndex(), 1);
+            } else {
+                Equation<DcVariableType, DcEquationType> p1 = equationSystem.getEquation(bus1.getNum(), DcEquationType.BUS_TARGET_P).orElseThrow(IllegalStateException::new);
+                Equation<DcVariableType, DcEquationType> p2 = equationSystem.getEquation(bus2.getNum(), DcEquationType.BUS_TARGET_P).orElseThrow(IllegalStateException::new);
+                rhs.set(p1.getColumn(), element.getComputedElementIndex(), 1);
+                rhs.set(p2.getColumn(), element.getComputedElementIndex(), -1);
+            }
+        }
+    }
+
+    static DenseMatrix initRhs(EquationSystem<DcVariableType, DcEquationType> equationSystem, Collection<? extends ComputedElement> elements) {
+        // the number of columns of the rhs equals the number of distinct branches affected by the computed elements
+        // those affecting the same branch share the same column
+        int columnCount = (int) elements.stream().map(ComputedElement::getLfBranch).filter(Objects::nonNull).distinct().count();
+        // otherwise, defining the rhs matrix will result in integer overflow
+        int equationCount = equationSystem.getIndex().getColumnCount();
+        int maxElements = Integer.MAX_VALUE / (equationCount * Double.BYTES);
+        if (columnCount > maxElements) {
+            throw new PowsyblException("Too many elements " + columnCount
+                    + ", maximum is " + maxElements + " for a system with " + equationCount + " equations");
+        }
+        DenseMatrix rhs = new DenseMatrix(equationCount, columnCount);
+        fillRhs(equationSystem, elements, rhs);
+        return rhs;
+    }
+
+    static DenseMatrix calculateElementsStates(DcLoadFlowContext loadFlowContext, Collection<? extends ComputedElement> computedElements) {
+        DenseMatrix elementsStates = initRhs(loadFlowContext.getEquationSystem(), computedElements); // rhs with +1 -1 on computed elements
+        loadFlowContext.getJacobianMatrix().solveTransposed(elementsStates);
+        return elementsStates;
+    }
+}

--- a/src/main/java/com/powsybl/openloadflow/dc/fastdc/ComputedSwitchBranchElement.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/fastdc/ComputedSwitchBranchElement.java
@@ -19,7 +19,7 @@ import com.powsybl.openloadflow.network.LfBus;
 /**
  * @author Pierre Arvy {@literal <pierre.arvy@artelys.com>}
  */
-public final class ComputedSwitchBranchElement extends AbstractComputedElement {
+public final class ComputedSwitchBranchElement extends AbstractComputedElement implements ComputedElement {
 
     private final boolean enabled; // indicates whether the action opens or closes the branch
 
@@ -36,7 +36,7 @@ public final class ComputedSwitchBranchElement extends AbstractComputedElement {
     public void applyToConnectivity(GraphConnectivity<LfBus, LfBranch> connectivity) {
         LfBranch lfBranch = getLfBranch();
         if (lfBranch.getBus1() != null && lfBranch.getBus2() != null) {
-            if (isEnabled()) {
+            if (enabled) {
                 connectivity.addEdge(lfBranch.getBus1(), lfBranch.getBus2(), lfBranch);
             } else {
                 connectivity.removeEdge(lfBranch);

--- a/src/main/java/com/powsybl/openloadflow/dc/fastdc/ComputedTapPositionChangeElement.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/fastdc/ComputedTapPositionChangeElement.java
@@ -20,7 +20,7 @@ import com.powsybl.openloadflow.network.TapPositionChange;
 /**
  * @author Pierre Arvy {@literal <pierre.arvy@artelys.com>}
  */
-public final class ComputedTapPositionChangeElement extends AbstractComputedElement {
+public final class ComputedTapPositionChangeElement extends AbstractComputedElement implements ComputedElement {
 
     private final TapPositionChange tapPositionChange;
 

--- a/src/main/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysis.java
@@ -125,7 +125,7 @@ public class WoodburyDcSecurityAnalysis extends DcSecurityAnalysis {
      */
     private double[] calculatePostContingencyAndOperatorStrategyStates(DcLoadFlowContext loadFlowContext, DenseMatrix contingenciesStates, double[] flowStates,
                                                                        ConnectivityAnalysisResult connectivityAnalysisResult, Map<String, ComputedContingencyElement> contingencyElementByBranch,
-                                                                       Map<LfAction, AbstractComputedElement> actionElementByLfAction, DenseMatrix actionsStates, ReportNode reportNode) {
+                                                                       Map<LfAction, ComputedElement> actionElementByLfAction, DenseMatrix actionsStates, ReportNode reportNode) {
         PropagatedContingency contingency = connectivityAnalysisResult.getPropagatedContingency();
         Set<LfBus> disabledBuses = connectivityAnalysisResult.getDisabledBuses();
         Set<LfBranch> partialDisabledBranches = connectivityAnalysisResult.getPartialDisabledBranches();
@@ -142,7 +142,7 @@ public class WoodburyDcSecurityAnalysis extends DcSecurityAnalysis {
                 .filter(element -> !elementsToReconnect.contains(element))
                 .map(contingencyElementByBranch::get)
                 .collect(Collectors.toList());
-        List<AbstractComputedElement> actionElements = operatorStrategyLfActions.stream()
+        List<ComputedElement> actionElements = operatorStrategyLfActions.stream()
                 .map(actionElementByLfAction::get)
                 .filter(actionElement -> !elementsToReconnect.contains(actionElement.getLfBranch().getId()))
                 .collect(Collectors.toList());
@@ -363,10 +363,10 @@ public class WoodburyDcSecurityAnalysis extends DcSecurityAnalysis {
         });
     }
 
-    private static Map<LfAction, AbstractComputedElement> createActionElementsIndexByLfAction(Map<String, LfAction> lfActionById, EquationSystem<DcVariableType, DcEquationType> equationSystem) {
-        Map<LfAction, AbstractComputedElement> computedElements = lfActionById.values().stream()
+    private static Map<LfAction, ComputedElement> createActionElementsIndexByLfAction(Map<String, LfAction> lfActionById, EquationSystem<DcVariableType, DcEquationType> equationSystem) {
+        Map<LfAction, ComputedElement> computedElements = lfActionById.values().stream()
                 .map(lfAction -> {
-                    AbstractComputedElement element;
+                    ComputedElement element;
                     if (lfAction instanceof AbstractLfTapChangerAction<?> abstractLfTapChangerAction) {
                         element = new ComputedTapPositionChangeElement(abstractLfTapChangerAction.getChange(), equationSystem);
                     } else if (lfAction instanceof AbstractLfBranchAction<?> abstractLfBranchAction && abstractLfBranchAction.getEnabledBranch() != null) {
@@ -385,7 +385,7 @@ public class WoodburyDcSecurityAnalysis extends DcSecurityAnalysis {
                         (existing, replacement) -> existing,
                         LinkedHashMap::new
                 ));
-        AbstractComputedElement.setComputedElementIndexes(computedElements.values());
+        ComputedElement.setComputedElementIndexes(computedElements.values());
         return computedElements;
     }
 
@@ -445,11 +445,11 @@ public class WoodburyDcSecurityAnalysis extends DcSecurityAnalysis {
             ConnectivityBreakAnalysis.ConnectivityBreakAnalysisResults connectivityBreakAnalysisResults = ConnectivityBreakAnalysis.run(context, propagatedContingencies);
 
             // the map is indexed by lf actions as different kind of actions can be given on the same branch
-            Map<LfAction, AbstractComputedElement> actionElementsIndexByLfAction = createActionElementsIndexByLfAction(lfActionById, context.getEquationSystem());
+            Map<LfAction, ComputedElement> actionElementsIndexByLfAction = createActionElementsIndexByLfAction(lfActionById, context.getEquationSystem());
 
             // compute states with +1 -1 to model the actions in Woodbury engine
             // note that the number of columns in the matrix depends on the number of distinct branches affected by the action elements
-            DenseMatrix actionsStates = AbstractComputedElement.calculateElementsStates(context, actionElementsIndexByLfAction.values());
+            DenseMatrix actionsStates = ComputedElement.calculateElementsStates(context, actionElementsIndexByLfAction.values());
 
             // save base state for later restoration after each contingency/action
             NetworkState networkState = NetworkState.save(lfNetwork);

--- a/src/test/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysisTest.java
@@ -24,7 +24,7 @@ import com.powsybl.math.matrix.SparseMatrixFactory;
 import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.dc.equations.DcEquationType;
 import com.powsybl.openloadflow.dc.equations.DcVariableType;
-import com.powsybl.openloadflow.dc.fastdc.AbstractComputedElement;
+import com.powsybl.openloadflow.dc.fastdc.ComputedElement;
 import com.powsybl.openloadflow.dc.fastdc.ComputedContingencyElement;
 import com.powsybl.openloadflow.equations.EquationSystem;
 import com.powsybl.openloadflow.equations.EquationSystemIndex;
@@ -1129,7 +1129,7 @@ class DcSensitivityAnalysisTest extends AbstractSensitivityAnalysisTest {
             Mockito.when(contingencyElement.getLfBranch()).thenReturn(branch);
             contingencyElements.add(contingencyElement);
         }
-        e = assertThrows(PowsyblException.class, () -> AbstractComputedElement.initRhs(equationSystem, contingencyElements));
+        e = assertThrows(PowsyblException.class, () -> ComputedElement.initRhs(equationSystem, contingencyElements));
         assertEquals("Too many elements 3000, maximum is 2684 for a system with 100000 equations", e.getMessage());
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Refactoring


**What is the current behavior?**
<!-- You can also link to an open issue here -->
`AbstractComputedElement`is exposed directly in other package as an API for computed elements. It is a bad practice to expose an abstract class outside of its package.


**What is the new behavior (if this is a feature change)?**
`ComputedElement` interface has been added.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
