### PR TITLE
Add outerloop name in status text when it fails.

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/AcLoadFlowResult.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcLoadFlowResult.java
@@ -73,7 +73,7 @@ public class AcLoadFlowResult extends AbstractLoadFlowResult {
         if (getOuterLoopResult().status() == OuterLoopStatus.UNSTABLE) {
             return new Status(LoadFlowResult.ComponentResult.Status.MAX_ITERATION_REACHED, "Reached outer loop max iterations limit. Last outer loop name: " + getOuterLoopResult().outerLoopName());
         } else if (getOuterLoopResult().status() == OuterLoopStatus.FAILED) {
-            return new Status(LoadFlowResult.ComponentResult.Status.FAILED, "Outer loop failed: " + getOuterLoopResult().statusText());
+            return new Status(LoadFlowResult.ComponentResult.Status.FAILED, "Outer loop '" + getOuterLoopResult().outerLoopName() + "' failed: " + getOuterLoopResult().statusText());
         } else {
             return switch (getSolverStatus()) {
                 case CONVERGED -> new Status(LoadFlowResult.ComponentResult.Status.CONVERGED, "Converged");

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
@@ -360,17 +360,16 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
             return new OuterLoopResult(this, OuterLoopStatus.STABLE);
         }
 
-        OuterLoopStatus status = OuterLoopStatus.STABLE;
-
         List<String> adjustedZoneNames = processSecondaryVoltageControl(secondaryVoltageControls, context.getLoadFlowContext()).orElse(null);
         if (adjustedZoneNames == null) {
-            status = OuterLoopStatus.FAILED;
-        } else {
-            if (!adjustedZoneNames.isEmpty()) {
-                status = OuterLoopStatus.UNSTABLE;
-                LOGGER.info("{} secondary voltage control zones have been adjusted: {}",
-                        adjustedZoneNames.size(), adjustedZoneNames);
-            }
+            return new OuterLoopResult(this, OuterLoopStatus.FAILED, "Cannot adjust secondary voltage control because some calculated controlled bus target voltages are not plausible");
+        }
+
+        OuterLoopStatus status = OuterLoopStatus.STABLE;
+        if (!adjustedZoneNames.isEmpty()) {
+            status = OuterLoopStatus.UNSTABLE;
+            LOGGER.info("{} secondary voltage control zones have been adjusted: {}",
+                    adjustedZoneNames.size(), adjustedZoneNames);
         }
 
         return new OuterLoopResult(this, status);

--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowResult.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowResult.java
@@ -51,7 +51,7 @@ public class DcLoadFlowResult extends AbstractLoadFlowResult {
         if (getOuterLoopResult().status() == OuterLoopStatus.UNSTABLE) {
             return new Status(LoadFlowResult.ComponentResult.Status.MAX_ITERATION_REACHED, "Reached outer loop max iterations limit. Last outer loop name: " + getOuterLoopResult().outerLoopName());
         } else if (getOuterLoopResult().status() == OuterLoopStatus.FAILED) {
-            return new Status(LoadFlowResult.ComponentResult.Status.FAILED, "Outer loop failed: " + getOuterLoopResult().statusText());
+            return new Status(LoadFlowResult.ComponentResult.Status.FAILED, "Outer loop '" + getOuterLoopResult().outerLoopName() + "' failed: " + getOuterLoopResult().statusText());
         }
         if (solverSuccess) {
             return new Status(LoadFlowResult.ComponentResult.Status.CONVERGED, "Converged");

--- a/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/DistributedSlackOnGenerationTest.java
@@ -459,7 +459,7 @@ class DistributedSlackOnGenerationTest {
         LoadFlowResult.ComponentResult componentResult = result.getComponentResults().get(0);
         assertFalse(result.isFullyConverged());
         assertEquals(LoadFlowResult.ComponentResult.Status.FAILED, componentResult.getStatus());
-        assertEquals("Outer loop failed: Failed to distribute slack bus active power mismatch, 200.00 MW remains", componentResult.getStatusText());
+        assertEquals("Outer loop 'DistributedSlack' failed: Failed to distribute slack bus active power mismatch, 200.00 MW remains", componentResult.getStatusText());
         assertEquals(0, componentResult.getDistributedActivePower(), 1e-4);
         assertEquals(520, componentResult.getSlackBusResults().get(0).getActivePowerMismatch(), 1e-4);
         assertReportContains("Failed to distribute slack bus active power mismatch, [-+]?\\d*\\.\\d* MW remains", reportNode);
@@ -515,7 +515,7 @@ class DistributedSlackOnGenerationTest {
         LoadFlowResult.ComponentResult componentResult = result.getComponentResults().get(0);
         assertTrue(result.isFailed());
         assertEquals(LoadFlowResult.ComponentResult.Status.FAILED, componentResult.getStatus());
-        assertEquals("Outer loop failed: Failed to distribute slack bus active power mismatch, 200.00 MW remains", componentResult.getStatusText());
+        assertEquals("Outer loop 'DistributedSlack' failed: Failed to distribute slack bus active power mismatch, 200.00 MW remains", componentResult.getStatusText());
         assertEquals(520., componentResult.getSlackBusResults().get(0).getActivePowerMismatch(), 1e-3);
         assertReportContains("Failed to distribute slack bus active power mismatch, [-+]?\\d*\\.\\d* MW remains", reportNode);
     }

--- a/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
@@ -656,7 +656,7 @@ class AcDcLoadFlowTest {
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFailed());
         assertEquals(LoadFlowResult.ComponentResult.Status.FAILED, result.getComponentResults().getFirst().getStatus());
-        assertEquals("Outer loop failed: Failed to distribute slack bus active power mismatch, 30.00 MW remains",
+        assertEquals("Outer loop 'DistributedSlack' failed: Failed to distribute slack bus active power mismatch, 30.00 MW remains",
                 result.getComponentResults().getFirst().getStatusText());
     }
 

--- a/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/dc/DcLoadFlowTest.java
@@ -531,7 +531,7 @@ class DcLoadFlowTest {
         assertFalse(result.isFullyConverged());
 
         assertEquals(LoadFlowResult.ComponentResult.Status.FAILED, result.getComponentResults().get(0).getStatus());
-        assertEquals("Outer loop failed: Failed to distribute active power mismatch", result.getComponentResults().get(0).getStatusText());
+        assertEquals("Outer loop 'AreaInterchangeControl' failed: Failed to distribute active power mismatch", result.getComponentResults().get(0).getStatusText());
     }
 
     @Test
@@ -653,7 +653,7 @@ class DcLoadFlowTest {
         assertFalse(result.isFullyConverged());
         assertEquals(1, result.getComponentResults().size());
         assertEquals(LoadFlowResult.ComponentResult.Status.FAILED, result.getComponentResults().get(0).getStatus());
-        assertEquals("Outer loop failed: Failed to distribute slack bus active power mismatch, 321.90 MW remains", result.getComponentResults().get(0).getStatusText());
+        assertEquals("Outer loop 'DistributedSlack' failed: Failed to distribute slack bus active power mismatch, 321.90 MW remains", result.getComponentResults().get(0).getStatusText());
         assertEquals(321.9, result.getComponentResults().get(0).getSlackBusResults().get(0).getActivePowerMismatch(), 0.01);
         assertEquals(0, result.getComponentResults().get(0).getDistributedActivePower(), 0.01);
         assertReportContains("Failed to distribute slack bus active power mismatch, [-+]?321\\.\\d* MW remains", reportNode);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
It adds the name of the failing outer loop in the status text


**What is the current behavior?**
<!-- You can also link to an open issue here -->
It prints: Outer loop failed: FAILED


**What is the new behavior (if this is a feature change)?**
It prints: Outer loop 'Name' failed: FAILED


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
