### PR TITLE
Remove unused powsybl-loadflow-results-completion dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,10 +157,6 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-loadflow-results-completion</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-math</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Unused `powsybl-loadflow-results-completion` dependency (originally used in #67 but unused since #573)


**What is the new behavior (if this is a feature change)?**
Removed `powsybl-loadflow-results-completion` dependency.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No
