### PR TITLE
Adapt to core 3669 - Properties on MinMaxReactiveLimits

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfStaticVarCompensatorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfStaticVarCompensatorImpl.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -76,6 +77,41 @@ public final class LfStaticVarCompensatorImpl extends AbstractLfGenerator implem
             @Override
             public double getMaxQ(double p) {
                 return getMaxQ();
+            }
+
+            @Override
+            public boolean hasProperty() {
+                throw new UnsupportedOperationException("No property management");
+            }
+
+            @Override
+            public String getProperty(String key) {
+                throw new UnsupportedOperationException("No property management");
+            }
+
+            @Override
+            public String setProperty(String key, String value) {
+                throw new UnsupportedOperationException("No property management");
+            }
+
+            @Override
+            public Set<String> getPropertyNames() {
+                throw new UnsupportedOperationException("No property management");
+            }
+
+            @Override
+            public String getProperty(String key, String defaultValue) {
+                throw new UnsupportedOperationException("No property management");
+            }
+
+            @Override
+            public boolean hasProperty(String key) {
+                throw new UnsupportedOperationException("No property management");
+            }
+
+            @Override
+            public boolean removeProperty(String key) {
+                throw new UnsupportedOperationException("No property management");
             }
         };
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Dependency adaptation


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**
<!-- -->
Since powsybl/powsybl-core#3669, `MinMaxReactiveLimits` interface extends `PropertyHolder`.
This PR changes `LfStaticVarCompensatorImpl`'s `MinMaxReactiveLimtis` anonymous class to implement the properties management methods. Since there's no interest to support properties on this object in OLF, the methods throw an exception.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
