### PR TITLE
Fix handling of pure phase-shift taps in DC sensitivity analysis

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/dc/fastdc/ComputedElement.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/fastdc/ComputedElement.java
@@ -24,6 +24,8 @@ import com.powsybl.openloadflow.equations.EquationSystem;
 import com.powsybl.openloadflow.graph.GraphConnectivity;
 import com.powsybl.openloadflow.network.LfBranch;
 import com.powsybl.openloadflow.network.LfBus;
+import com.powsybl.openloadflow.network.PiModel;
+import com.powsybl.openloadflow.network.TapPositionChange;
 import com.powsybl.openloadflow.network.action.AbstractLfBranchAction;
 import com.powsybl.openloadflow.network.action.AbstractLfTapChangerAction;
 import com.powsybl.openloadflow.network.action.LfAction;
@@ -157,8 +159,15 @@ public interface ComputedElement {
                     elements.addAll(lfBranchAction.getDisabledBranches().stream().map(b -> ComputedSwitchBranchElement.create(b, false, equationSystem)).toList());
                 }
             }
-            case PhaseTapChangerTapPositionAction.NAME ->
-                elements.add(new ComputedTapPositionChangeElement(((AbstractLfTapChangerAction<?>) lfAction).getChange(), equationSystem));
+            case PhaseTapChangerTapPositionAction.NAME -> {
+                TapPositionChange change = ((AbstractLfTapChangerAction<?>) lfAction).getChange();
+                // a pure phase shift (no impedance/ratio change) does not modify the branch power and is fully
+                // handled through the target vector: it must not produce a Woodbury element, otherwise its
+                // diagonal term (1 / (oldPower - newPower)) would be infinite and corrupt the alpha solve
+                if (changesBranchPower(change)) {
+                    elements.add(new ComputedTapPositionChangeElement(change, equationSystem));
+                }
+            }
             case GeneratorAction.NAME -> { /* generator actions modify the target vector, they produce no Woodbury elements */ }
             case LoadAction.NAME -> { /* load actions modify the target vector, they produce no Woodbury elements */ }
             default -> throw new IllegalStateException("Only tap position change and branch enabling/disabling are supported in WoodburyDcSecurityAnalysis");
@@ -167,5 +176,19 @@ public interface ComputedElement {
             return Stream.empty();
         }
         return Stream.of(Map.entry(lfAction, elements));
+    }
+
+    /**
+     * Returns true if the tap position change modifies the branch power, i.e. its impedance or ratio. In DC the branch
+     * power only depends on the resistance, the reactance and the first side ratio (see
+     * {@link com.powsybl.openloadflow.dc.equations.AbstractClosedBranchDcFlowEquationTerm#computePower}). A pure phase
+     * shift leaves the power unchanged and so does not require a Woodbury element.
+     */
+    private static boolean changesBranchPower(TapPositionChange change) {
+        PiModel oldPiModel = change.getBranch().getPiModel();
+        PiModel newPiModel = change.getNewPiModel();
+        return oldPiModel.getR() != newPiModel.getR()
+                || oldPiModel.getX() != newPiModel.getX()
+                || oldPiModel.getR1() != newPiModel.getR1();
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/dc/fastdc/ComputedElement.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/fastdc/ComputedElement.java
@@ -16,7 +16,10 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.math.matrix.DenseMatrix;
 import com.powsybl.math.matrix.Matrix;
 import com.powsybl.openloadflow.dc.DcLoadFlowContext;
+import com.powsybl.openloadflow.dc.equations.AbstractClosedBranchDcFlowEquationTerm;
 import com.powsybl.openloadflow.dc.equations.ClosedBranchSide1DcFlowEquationTerm;
+import com.powsybl.openloadflow.dc.equations.DcApproximationType;
+import com.powsybl.openloadflow.dc.equations.DcEquationSystemCreationParameters;
 import com.powsybl.openloadflow.dc.equations.DcEquationType;
 import com.powsybl.openloadflow.dc.equations.DcVariableType;
 import com.powsybl.openloadflow.equations.Equation;
@@ -133,9 +136,10 @@ public interface ComputedElement {
         return elementsStates;
     }
 
-    static Map<LfAction, List<ComputedElement>> createActionElementsIndexByLfAction(Map<String, LfAction> lfActionById, EquationSystem<DcVariableType, DcEquationType> equationSystem) {
+    static Map<LfAction, List<ComputedElement>> createActionElementsIndexByLfAction(Map<String, LfAction> lfActionById, EquationSystem<DcVariableType, DcEquationType> equationSystem,
+                                                                                    DcEquationSystemCreationParameters creationParameters) {
         Map<LfAction, List<ComputedElement>> computedElements = lfActionById.values().stream()
-            .flatMap(lfAction -> computeActionElementsIndexByLfAction(lfAction, equationSystem))
+            .flatMap(lfAction -> computeActionElementsIndexByLfAction(lfAction, equationSystem, creationParameters))
             .filter(e -> e.getValue().stream().filter(b -> b.getLfBranchEquation() == null).findAny().isEmpty())
             .collect(Collectors.toMap(
                 Map.Entry::getKey,
@@ -148,7 +152,8 @@ public interface ComputedElement {
     }
 
     private static Stream<Map.Entry<LfAction, List<ComputedElement>>> computeActionElementsIndexByLfAction(LfAction lfAction,
-                                                                                                    EquationSystem<DcVariableType, DcEquationType> equationSystem) {
+                                                                                                    EquationSystem<DcVariableType, DcEquationType> equationSystem,
+                                                                                                    DcEquationSystemCreationParameters creationParameters) {
         List<ComputedElement> elements = new ArrayList<>();
         switch (lfAction.getType()) {
             case SwitchAction.NAME, TerminalsConnectionAction.NAME -> {
@@ -164,7 +169,7 @@ public interface ComputedElement {
                 // a pure phase shift (no impedance/ratio change) does not modify the branch power and is fully
                 // handled through the target vector: it must not produce a Woodbury element, otherwise its
                 // diagonal term (1 / (oldPower - newPower)) would be infinite and corrupt the alpha solve
-                if (changesBranchPower(change)) {
+                if (changesBranchPower(change, creationParameters)) {
                     elements.add(new ComputedTapPositionChangeElement(change, equationSystem));
                 }
             }
@@ -179,16 +184,22 @@ public interface ComputedElement {
     }
 
     /**
-     * Returns true if the tap position change modifies the branch power, i.e. its impedance or ratio. In DC the branch
-     * power only depends on the resistance, the reactance and the first side ratio (see
-     * {@link com.powsybl.openloadflow.dc.equations.AbstractClosedBranchDcFlowEquationTerm#computePower}). A pure phase
-     * shift leaves the power unchanged and so does not require a Woodbury element.
+     * Returns true if the tap position change modifies the branch power. The Woodbury element built for such a change
+     * has a diagonal term {@code 1 / (oldPower - newPower)} (see {@link WoodburyEngine}), so it must only be created
+     * when the power actually changes, otherwise that term is infinite and corrupts the alpha solve. The power is
+     * evaluated with the exact same inputs as the diagonal, i.e. through
+     * {@link AbstractClosedBranchDcFlowEquationTerm#computePower} with the configured DC approximation type and
+     * transformer ratio usage: depending on those, the power ignores the resistance (IGNORE_R) or the first side ratio
+     * (transformer ratio not used), so comparing the pi model resistance, reactance and ratio directly would wrongly
+     * flag as power changes some tap changes that leave the power unchanged (e.g. a pure phase shift, but also a
+     * resistance-only change in IGNORE_R).
      */
-    private static boolean changesBranchPower(TapPositionChange change) {
+    private static boolean changesBranchPower(TapPositionChange change, DcEquationSystemCreationParameters creationParameters) {
         PiModel oldPiModel = change.getBranch().getPiModel();
         PiModel newPiModel = change.getNewPiModel();
-        return oldPiModel.getR() != newPiModel.getR()
-                || oldPiModel.getX() != newPiModel.getX()
-                || oldPiModel.getR1() != newPiModel.getR1();
+        boolean useTransformerRatio = creationParameters.isUseTransformerRatio();
+        DcApproximationType dcApproximationType = creationParameters.getDcApproximationType();
+        return AbstractClosedBranchDcFlowEquationTerm.computePower(useTransformerRatio, dcApproximationType, oldPiModel)
+                != AbstractClosedBranchDcFlowEquationTerm.computePower(useTransformerRatio, dcApproximationType, newPiModel);
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysis.java
@@ -441,7 +441,8 @@ public class WoodburyDcSecurityAnalysis extends DcSecurityAnalysis {
             ConnectivityBreakAnalysis.ConnectivityBreakAnalysisResults connectivityBreakAnalysisResults = ConnectivityBreakAnalysis.run(context, propagatedContingencies);
 
             // the map is indexed by lf actions as different kind of actions can be given on the same branch
-            Map<LfAction, List<ComputedElement>> actionElementsIndexByLfAction = ComputedElement.createActionElementsIndexByLfAction(lfActionById, context.getEquationSystem());
+            Map<LfAction, List<ComputedElement>> actionElementsIndexByLfAction = ComputedElement.createActionElementsIndexByLfAction(lfActionById, context.getEquationSystem(),
+                    context.getParameters().getEquationSystemCreationParameters());
 
             // compute states with +1 -1 to model the actions in Woodbury engine
             // note that the number of columns in the matrix depends on the number of distinct branches affected by the action elements

--- a/src/main/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysis.java
@@ -140,6 +140,7 @@ public class WoodburyDcSecurityAnalysis extends DcSecurityAnalysis {
                 .toList();
         List<ComputedElement> actionElements = operatorStrategyLfActions.stream()
                 .map(actionElementByLfAction::get)
+                .filter(Objects::nonNull)
                 .flatMap(Collection::stream)
                 .filter(actionElement -> !elementsToReconnect.contains(actionElement.getLfBranch().getId()))
                 .toList();

--- a/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
+++ b/src/main/java/com/powsybl/openloadflow/sensi/DcSensitivityAnalysis.java
@@ -625,7 +625,8 @@ public class DcSensitivityAnalysis extends AbstractSensitivityAnalysis<DcVariabl
                 ConnectivityBreakAnalysis.ConnectivityBreakAnalysisResults connectivityBreakAnalysisResults = ConnectivityBreakAnalysis.run(loadFlowContext, contingenciesWithFactors);
 
                 // the map is indexed by lf actions as different kind of actions can be given on the same branch
-                Map<LfAction, List<ComputedElement>> actionElementsIndexByLfAction = ComputedElement.createActionElementsIndexByLfAction(lfActionById, loadFlowContext.getEquationSystem());
+                Map<LfAction, List<ComputedElement>> actionElementsIndexByLfAction = ComputedElement.createActionElementsIndexByLfAction(lfActionById, loadFlowContext.getEquationSystem(),
+                        loadFlowContext.getParameters().getEquationSystemCreationParameters());
 
                 // compute states with +1 -1 to model the actions in Woodbury engine
                 // note that the number of columns in the matrix depends on the number of distinct branches affected by the action elements

--- a/src/test/java/com/powsybl/openloadflow/dc/fastdc/WoodburyEngineTest.java
+++ b/src/test/java/com/powsybl/openloadflow/dc/fastdc/WoodburyEngineTest.java
@@ -18,6 +18,7 @@ import com.powsybl.math.matrix.DenseMatrix;
 import com.powsybl.openloadflow.dc.DcLoadFlowContext;
 import com.powsybl.openloadflow.dc.DcLoadFlowEngine;
 import com.powsybl.openloadflow.dc.DcLoadFlowParameters;
+import com.powsybl.openloadflow.dc.equations.DcApproximationType;
 import com.powsybl.openloadflow.equations.EquationTerm;
 import com.powsybl.openloadflow.network.*;
 import com.powsybl.openloadflow.network.action.LfAction;
@@ -294,6 +295,30 @@ class WoodburyEngineTest {
                 "a pure phase-shift tap action must not produce a Woodbury element");
     }
 
+    @Test
+    void testResistanceOnlyTapActionDependsOnDcApproximationType() {
+        // Turn PS1 into a resistance-only tap changer: a non-zero base resistance, the same reactance and ratio on
+        // every step, and only the resistance varying from one tap to the next (effective R = 15 on tap 0, 10 on
+        // tap 1, while X = 100 and rho = 1 on both).
+        pstNetwork.getTwoWindingsTransformer("PS1").setR(10);
+        PhaseTapChanger ptc = pstNetwork.getTwoWindingsTransformer("PS1").getPhaseTapChanger();
+        ptc.getStep(0).setX(0).setR(50);
+        ptc.getStep(1).setX(0).setR(0);
+
+        // IGNORE_R (default): the DC power ignores the resistance, so a resistance-only tap change leaves the power
+        // unchanged. It must not produce a Woodbury element, otherwise its 1 / (oldPower - newPower) diagonal term
+        // would be infinite and corrupt the alpha solve.
+        dcParameters.getEquationSystemCreationParameters().setDcApproximationType(DcApproximationType.IGNORE_R);
+        assertTrue(computedTapChangeElements(pstNetwork, 1, 0).isEmpty(),
+                "a resistance-only tap action must not produce a Woodbury element when the resistance is ignored");
+
+        // IGNORE_G: the DC power depends on the resistance, so the same tap change now modifies the power and must
+        // produce a Woodbury element.
+        dcParameters.getEquationSystemCreationParameters().setDcApproximationType(DcApproximationType.IGNORE_G);
+        assertFalse(computedTapChangeElements(pstNetwork, 1, 0).isEmpty(),
+                "a resistance-only tap action must produce a Woodbury element when the resistance matters");
+    }
+
     private Map<LfAction, List<ComputedElement>> computedTapChangeElements(Network network, int fromTap, int toTap) {
         network.getTwoWindingsTransformer("PS1").getPhaseTapChanger().setTapPosition(fromTap);
         LfTopoConfig topoConfig = new LfTopoConfig();
@@ -304,7 +329,8 @@ class WoodburyEngineTest {
             new DcLoadFlowEngine(context).run();
             Map<String, LfAction> lfActions = LfActionUtils.createLfActions(lfNetwork,
                     Set.of(new PhaseTapChangerTapPositionAction("pst", "PS1", false, toTap)), network);
-            return ComputedElement.createActionElementsIndexByLfAction(lfActions, context.getEquationSystem());
+            return ComputedElement.createActionElementsIndexByLfAction(lfActions, context.getEquationSystem(),
+                    context.getParameters().getEquationSystemCreationParameters());
         }
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/dc/fastdc/WoodburyEngineTest.java
+++ b/src/test/java/com/powsybl/openloadflow/dc/fastdc/WoodburyEngineTest.java
@@ -13,6 +13,7 @@ import com.powsybl.commons.report.ReportNode;
 import com.powsybl.contingency.BranchContingency;
 import com.powsybl.contingency.SwitchContingency;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.PhaseTapChanger;
 import com.powsybl.math.matrix.DenseMatrix;
 import com.powsybl.openloadflow.dc.DcLoadFlowContext;
 import com.powsybl.openloadflow.dc.DcLoadFlowEngine;
@@ -20,6 +21,7 @@ import com.powsybl.openloadflow.dc.DcLoadFlowParameters;
 import com.powsybl.openloadflow.equations.EquationTerm;
 import com.powsybl.openloadflow.network.*;
 import com.powsybl.openloadflow.network.action.LfAction;
+import com.powsybl.openloadflow.network.action.LfActionUtils;
 import com.powsybl.openloadflow.network.action.LfPhaseTapChangerAction;
 import com.powsybl.openloadflow.network.action.LfSwitchAction;
 import com.powsybl.openloadflow.network.impl.LfNetworkLoaderImpl;
@@ -30,9 +32,12 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -265,6 +270,41 @@ class WoodburyEngineTest {
             engine.toPostContingencyAndOperatorStrategyStates(flowStates);
             var flows = calculateFlows(lfNetwork, flowStates, Set.of("C", "B3"));
             assertArrayEquals(flowsRef, flows, LoadFlowAssert.DELTA_POWER);
+        }
+    }
+
+    /**
+     * A pure phase-shift tap change (only the phase angle alpha varies across taps; r, x and rho are constant) does not
+     * modify the branch power, so it must NOT produce a Woodbury {@link ComputedTapPositionChangeElement}: its diagonal
+     * term {@code 1 / (oldPower - newPower)} would be infinite and corrupt the alpha solve, which surfaced as NaN
+     * function references in DC sensitivity analysis. The phase shift is instead fully handled through the target vector.
+     * A tap change that does modify the branch impedance must still produce an element.
+     */
+    @Test
+    void testPurePhaseShiftTapActionProducesNoWoodburyElement() {
+        // PS1 steps have different reactances (x = 50, 100, 200): moving the tap changes the branch power, so the
+        // action must produce a Woodbury element
+        assertFalse(computedTapChangeElements(pstNetworkRef, 1, 0).isEmpty());
+
+        // derive a pure phase shifter from PS1 by giving every tap step the same impedance (only alpha keeps varying)
+        PhaseTapChanger ptc = pstNetwork.getTwoWindingsTransformer("PS1").getPhaseTapChanger();
+        ptc.getStep(0).setX(100);
+        ptc.getStep(2).setX(100);
+        assertTrue(computedTapChangeElements(pstNetwork, 1, 0).isEmpty(),
+                "a pure phase-shift tap action must not produce a Woodbury element");
+    }
+
+    private Map<LfAction, List<ComputedElement>> computedTapChangeElements(Network network, int fromTap, int toTap) {
+        network.getTwoWindingsTransformer("PS1").getPhaseTapChanger().setTapPosition(fromTap);
+        LfTopoConfig topoConfig = new LfTopoConfig();
+        topoConfig.addBranchIdWithPtcToRetain("PS1");
+        LfNetwork lfNetwork = LfNetwork.load(network, new LfNetworkLoaderImpl(), topoConfig, dcParameters.getNetworkParameters(), ReportNode.NO_OP).getFirst();
+        try (DcLoadFlowContext context = new DcLoadFlowContext(lfNetwork, dcParameters)) {
+            context.getParameters().getEquationSystemCreationParameters().setForcePhaseControlOffAndAddAngle1Var(true);
+            new DcLoadFlowEngine(context).run();
+            Map<String, LfAction> lfActions = LfActionUtils.createLfActions(lfNetwork,
+                    Set.of(new PhaseTapChangerTapPositionAction("pst", "PS1", false, toTap)), network);
+            return ComputedElement.createActionElementsIndexByLfAction(lfActions, context.getEquationSystem());
         }
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When a phase shift action does not change the impedance, it should not produce a woodburry element. Otherwise we might get a nan in the alpha solve.


**What is the new behavior (if this is a feature change)?**
Pure phase shift without any impedance change are not producing a woodburry element anymore.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
