### PR TITLE
Fix JSON update of Security and Sensitivity Parameters extensions

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisParameterJsonSerializer.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisParameterJsonSerializer.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.powsybl.commons.extensions.ExtensionJsonSerializer;
 import com.powsybl.commons.json.JsonUtil;
@@ -64,5 +65,12 @@ public class OpenSecurityAnalysisParameterJsonSerializer implements ExtensionJso
     @Override
     public OpenSecurityAnalysisParameters deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
         return createMapper().readValue(jsonParser, OpenSecurityAnalysisParameters.class);
+    }
+
+    @Override
+    public OpenSecurityAnalysisParameters deserializeAndUpdate(JsonParser jsonParser, DeserializationContext deserializationContext, OpenSecurityAnalysisParameters extension) throws IOException {
+        ObjectMapper objectMapper = createMapper();
+        ObjectReader objectReader = objectMapper.readerForUpdating(extension);
+        return objectReader.readValue(jsonParser, OpenSecurityAnalysisParameters.class);
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisParameterJsonSerializer.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisParameterJsonSerializer.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.powsybl.commons.extensions.ExtensionJsonSerializer;
 import com.powsybl.commons.json.JsonUtil;
@@ -64,5 +65,12 @@ public class OpenSensitivityAnalysisParameterJsonSerializer implements Extension
     @Override
     public OpenSensitivityAnalysisParameters deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
         return createMapper().readValue(jsonParser, OpenSensitivityAnalysisParameters.class);
+    }
+
+    @Override
+    public OpenSensitivityAnalysisParameters deserializeAndUpdate(JsonParser jsonParser, DeserializationContext deserializationContext, OpenSensitivityAnalysisParameters extension) throws IOException {
+        ObjectMapper objectMapper = createMapper();
+        ObjectReader objectReader = objectMapper.readerForUpdating(extension);
+        return objectReader.readValue(jsonParser, OpenSensitivityAnalysisParameters.class);
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProviderTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisProviderTest.java
@@ -11,6 +11,8 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.config.InMemoryPlatformConfig;
 import com.powsybl.commons.config.MapModuleConfig;
 import com.powsybl.commons.test.AbstractSerDeTest;
+import com.powsybl.loadflow.LoadFlowParameters;
+import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.util.PowsyblOpenLoadFlowVersion;
 import com.powsybl.openloadflow.util.ProviderConstants;
 import com.powsybl.security.SecurityAnalysisParameters;
@@ -18,7 +20,9 @@ import com.powsybl.security.json.JsonSecurityAnalysisParameters;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -152,5 +156,63 @@ class OpenSecurityAnalysisProviderTest extends AbstractSerDeTest {
                 .setStartWithFrozenACEmulation(false);
         parameters.addExtension(OpenSecurityAnalysisParameters.class, parametersExt);
         roundTripTest(parameters, JsonSecurityAnalysisParameters::write, JsonSecurityAnalysisParameters::read, "/sa-params.json");
+    }
+
+    @Test
+    void testParamsExtensionJsonUpdate() {
+
+        // some params with non-default values
+        LoadFlowParameters p = new LoadFlowParameters()
+                .setBalanceType(LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD)
+                .setUseReactiveLimits(false);
+        OpenLoadFlowParameters op = OpenLoadFlowParameters.create(p)
+                .setMaxNewtonRaphsonIterations(30)
+                .setMaxNewtonKrylovIterations(50);
+        SecurityAnalysisParameters sp = new SecurityAnalysisParameters()
+                .setLoadFlowParameters(p);
+        OpenSecurityAnalysisParameters osp = new OpenSecurityAnalysisParameters()
+                .setThreadCount(2)
+                .setCreateResultExtension(true);
+        sp.addExtension(OpenSecurityAnalysisParameters.class, osp);
+
+        assertEquals(LoadFlowParameters.VoltageInitMode.UNIFORM_VALUES, p.getVoltageInitMode());
+        assertFalse(op.isNewtonKrylovLineSearch());
+        assertFalse(osp.isDcFastMode());
+
+        byte[] json = """
+            {
+              "version" : "1.2",
+              "load-flow-parameters" : {
+                "version" : "1.10",
+                "voltageInitMode" : "DC_VALUES",
+                "extensions": {
+                  "open-load-flow-parameters": {
+                    "maxNewtonRaphsonIterations": 35,
+                    "newtonKrylovLineSearch" : true
+                  }
+                }
+              },
+              "extensions" : {
+                "open-security-analysis-parameters" : {
+                  "threadCount": 4,
+                  "dcFastMode": true
+                }
+              }
+            }
+            """.getBytes(StandardCharsets.UTF_8);
+
+        JsonSecurityAnalysisParameters.update(sp, new ByteArrayInputStream(json));
+
+        // unchanged
+        assertEquals(LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD, p.getBalanceType());
+        assertFalse(p.isUseReactiveLimits());
+        assertEquals(50, op.getMaxNewtonKrylovIterations());
+        assertTrue(osp.isCreateResultExtension());
+
+        // updated
+        assertEquals(35, op.getMaxNewtonRaphsonIterations());
+        assertTrue(op.isNewtonKrylovLineSearch());
+        assertTrue(osp.isDcFastMode());
+        assertEquals(4, osp.getThreadCount());
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProviderTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sensi/OpenSensitivityAnalysisProviderTest.java
@@ -7,18 +7,22 @@
  */
 package com.powsybl.openloadflow.sensi;
 
+import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.math.matrix.DenseMatrixFactory;
+import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.util.ProviderConstants;
 import com.powsybl.sensitivity.SensitivityAnalysisParameters;
+import com.powsybl.sensitivity.json.JsonSensitivityAnalysisParameters;
 import com.powsybl.tools.PowsyblCoreVersion;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -56,5 +60,63 @@ class OpenSensitivityAnalysisProviderTest extends AbstractSensitivityAnalysisTes
         provider.loadSpecificParameters(Map.of(OpenSensitivityAnalysisParameters.THREAD_COUNT_PARAM_NAME, "2"))
                 .ifPresent(parametersExt -> parameters.addExtension((Class) parametersExt.getClass(), parametersExt));
         assertEquals(2, parameters.getExtension(OpenSensitivityAnalysisParameters.class).getThreadCount());
+    }
+
+    @Test
+    void testParamsExtensionJsonUpdate() {
+
+        // some params with non-default values
+        LoadFlowParameters p = new LoadFlowParameters()
+                .setBalanceType(LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD)
+                .setUseReactiveLimits(false);
+        OpenLoadFlowParameters op = OpenLoadFlowParameters.create(p)
+                .setMaxNewtonRaphsonIterations(30)
+                .setMaxNewtonKrylovIterations(50);
+        SensitivityAnalysisParameters sp = new SensitivityAnalysisParameters()
+                .setLoadFlowParameters(p);
+        OpenSensitivityAnalysisParameters osp = new OpenSensitivityAnalysisParameters()
+                .setThreadCount(2)
+                .setStartWithFrozenACEmulation(false);
+        sp.addExtension(OpenSensitivityAnalysisParameters.class, osp);
+
+        assertEquals(LoadFlowParameters.VoltageInitMode.UNIFORM_VALUES, p.getVoltageInitMode());
+        assertFalse(op.isNewtonKrylovLineSearch());
+        assertNull(osp.getDebugDir());
+
+        byte[] json = """
+            {
+              "version" : "1.2",
+              "load-flow-parameters" : {
+                "version" : "1.10",
+                "voltageInitMode" : "DC_VALUES",
+                "extensions": {
+                  "open-load-flow-parameters": {
+                    "maxNewtonRaphsonIterations": 35,
+                    "newtonKrylovLineSearch" : true
+                  }
+                }
+              },
+              "extensions" : {
+                "open-sensitivity-parameters" : {
+                  "threadCount": 4,
+                  "debugDir": "/tmp/my-debug-dir"
+                }
+              }
+            }
+            """.getBytes(StandardCharsets.UTF_8);
+
+        JsonSensitivityAnalysisParameters.update(sp, new ByteArrayInputStream(json));
+
+        // unchanged
+        assertEquals(LoadFlowParameters.BalanceType.PROPORTIONAL_TO_CONFORM_LOAD, p.getBalanceType());
+        assertFalse(p.isUseReactiveLimits());
+        assertEquals(50, op.getMaxNewtonKrylovIterations());
+        assertFalse(osp.isStartWithFrozenACEmulation());
+
+        // updated
+        assertEquals(35, op.getMaxNewtonRaphsonIterations());
+        assertTrue(op.isNewtonKrylovLineSearch());
+        assertEquals("/tmp/my-debug-dir", osp.getDebugDir());
+        assertEquals(4, osp.getThreadCount());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)

**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix

**What is the current behavior?**
<!-- You can also link to an open issue here -->
On JSON update, OLF SA and Sensi parameters extensions are not updated but re-created using defaults.
Caused by missing override of `deserializeAndUpdate` in `OpenSecurityAnalysisParameterJsonSerializer` and `OpenSensitivityAnalysisParameterJsonSerializer`.

**What is the new behavior (if this is a feature change)?**
JSON update works as it should.

**Does this PR introduce a breaking change or deprecate an API?**
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
#1335 fixed only the LF parameters, but forgot to fix also Security and Sensitivity analysis parameters ...