### PR TITLE
Fix reproducibility issue introduced by EquationTerm sorting

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/equations/EquationArray.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationArray.java
@@ -426,7 +426,7 @@ public class EquationArray<V extends Enum<V> & Quantity, E extends Enum<E> & Qua
             }
         }
         // Terms do not have a row initially so they are sorted by variable hash code
-        terms.sort(Comparator.comparingInt(o -> o.derivative.getVariable().hashCode()));
+        terms.sort(Comparator.comparing(o -> o.derivative.getVariable()));
 
         allTerms.addAll(terms);
     }

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationArray.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationArray.java
@@ -425,7 +425,7 @@ public class EquationArray<V extends Enum<V> & Quantity, E extends Enum<E> & Qua
                 }
             }
         }
-        // Terms do not have a row initially so they are sorted by variable hash code
+        // Terms are sorted with variable comparator
         terms.sort(Comparator.comparing(o -> o.derivative.getVariable()));
 
         allTerms.addAll(terms);

--- a/src/test/java/com/powsybl/openloadflow/equations/EquationArrayTest.java
+++ b/src/test/java/com/powsybl/openloadflow/equations/EquationArrayTest.java
@@ -9,6 +9,10 @@ package com.powsybl.openloadflow.equations;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.math.matrix.DenseMatrix;
+import com.powsybl.math.matrix.SparseMatrix;
+import com.powsybl.math.matrix.SparseMatrixFactory;
+import com.powsybl.openloadflow.ac.AcLoadFlowContext;
+import com.powsybl.openloadflow.ac.AcLoadFlowParameters;
 import com.powsybl.openloadflow.ac.equations.*;
 import com.powsybl.openloadflow.ac.equations.vector.*;
 import com.powsybl.openloadflow.ac.solver.AcSolverUtil;
@@ -17,8 +21,7 @@ import com.powsybl.openloadflow.network.impl.LfNetworkLoaderImpl;
 import com.powsybl.openloadflow.network.util.UniformValueVoltageInitializer;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -122,5 +125,28 @@ class EquationArrayTest {
 
         assertEquals(equationSystem.getEquation(1, AcEquationType.BUS_TARGET_P).orElseThrow().eval(),
                      equationSystem2.getEquationArray(AcEquationType.BUS_TARGET_P).orElseThrow().getElement(1).eval());
+    }
+
+    /**
+     * With SparseMatrixFactory, when calculating the Jacobian Matrix of an equation system with equation arrays,
+     * all the terms are added in some order depending on the EquationDerivativeVector order (rows and columns do
+     * not depend on it, but the order of stacking the values in the sparse structure is impacted). This test ensures
+     * the order is always the same. (If not, very small non-reproducible numerical errors (10^-12) can occur during
+     * Sparse LU decomposition)
+     */
+    @Test
+    void testSparseReproducibility() {
+        Network network = FourBusNetworkFactory.createWithTwoScs();
+        LfNetwork lfNetwork = LfNetwork.load(network, new LfNetworkLoaderImpl(), new FirstSlackBusSelector()).get(0);
+
+        try (var acContext = new AcLoadFlowContext(lfNetwork, new AcLoadFlowParameters().setMatrixFactory(new SparseMatrixFactory()))) {
+            acContext.getJacobianMatrix().initDer();
+            int[] expectedRowIndices = {0, 1, 6, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            int[] rowIndices = ((SparseMatrix) acContext.getJacobianMatrix().matrix).getRowIndices();
+            int[] expectedColumnStarts = {0, 1, 2, 3, 9, 17, 23, 29, 37};
+            int[] columnStarts = ((SparseMatrix) acContext.getJacobianMatrix().matrix).getColumnStart();
+            assertArrayEquals(expectedRowIndices, rowIndices);
+            assertArrayEquals(expectedColumnStarts, columnStarts);
+        }
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -4158,7 +4158,6 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
 
         // Remove Windows EOL
         String reportString = TestUtil.normalizeLineSeparator(reportToString(testReport));
-        //reportString = reportToString(testReport);
 
         // The report should be the same with one or two threads
         // Let's just check the size here
@@ -4178,7 +4177,6 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
                                     Outer loop ReactiveLimits
                                     AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
                         """;
-        System.out.println(reportString);
         assertTrue(reportString.contains(expected));
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Minor reproducibility issue has been detected where very small numerical changes could happen on the same test on the same machine when using sparse matrix. Even if rows and columns do not change, order of stacking values in the sparse matrix structure can trigger very small numerical change in sparse LU decomposition.

The difference could be detected in test `multiComponentSaTest()` in OpenSecurityAnalysisTest, if SparseMatrixFactory is used, and if report numerical values rounding is disabled. In that case, small numerical changes could affect the size of the report (one character change).

**What is the current behavior?**
Terms are sorted by hashCode (which is not stable because of the VariableType's hashCode that can change)

**What is the new behavior (if this is a feature change)?**
Terms are sorted using Variable comparator which is stable

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

N.B. This minor issue of reproducibility appeared because of the fix introduced in #1394 (@Hadrien-Godard you were right...)