### PR TITLE
Take tap changer impedance updates into account

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/equations/vector/AcNetworkVector.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/vector/AcNetworkVector.java
@@ -463,6 +463,14 @@ public class AcNetworkVector extends AbstractLfNetworkListener
         PiModel piModel = branch.getPiModel();
         branchVector.a1[branch.getNum()] = piModel.getA1();
         branchVector.r1[branch.getNum()] = piModel.getR1();
+        branchVector.y[branch.getNum()] = piModel.getY();
+        double ksi = piModel.getKsi();
+        var w = new DoubleWrapper();
+        branchVector.ksi[branch.getNum()] = ksi;
+        branchVector.sinKsi[branch.getNum()] = FastMath.sinAndCos(ksi, w);
+        branchVector.cosKsi[branch.getNum()] = w.value;
+        branchVector.g1[branch.getNum()] = piModel.getG1();
+        branchVector.b1[branch.getNum()] = piModel.getB1();
     }
 
     @Override


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
Currently, the changing of the tap position of a tap changer inside the load flow does not impact the impedance of the branch. It is especially concerning for the incremental control modes.



**What is the new behavior (if this is a feature change)?**
With the new behavior, the changing of the tap position of a tap changer inside the load flow does impact the impedance of the branch.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
