### PR TITLE
Fix sensitivity analysis parameters documentation anchors

### DIFF
--- a/docs/sensitivity/parameters.md
+++ b/docs/sensitivity/parameters.md
@@ -14,12 +14,12 @@ The next section details the parameters that are specific to PowSyBl Open LoadFL
 
 ## Specific parameters
 
-(param-sensi-debug-dir)
+(param-sensi-debug-dir)=
 ### debugDir
 Allows to dump debug files to a specific directory.<br>
 The default value is undefined (`null`), disabling any debug files writing.
 
-(param-sensi-start-with-frozen-ac-emulation)
+(param-sensi-start-with-frozen-ac-emulation)=
 ### startWithFrozenACEmulation
 If `true`, contingence simulation starts with HVDC link configured in AC emulation frozen at their previous active set point
 defined by the angles at the HVDC extremities in the base case. If a solution is found then the simulator
@@ -29,7 +29,7 @@ If `false`, contingence simulation allows HVDC lines to immediately adapt to the
 
 The default value is `true`
 
-(param-sensi-thread-count)
+(param-sensi-thread-count)=
 ### threadCount
 The `threadCount` property defines the number of threads used to run an AC sensitivity analysis (multi-threading is currently not 
 supported for DC sensitivity analysis).


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Doc bug fix, bug introduced in #1381


**What is the current behavior?**
<!-- You can also link to an open issue here -->

See https://powsybl.readthedocs.io/projects/powsybl-open-loadflow/en/latest/sensitivity/parameters.html

<img width="991" height="431" alt="image" src="https://github.com/user-attachments/assets/9287b3ec-0598-4ed4-8665-433fe4277a7f" />



**What is the new behavior (if this is a feature change)?**
Fixed anchor (missing trailing `=`)

See https://powsybl--1428.org.readthedocs.build/projects/powsybl-open-loadflow/en/1428/sensitivity/parameters.html


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
