### PR TITLE
Add warn for selecting limit reduction with groups (not implemented)

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sa/LimitReductionManager.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/LimitReductionManager.java
@@ -144,6 +144,10 @@ public class LimitReductionManager {
             LOGGER.warn("When two duration criteria are provided, they cannot be of the same type");
             return false;
         }
+        if (!limitReduction.getOperationalLimitsGroupIdsSelection().isEmpty()) {
+            LOGGER.warn("Selecting operational limits groups to apply limit reductions to is not yet supported");
+            return false;
+        }
         return true;
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/LimitReductionManagerTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/LimitReductionManagerTest.java
@@ -236,4 +236,15 @@ class LimitReductionManagerTest {
         List<LimitReductionManager.TerminalLimitReduction> terminalLimitReductions = limitReductionManager.getTerminalLimitReductions();
         assertEquals(0, terminalLimitReductions.size());
     }
+
+    @Test
+    void noSelectionOfOperationalLimitsGroupTest() {
+        LimitReduction limitReduction = LimitReduction.builder(LimitType.CURRENT, 0.95)
+            .withOperationalLimitsGroupIdSelection("group1")
+            .build();
+        LimitReductionManager limitReductionManager = LimitReductionManager.create(List.of(limitReduction));
+        assertTrue(limitReductionManager.isEmpty());
+        List<LimitReductionManager.TerminalLimitReduction> terminalLimitReductions = limitReductionManager.getTerminalLimitReductions();
+        assertTrue(terminalLimitReductions.isEmpty());
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Disable group selection for limit reduction, introduced by https://github.com/powsybl/powsybl-core/pull/3802

**What is the current behavior?**
<!-- You can also link to an open issue here -->

There is no implementation to support this in OLF.

**What is the new behavior (if this is a feature change)?**

The implementation is to disable it for now. It is supposed to be developped for the release in June. This is a temporary warn message for users for the march release.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
