### PR TITLE
Throw exception when having DcSwitch with non zero resistance

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -1324,6 +1324,18 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         createDcGrounds(lfNetwork, dcGrounds);
         createDcLines(lfNetwork, loadingContext, parameters);
 
+        // TO DO : Handle switches that have non zero impedance
+        network.getDcSwitchStream().filter(s -> !s.isOpen() && s.getR() != 0)
+                .filter(s -> {
+                    DcBus dcBus1 = s.getDcNode1().getDcBus();
+                    DcBus dcBus2 = s.getDcNode2().getDcBus();
+                    return dcBus1 != null && lfDcBuses.contains(lfNetwork.getDcBusById(dcBus1.getId()))
+                            || dcBus2 != null && lfDcBuses.contains(lfNetwork.getDcBusById(dcBus2.getId()));
+                })
+                .forEach(s -> {
+                    throw new PowsyblException("DcSwitch " + s.getId() + " has non zero resistance: not handled yet in AC DC load flow (R = " + s.getR() + ")");
+                });
+
         // Ensure at least one converter controls V_DC
         boolean isVdcControlled = false;
         for (AcDcConverter<?> converter : loadingContext.acDcConverterSet) {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -1326,12 +1326,6 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
 
         // TO DO : Handle switches that have non zero resistance
         network.getDcSwitchStream().filter(s -> !s.isOpen() && s.getR() != 0)
-                .filter(s -> {
-                    DcBus dcBus1 = s.getDcNode1().getDcBus();
-                    DcBus dcBus2 = s.getDcNode2().getDcBus();
-                    return dcBus1 != null && lfDcBuses.contains(lfNetwork.getDcBusById(dcBus1.getId()))
-                            || dcBus2 != null && lfDcBuses.contains(lfNetwork.getDcBusById(dcBus2.getId()));
-                })
                 .forEach(s -> {
                     throw new PowsyblException("DcSwitch " + s.getId() + " has non zero resistance: not handled yet in AC DC load flow (R = " + s.getR() + ")");
                 });

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -1324,7 +1324,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         createDcGrounds(lfNetwork, dcGrounds);
         createDcLines(lfNetwork, loadingContext, parameters);
 
-        // TO DO : Handle switches that have non zero impedance
+        // TO DO : Handle switches that have non zero resistance
         network.getDcSwitchStream().filter(s -> !s.isOpen() && s.getR() != 0)
                 .filter(s -> {
                     DcBus dcBus1 = s.getDcNode1().getDcBus();

--- a/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import javax.annotation.processing.Completion;
 import java.util.List;
 import java.util.concurrent.CompletionException;
 

--- a/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import javax.annotation.processing.Completion;
 import java.util.List;
 import java.util.concurrent.CompletionException;
 
@@ -1018,6 +1019,34 @@ class AcDcLoadFlowTest {
 
         List<String> secondScSlackBusIds = result.getComponentResults().getLast().getSlackBusResults().stream().map(LoadFlowResult.SlackBusResult::getId).toList();
         assertEquals(List.of("vl5_0"), secondScSlackBusIds); // Only one bus on this synchronous component
+    }
 
+    @Test
+    void testUnsupportedDcSwitchWithNonZeroR() {
+        Network network = AcDcNetworkFactory.createMtDcNetworkWithThreeAcZones();
+        network.getDcLine("dl47").remove();
+        DcSwitch sw47 = network.newDcSwitch()
+                .setId("sw47")
+                .setKind(DcSwitchKind.BREAKER)
+                .setDcNode1("dn4p")
+                .setDcNode2("dn7")
+                .setOpen(false)
+                .setR(0.0)
+                .add();
+        parameters.setComponentMode(LoadFlowParameters.ComponentMode.ALL_CONNECTED);
+        parametersExt.setMaxSlackBusCount(2);
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isFullyConverged()); // Load flow succeeds because DcSwitch has R = 0
+
+        sw47.setR(0.1);
+        CompletionException e = assertThrows(CompletionException.class, () -> loadFlowRunner.run(network, parameters));
+        assertEquals("DcSwitch sw47 has non zero resistance: not handled yet in AC DC load flow (R = 0.1)", e.getCause().getMessage());
+
+        sw47.setOpen(true);
+        network.getVoltageSourceConverter("conv14")
+                .setTargetVdc(525.)
+                .setControlMode(AcDcConverter.ControlMode.V_DC);
+        result = loadFlowRunner.run(network, parameters);
+        assertFalse(result.isFullyConverged()); // Load flow do not succeed but no exception is thrown because of open switch
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
DC Switch with resistance is introduced in IIDM but not supported yet in Open Load Flow. Adding an exception (before merging #1423 in a future release)



**What is the current behavior?**
No exception thrown, possibly unwanted behavior happening in the load flow

**What is the new behavior (if this is a feature change)?**
If any DcSwitch in the network has R != 0, throwing an exception.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
