### PR TITLE
Check Sparse Matrix consistency when initializing Jacobian matrix

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/equations/JacobianMatrix.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/JacobianMatrix.java
@@ -9,11 +9,7 @@ package com.powsybl.openloadflow.equations;
 
 import com.google.common.base.Stopwatch;
 import com.powsybl.commons.PowsyblException;
-import com.powsybl.math.matrix.DenseMatrix;
-import com.powsybl.math.matrix.LUDecomposition;
-import com.powsybl.math.matrix.Matrix;
-import com.powsybl.math.matrix.MatrixException;
-import com.powsybl.math.matrix.MatrixFactory;
+import com.powsybl.math.matrix.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,7 +140,9 @@ public class JacobianMatrix<V extends Enum<V> & Quantity, E extends Enum<E> & Qu
                 eqArray = itSortedEquationArray.hasNext() ? itSortedEquationArray.next() : null;
             }
         }
-
+        if (matrix instanceof SparseMatrix sparse) {
+            sparse.checkBuildingInconsistency(); // Will throw exception if any building construction (e.g. duplicate rows) is detected
+        }
         LOGGER.debug(PERFORMANCE_MARKER, "Jacobian matrix built in {} us", stopwatch.elapsed(TimeUnit.MICROSECONDS));
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**

https://github.com/powsybl/powsybl-core/pull/3912/ introduces a new method in SparseMatrix class to allow checking inconsistencies in the construction of the matrix (it happened in the past that some cell of the matrix were referenced multiple time in the same column, hence a corrupted sparse matrix). 

This check is executed at the end of initDer() after having filled the full matrix.


**What is the current behavior?**
No test, such errors can be invisible (led to not detect the bug fixed by https://github.com/powsybl/powsybl-open-loadflow/pull/1394)


**What is the new behavior (if this is a feature change)?**
An explicit exception would be thrown since  the Jacobian is completely wrong in this case, it cannot be kept for a further computation.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
