### PR TITLE
Update documentation dependencies

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.9"
+    python: "3.12"
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-sphinx==7.1.2
+sphinx==9.1.0
 sphinx-tabs
-furo==2024.1.29
-myst-parser
+furo==2025.12.19
+myst-parser>=4.0.0
 sphinx-copybutton


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines



**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Dependency updates


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Documentation uses in .readthedocs.yaml:
- ubuntu 20.04
- python 3.9

In requirements:
- sphinx==7.1.2
- furo==2024.1.29
- myst-parser


**What is the new behavior (if this is a feature change)?**
Documentation uses in .readthedocs.yaml:
- ubuntu **24.04**
- python **3.12**

In requirements:
- sphinx==9.1.0
- furo==2025.12.19
- myst-parser>=4.0.0

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

Ubuntu 20.04 LTS will not be supported anymore by Readthedocs starting from June 2026 (see the [announcement](https://about.readthedocs.com/blog/2026/03/ubuntu-20-04-deprecated/)).
