### PR TITLE
Bump IIDM version to 1.16 in unit test files

### DIFF
--- a/src/test/resources/debug-network.xiidm
+++ b/src/test/resources/debug-network.xiidm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_15" xmlns:reft="http://www.powsybl.org/schema/iidm/ext/reference_terminals/1_0" id="test" caseDate="2021-04-25T13:47:34.697+02:00" forecastDistance="0" sourceFormat="code" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_16" xmlns:reft="http://www.powsybl.org/schema/iidm/ext/reference_terminals/1_0" id="test" caseDate="2021-04-25T13:47:34.697+02:00" forecastDistance="0" sourceFormat="code" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
     <iidm:substation id="b1_s" country="FR">
         <iidm:voltageLevel id="b1_vl" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>


### PR DESCRIPTION
This is a pull request on integration branch ci/core-7.2.0-SNAPSHOT

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
IIDM Version bump in unit tests



**What is the current behavior?**
IIDM version used is 1.15



**What is the new behavior (if this is a feature change)?**
IIDM version used is 1.16
