### PR TITLE
Improve secondary voltage control robustness

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
@@ -36,8 +36,10 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
 
     public static final String NAME = "SecondaryVoltageControl";
 
-    private static final double DV_EPS = 1E-4; // 0.1 kV
-    private static final double DK_DIFF_MAX_EPS = 1E-3; // 1 MVar
+    private static final double DV_EPS = 5E-4;
+    private static final double DK_DIFF_MAX_EPS = 5E-3;
+    private static final double K_SATURATION_EPS = 5E-2;
+    private static final double MAX_TARGET_VOLTAGE_STEP_KV = 2;
 
     private final double minPlausibleTargetVoltage;
 
@@ -216,6 +218,49 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
         return secondaryVoltageControl.getTargetValue() - secondaryVoltageControl.getPilotBus().getV();
     }
 
+    private static boolean shouldAdjustSecondaryVoltageControl(double pilotDv, KStats kStats) {
+        if (Math.abs(pilotDv) > DV_EPS) {
+            return pilotDv > 0 && kStats.kAverage() < 1 - K_SATURATION_EPS
+                    || pilotDv < 0 && kStats.kAverage() > -1 + K_SATURATION_EPS;
+        }
+        if (kStats.allAtLimits()) {
+            return false;
+        }
+        // Once the pilot target is reached, do not keep adjusting a globally saturated zone just to improve reactive
+        // power sharing.
+        if (kStats.kAverage() <= -1 + K_SATURATION_EPS || kStats.kAverage() >= 1 - K_SATURATION_EPS) {
+            return false;
+        }
+        return Math.abs(kStats.dkDiffMax()) > DK_DIFF_MAX_EPS;
+    }
+
+    private record TargetVoltageChange(DenseMatrix dv, int clippedTargetVoltageCount, double maxTargetVoltageStepKv) {
+    }
+
+    private static TargetVoltageChange clipTargetVoltageChange(List<LfBus> controlledBuses, DenseMatrix dv,
+                                                               Map<Integer, Integer> controlledBusIndex) {
+        DenseMatrix clippedDv = new DenseMatrix(dv.getRowCount(), dv.getColumnCount());
+        int clippedTargetVoltageCount = 0;
+        double maxTargetVoltageStepKv = 0;
+        for (LfBus controlledBus : controlledBuses) {
+            int i = controlledBusIndex.get(controlledBus.getNum());
+            double dvValue = dv.get(i, 0);
+            double stepKv = dvValue * controlledBus.getNominalV();
+            double absStepKv = Math.abs(stepKv);
+            maxTargetVoltageStepKv = Math.max(maxTargetVoltageStepKv, absStepKv);
+            if (stepKv > MAX_TARGET_VOLTAGE_STEP_KV) {
+                clippedDv.set(i, 0, MAX_TARGET_VOLTAGE_STEP_KV / controlledBus.getNominalV());
+                clippedTargetVoltageCount++;
+            } else if (stepKv < -MAX_TARGET_VOLTAGE_STEP_KV) {
+                clippedDv.set(i, 0, -MAX_TARGET_VOLTAGE_STEP_KV / controlledBus.getNominalV());
+                clippedTargetVoltageCount++;
+            } else {
+                clippedDv.set(i, 0, dvValue);
+            }
+        }
+        return new TargetVoltageChange(clippedDv, clippedTargetVoltageCount, maxTargetVoltageStepKv);
+    }
+
     private Optional<List<String>> processSecondaryVoltageControl(List<LfSecondaryVoltageControl> secondaryVoltageControls,
                                                                   AcLoadFlowContext loadFlowContext) {
         List<String> adjustedZoneNames = new ArrayList<>();
@@ -224,7 +269,7 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
             double pilotDv = calculatePilotPointDv(secondaryVoltageControl);
             List<LfBus> controllerBuses = secondaryVoltageControl.getControllerBuses();
             KStats kStats = calculateKStats(controllerBuses);
-            if (Math.abs(pilotDv) > DV_EPS || !kStats.allAtLimits() && Math.abs(kStats.dkDiffMax()) > DK_DIFF_MAX_EPS) {
+            if (shouldAdjustSecondaryVoltageControl(pilotDv, kStats)) {
                 var pilotBus = secondaryVoltageControl.getPilotBus();
                 if (LOGGER.isDebugEnabled()) {
                     int allControllerBusesCount = secondaryVoltageControl.getControllerBuses().size();
@@ -263,7 +308,7 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
         DenseMatrix jK = createJk(sensitivityContext, allControllerBuses, allControlledBuses, controllerBusIndex, controlledBusIndex).transpose();
         DenseMatrix b = a.times(jK);
 
-        // replace last row for each of the secondary voltage control block
+        // replace last row for each secondary voltage control block
         for (LfSecondaryVoltageControl secondaryVoltageControl : secondaryVoltageControls) {
             List<LfBus> controllerBuses = secondaryVoltageControl.getEnabledControllerBuses();
             List<LfBus> controlledBuses = controllerBuses.stream()
@@ -288,12 +333,19 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
         @SuppressWarnings("UnnecessaryLocalVariable")
         DenseMatrix dv = rhs;
 
+        TargetVoltageChange targetVoltageChange = clipTargetVoltageChange(allControlledBuses, dv, controlledBusIndex);
+        if (targetVoltageChange.clippedTargetVoltageCount() > 0) {
+            LOGGER.info("Clip {} secondary voltage control target voltage changes to {} kV (unclipped max step was {} kV)",
+                    targetVoltageChange.clippedTargetVoltageCount(), MAX_TARGET_VOLTAGE_STEP_KV,
+                    targetVoltageChange.maxTargetVoltageStepKv());
+        }
+
         // compute new controlled bus target voltages
         Map<LfBus, Double> newControlledBusTargetV = new HashMap<>(allControllerBuses.size());
         for (LfBus controlledBus : allControlledBuses) {
             int i = controlledBusIndex.get(controlledBus.getNum());
             var vc = controlledBus.getGeneratorVoltageControl().orElseThrow();
-            double newTargetV = vc.getTargetValue() + dv.get(i, 0);
+            double newTargetV = vc.getTargetValue() + targetVoltageChange.dv().get(i, 0);
             newControlledBusTargetV.put(controlledBus, newTargetV);
         }
 

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
@@ -21,6 +21,7 @@ import com.powsybl.openloadflow.lf.outerloop.OuterLoopResult;
 import com.powsybl.openloadflow.lf.outerloop.OuterLoopStatus;
 import com.powsybl.openloadflow.network.*;
 import org.apache.commons.lang3.mutable.MutableDouble;
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +41,17 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
     private static final double K_SATURATION_EPS = 5E-2;
     private static final double MAX_TARGET_VOLTAGE_STEP_KV = 2;
 
+    /**
+     * A zone error (pilot point voltage difference and controller buses k difference) has to decrease by at least this
+     * ratio from one adjustment to the next one to be considered as progressing.
+     */
+    private static final double MIN_PROGRESS_RATIO = 1E-2;
+
+    /**
+     * Number of consecutive adjustments without progress after which a zone is considered as stalled.
+     */
+    private static final int MAX_NO_PROGRESS_COUNT = 2;
+
     private final double minPlausibleTargetVoltage;
 
     private final double maxPlausibleTargetVoltage;
@@ -52,6 +64,33 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
     public SecondaryVoltageControlOuterLoop(double minPlausibleTargetVoltage, double maxPlausibleTargetVoltage) {
         this.minPlausibleTargetVoltage = minPlausibleTargetVoltage;
         this.maxPlausibleTargetVoltage = maxPlausibleTargetVoltage;
+    }
+
+    /**
+     * Error of a zone at the time of its last adjustment, used to detect zones that cannot be adjusted anymore (for
+     * instance because their controlled bus target voltages are clipped to the plausible voltage range, or because
+     * their controller buses reactive power cannot be aligned any better).
+     */
+    private record ZoneError(double pilotDvAbs, double dkDiffMax) {
+
+        boolean hasProgressedFrom(ZoneError previous) {
+            return pilotDvAbs < previous.pilotDvAbs * (1 - MIN_PROGRESS_RATIO)
+                    || dkDiffMax < previous.dkDiffMax * (1 - MIN_PROGRESS_RATIO);
+        }
+    }
+
+    private static final class ContextData {
+
+        private final Map<String, ZoneError> lastZoneError = new HashMap<>();
+
+        private final Map<String, MutableInt> noProgressCount = new HashMap<>();
+
+        private final Set<String> stalledZoneNames = new HashSet<>();
+    }
+
+    @Override
+    public void initialize(AcOuterLoopContext context) {
+        context.setData(new ContextData());
     }
 
     public static class SensitivityContext {
@@ -217,6 +256,28 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
         return secondaryVoltageControl.getTargetValue() - secondaryVoltageControl.getPilotBus().getV();
     }
 
+    /**
+     * A zone is stalled when its error did not decrease anymore during the last adjustments: adjusting it again would
+     * just repeat the same ineffective target voltage change until max outer loop iteration is reached.
+     */
+    private static boolean isStalled(ContextData contextData, String zoneName, ZoneError zoneError, double pilotNominalV) {
+        ZoneError previousZoneError = contextData.lastZoneError.put(zoneName, zoneError);
+        if (previousZoneError == null || zoneError.hasProgressedFrom(previousZoneError)) {
+            contextData.noProgressCount.remove(zoneName);
+            return false;
+        }
+        MutableInt count = contextData.noProgressCount.computeIfAbsent(zoneName, k -> new MutableInt());
+        count.increment();
+        if (count.intValue() < MAX_NO_PROGRESS_COUNT) {
+            return false;
+        }
+        contextData.stalledZoneNames.add(zoneName);
+        LOGGER.warn("Secondary voltage control of zone '{}' is stalled after {} adjustments without progress (remaining pilot point dv is {} kV, " +
+                "controller buses dk diff max is {}): it cannot be adjusted any further and is now ignored",
+                zoneName, count.intValue(), zoneError.pilotDvAbs() * pilotNominalV, zoneError.dkDiffMax());
+        return true;
+    }
+
     private static boolean shouldAdjustSecondaryVoltageControl(double pilotDv, KStats kStats) {
         if (Math.abs(pilotDv) > DV_EPS) {
             return pilotDv > 0 && kStats.kAverage() < 1 - K_SATURATION_EPS
@@ -274,10 +335,15 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
     }
 
     private List<String> processSecondaryVoltageControl(List<LfSecondaryVoltageControl> secondaryVoltageControls,
-                                                        AcLoadFlowContext loadFlowContext) {
+                                                        AcLoadFlowContext loadFlowContext,
+                                                        ContextData contextData) {
         List<String> adjustedZoneNames = new ArrayList<>();
 
         for (LfSecondaryVoltageControl secondaryVoltageControl : secondaryVoltageControls) {
+            String zoneName = secondaryVoltageControl.getZoneName();
+            if (contextData.stalledZoneNames.contains(zoneName)) {
+                continue;
+            }
             double pilotDv = calculatePilotPointDv(secondaryVoltageControl);
             List<LfBus> controllerBuses = secondaryVoltageControl.getControllerBuses();
             KStats kStats = calculateKStats(controllerBuses);
@@ -286,9 +352,16 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
                 if (LOGGER.isDebugEnabled()) {
                     int allControllerBusesCount = secondaryVoltageControl.getControllerBuses().size();
                     LOGGER.debug("Secondary voltage control of zone '{}': {}/{} controller buses available, pilot point dv is {} kV, controller buses dk diff max is {} (k average is {})",
-                            secondaryVoltageControl.getZoneName(), controllerBuses.size(), allControllerBusesCount, pilotDv * pilotBus.getNominalV(), kStats.dkDiffMax(), kStats.kAverage());
+                            zoneName, controllerBuses.size(), allControllerBusesCount, pilotDv * pilotBus.getNominalV(), kStats.dkDiffMax(), kStats.kAverage());
                 }
-                adjustedZoneNames.add(secondaryVoltageControl.getZoneName());
+                if (isStalled(contextData, zoneName, new ZoneError(Math.abs(pilotDv), kStats.dkDiffMax()), pilotBus.getNominalV())) {
+                    continue;
+                }
+                adjustedZoneNames.add(zoneName);
+            } else {
+                // zone does not need to be adjusted anymore, reset its progress tracking
+                contextData.lastZoneError.remove(zoneName);
+                contextData.noProgressCount.remove(zoneName);
             }
         }
 
@@ -399,6 +472,60 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
     }
 
     @Override
+    public void cleanup(AcOuterLoopContext context) {
+        logSecondaryVoltageControlSummary(context.getNetwork(), (ContextData) context.getData());
+    }
+
+    /**
+     * Log, for each secondary voltage control zone, whether the pilot point voltage target has been reached and
+     * whether reactive power of the controller buses has been aligned.
+     */
+    private static void logSecondaryVoltageControlSummary(LfNetwork network, ContextData contextData) {
+        List<LfSecondaryVoltageControl> secondaryVoltageControls = network.getSecondaryVoltageControls();
+        if (secondaryVoltageControls.isEmpty() || !LOGGER.isInfoEnabled()) {
+            return;
+        }
+        List<String> pilotPointNotReached = new ArrayList<>();
+        List<String> reactivePowerNotAligned = new ArrayList<>();
+        int okCount = 0;
+        for (LfSecondaryVoltageControl secondaryVoltageControl : secondaryVoltageControls) {
+            String zoneName = secondaryVoltageControl.getZoneName();
+            List<LfBus> controllerBuses = secondaryVoltageControl.getControllerBuses();
+            if (controllerBuses.isEmpty()) {
+                pilotPointNotReached.add(zoneName + " (no controller bus)");
+                continue;
+            }
+            LfBus pilotBus = secondaryVoltageControl.getPilotBus();
+            double pilotDv = calculatePilotPointDv(secondaryVoltageControl);
+            KStats kStats = calculateKStats(controllerBuses);
+            boolean pilotPointReached = Math.abs(pilotDv) <= DV_EPS;
+            // a zone where all controller buses are at their reactive power limit cannot align them any better
+            boolean reactivePowerAligned = kStats.dkDiffMax() <= DK_DIFF_MAX_EPS || kStats.allAtLimits();
+            if (!pilotPointReached) {
+                pilotPointNotReached.add(String.format(Locale.ROOT, "%s (dv=%.3f kV)", zoneName, pilotDv * pilotBus.getNominalV()));
+            }
+            if (!reactivePowerAligned) {
+                reactivePowerNotAligned.add(String.format(Locale.ROOT, "%s (dk=%.4f)", zoneName, kStats.dkDiffMax()));
+            }
+            if (pilotPointReached && reactivePowerAligned) {
+                okCount++;
+            }
+        }
+        LOGGER.info("Secondary voltage control summary: {}/{} zones with pilot point voltage target reached and reactive power aligned",
+                okCount, secondaryVoltageControls.size());
+        if (!pilotPointNotReached.isEmpty()) {
+            LOGGER.info("Secondary voltage control zones with pilot point voltage target not reached: {}", pilotPointNotReached);
+        }
+        if (!reactivePowerNotAligned.isEmpty()) {
+            LOGGER.info("Secondary voltage control zones with reactive power not aligned: {}", reactivePowerNotAligned);
+        }
+        if (contextData != null && !contextData.stalledZoneNames.isEmpty()) {
+            LOGGER.info("Secondary voltage control zones given up because they could not be adjusted any further: {}",
+                    contextData.stalledZoneNames);
+        }
+    }
+
+    @Override
     public OuterLoopResult check(AcOuterLoopContext context, ReportNode reportNode) {
         LfNetwork network = context.getNetwork();
 
@@ -419,7 +546,8 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
             return new OuterLoopResult(this, OuterLoopStatus.STABLE);
         }
 
-        List<String> adjustedZoneNames = processSecondaryVoltageControl(secondaryVoltageControls, context.getLoadFlowContext());
+        List<String> adjustedZoneNames = processSecondaryVoltageControl(secondaryVoltageControls, context.getLoadFlowContext(),
+                (ContextData) context.getData());
 
         OuterLoopStatus status = OuterLoopStatus.STABLE;
         if (!adjustedZoneNames.isEmpty()) {

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -237,6 +236,9 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
     private record TargetVoltageChange(DenseMatrix dv, int clippedTargetVoltageCount, double maxTargetVoltageStepKv) {
     }
 
+    private record TargetVoltage(double value, boolean clipped) {
+    }
+
     private static TargetVoltageChange clipTargetVoltageChange(List<LfBus> controlledBuses, DenseMatrix dv,
                                                                Map<Integer, Integer> controlledBusIndex) {
         DenseMatrix clippedDv = new DenseMatrix(dv.getRowCount(), dv.getColumnCount());
@@ -261,8 +263,18 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
         return new TargetVoltageChange(clippedDv, clippedTargetVoltageCount, maxTargetVoltageStepKv);
     }
 
-    private Optional<List<String>> processSecondaryVoltageControl(List<LfSecondaryVoltageControl> secondaryVoltageControls,
-                                                                  AcLoadFlowContext loadFlowContext) {
+    private TargetVoltage clipTargetVoltageToPlausibleRange(double targetV) {
+        if (targetV < minPlausibleTargetVoltage) {
+            return new TargetVoltage(minPlausibleTargetVoltage, true);
+        }
+        if (targetV > maxPlausibleTargetVoltage) {
+            return new TargetVoltage(maxPlausibleTargetVoltage, true);
+        }
+        return new TargetVoltage(targetV, false);
+    }
+
+    private List<String> processSecondaryVoltageControl(List<LfSecondaryVoltageControl> secondaryVoltageControls,
+                                                        AcLoadFlowContext loadFlowContext) {
         List<String> adjustedZoneNames = new ArrayList<>();
 
         for (LfSecondaryVoltageControl secondaryVoltageControl : secondaryVoltageControls) {
@@ -281,7 +293,7 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
         }
 
         if (adjustedZoneNames.isEmpty()) {
-            return Optional.of(Collections.emptyList());
+            return Collections.emptyList();
         }
 
         List<LfBus> allControllerBuses = secondaryVoltageControls.stream()
@@ -341,38 +353,33 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
         }
 
         // compute new controlled bus target voltages
-        Map<LfBus, Double> newControlledBusTargetV = new HashMap<>(allControllerBuses.size());
+        Map<LfBus, Double> newControlledBusTargetV = new HashMap<>(allControlledBuses.size());
+        int clippedPlausibleTargetVoltageCount = 0;
         for (LfBus controlledBus : allControlledBuses) {
             int i = controlledBusIndex.get(controlledBus.getNum());
             var vc = controlledBus.getGeneratorVoltageControl().orElseThrow();
-            double newTargetV = vc.getTargetValue() + targetVoltageChange.dv().get(i, 0);
-            newControlledBusTargetV.put(controlledBus, newTargetV);
-        }
-
-        Map<LfBus, Double> notPlausibleNewControlledBusTargetV = newControlledBusTargetV.entrySet()
-                .stream()
-                .filter(e -> {
-                    double newTargetV = e.getValue();
-                    return !VoltageControl.isTargetVoltagePlausible(newTargetV, minPlausibleTargetVoltage, maxPlausibleTargetVoltage);
-                })
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-        if (notPlausibleNewControlledBusTargetV.isEmpty()) {
-            for (var e : newControlledBusTargetV.entrySet()) {
-                LfBus controlledBus = e.getKey();
-                double newTargetV = e.getValue();
-                var vc = controlledBus.getGeneratorVoltageControl().orElseThrow();
-                LOGGER.trace("Adjust target voltage of controlled bus '{}': {} -> {}",
-                        controlledBus.getId(), vc.getTargetValue() * controlledBus.getNominalV(),
-                        newTargetV * controlledBus.getNominalV());
-                vc.setTargetValue(newTargetV);
+            TargetVoltage newTargetV = clipTargetVoltageToPlausibleRange(vc.getTargetValue() + targetVoltageChange.dv().get(i, 0));
+            if (newTargetV.clipped()) {
+                clippedPlausibleTargetVoltageCount++;
             }
-        } else {
-            LOGGER.error("Skipping all controlled bus target voltage adjustment because some of the calculated new target voltages are not plausible: {}",
-                    notPlausibleNewControlledBusTargetV);
-            return Optional.empty();
+            newControlledBusTargetV.put(controlledBus, newTargetV.value());
+        }
+        if (clippedPlausibleTargetVoltageCount > 0) {
+            LOGGER.info("Clip {} secondary voltage control target voltages to plausible range [{}, {}] pu",
+                    clippedPlausibleTargetVoltageCount, minPlausibleTargetVoltage, maxPlausibleTargetVoltage);
         }
 
-        return Optional.of(adjustedZoneNames);
+        for (var e : newControlledBusTargetV.entrySet()) {
+            LfBus controlledBus = e.getKey();
+            double newTargetV = e.getValue();
+            var vc = controlledBus.getGeneratorVoltageControl().orElseThrow();
+            LOGGER.trace("Adjust target voltage of controlled bus '{}': {} -> {}",
+                    controlledBus.getId(), vc.getTargetValue() * controlledBus.getNominalV(),
+                    newTargetV * controlledBus.getNominalV());
+            vc.setTargetValue(newTargetV);
+        }
+
+        return adjustedZoneNames;
     }
 
     private static void tryToReEnableHelpfulControllerBuses(LfNetwork network) {
@@ -412,10 +419,7 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
             return new OuterLoopResult(this, OuterLoopStatus.STABLE);
         }
 
-        List<String> adjustedZoneNames = processSecondaryVoltageControl(secondaryVoltageControls, context.getLoadFlowContext()).orElse(null);
-        if (adjustedZoneNames == null) {
-            return new OuterLoopResult(this, OuterLoopStatus.FAILED, "Cannot adjust secondary voltage control because some calculated controlled bus target voltages are not plausible");
-        }
+        List<String> adjustedZoneNames = processSecondaryVoltageControl(secondaryVoltageControls, context.getLoadFlowContext());
 
         OuterLoopStatus status = OuterLoopStatus.STABLE;
         if (!adjustedZoneNames.isEmpty()) {

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/SecondaryVoltageControlOuterLoop.java
@@ -35,8 +35,8 @@ public class SecondaryVoltageControlOuterLoop implements AcOuterLoop {
 
     public static final String NAME = "SecondaryVoltageControl";
 
-    private static final double DV_EPS = 5E-4;
-    private static final double DK_DIFF_MAX_EPS = 5E-3;
+    private static final double DV_EPS = 1E-4; // 0.1 kV
+    private static final double DK_DIFF_MAX_EPS = 1E-3; // 1 MVar
     private static final double K_SATURATION_EPS = 5E-2;
     private static final double MAX_TARGET_VOLTAGE_STEP_KV = 2;
 

--- a/src/main/java/com/powsybl/openloadflow/network/GeneratorVoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/GeneratorVoltageControl.java
@@ -10,6 +10,7 @@ package com.powsybl.openloadflow.network;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.ToDoubleFunction;
 
 /**
  * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
@@ -83,9 +84,10 @@ public class GeneratorVoltageControl extends VoltageControl<LfBus> {
     }
 
     /**
-     * Returns itself in case of local control, split into several local voltage controls in case of remote control.
+     * Returns itself in case of local control, split into several local voltage controls in case of remote control,
+     * each one getting the target voltage given by {@code localTargetV} for its controller bus.
      */
-    public List<GeneratorVoltageControl> toLocalVoltageControls() {
+    public List<GeneratorVoltageControl> toLocalVoltageControls(ToDoubleFunction<LfBus> localTargetV) {
         if (isLocalControl()) {
             return List.of(this);
         } else {
@@ -93,7 +95,7 @@ public class GeneratorVoltageControl extends VoltageControl<LfBus> {
             // create one (local) generator control per controller bus and remove this one
             controlledBus.setGeneratorVoltageControl(null);
             for (LfBus controllerBus : controllerElements) {
-                var generatorVoltageControl = new GeneratorVoltageControl(controllerBus, targetPriority, targetValue);
+                var generatorVoltageControl = new GeneratorVoltageControl(controllerBus, targetPriority, localTargetV.applyAsDouble(controllerBus));
                 generatorVoltageControl.addControllerElement(controllerBus);
                 generatorVoltageControls.add(generatorVoltageControl);
             }

--- a/src/main/java/com/powsybl/openloadflow/network/LfSecondaryVoltageControl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfSecondaryVoltageControl.java
@@ -20,23 +20,49 @@ public class LfSecondaryVoltageControl {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LfSecondaryVoltageControl.class);
 
+    public static final class ControlUnit {
+        private final String id;
+
+        private boolean participate;
+
+        private final GeneratorVoltageControl generatorVoltageControl;
+
+        public ControlUnit(String id, boolean participate, GeneratorVoltageControl generatorVoltageControl) {
+            this.id = Objects.requireNonNull(id);
+            this.participate = participate;
+            this.generatorVoltageControl = Objects.requireNonNull(generatorVoltageControl);
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public boolean isParticipate() {
+            return participate;
+        }
+
+        public void setParticipate(boolean participate) {
+            this.participate = participate;
+        }
+
+        public GeneratorVoltageControl getGeneratorVoltageControl() {
+            return generatorVoltageControl;
+        }
+    }
+
     private final String zoneName;
 
     private final LfBus pilotBus;
 
-    private final Set<String> participatingControlUnitIds;
-
-    private final Set<GeneratorVoltageControl> generatorVoltageControls;
+    private final List<ControlUnit> controlUnits;
 
     private double targetValue;
 
-    public LfSecondaryVoltageControl(String zoneName, LfBus pilotBus, double targetValue, Set<String> participatingControlUnitIds,
-                                     Set<GeneratorVoltageControl> generatorVoltageControls) {
+    public LfSecondaryVoltageControl(String zoneName, LfBus pilotBus, double targetValue, List<ControlUnit> controlUnits) {
         this.zoneName = Objects.requireNonNull(zoneName);
         this.pilotBus = Objects.requireNonNull(pilotBus);
         this.targetValue = targetValue;
-        this.participatingControlUnitIds = Objects.requireNonNull(participatingControlUnitIds);
-        this.generatorVoltageControls = Objects.requireNonNull(generatorVoltageControls);
+        this.controlUnits = List.copyOf(controlUnits);
     }
 
     public String getZoneName() {
@@ -59,32 +85,37 @@ public class LfSecondaryVoltageControl {
     }
 
     public void addParticipatingControlUnit(String id) {
-        if (participatingControlUnitIds.add(id)) {
+        if (setParticipatingControlUnit(id, true)) {
             tryToReEnableHelpfulControllerBuses();
         }
     }
 
     public void removeParticipatingControlUnit(String id) {
-        if (participatingControlUnitIds.remove(id)) {
+        if (setParticipatingControlUnit(id, false)) {
             tryToReEnableHelpfulControllerBuses();
         }
     }
 
-    public Set<GeneratorVoltageControl> getGeneratorVoltageControls() {
-        return generatorVoltageControls.stream()
-                .filter(this::hasAtLeastOneParticipatingControlUnit) // only keep voltage controls where there is at list one enabled control unit
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-    }
-
-    private boolean hasAtLeastOneParticipatingControlUnit(GeneratorVoltageControl vc) {
-        for (var controllerElement : vc.getMergedControllerElements()) {
-            for (LfGenerator generator : controllerElement.getGenerators()) {
-                if (participatingControlUnitIds.contains(generator.getId())) {
-                    return true;
-                }
+    private boolean setParticipatingControlUnit(String id, boolean participate) {
+        boolean changed = false;
+        for (ControlUnit controlUnit : controlUnits) {
+            if (controlUnit.getId().equals(id) && controlUnit.isParticipate() != participate) {
+                controlUnit.setParticipate(participate);
+                changed = true;
             }
         }
-        return false;
+        return changed;
+    }
+
+    public List<ControlUnit> getControlUnits() {
+        return controlUnits;
+    }
+
+    public Set<GeneratorVoltageControl> getGeneratorVoltageControls() {
+        return controlUnits.stream()
+                .filter(ControlUnit::isParticipate)
+                .map(ControlUnit::getGeneratorVoltageControl)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private static List<LfBus> findControllerBuses(LfBus controlledBus) {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfGenerator.java
@@ -139,6 +139,14 @@ public abstract class AbstractLfGenerator extends AbstractLfInjection implements
         return false;
     }
 
+    /**
+     * Returns true if an equivalent local target voltage is defined, meaning this generator can be switched from
+     * remote to local voltage control without having to rescale its target voltage.
+     */
+    public boolean hasEquivalentLocalTargetV() {
+        return false;
+    }
+
     @Override
     public GeneratorControlType getGeneratorControlType() {
         return generatorControlType;

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfGeneratorImpl.java
@@ -258,6 +258,11 @@ public final class LfGeneratorImpl extends AbstractLfGenerator {
     }
 
     @Override
+    public boolean hasEquivalentLocalTargetV() {
+        return !Double.isNaN(generatorRef.get().getEquivalentLocalTargetV());
+    }
+
+    @Override
     public boolean switchToLocalVoltageControl() {
         super.switchToLocalVoltageControl();
         if (!Double.isNaN(generatorRef.get().getEquivalentLocalTargetV())) {

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -43,6 +43,8 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LfNetworkLoaderImpl.class);
 
+    private static final double MIN_SECONDARY_VOLTAGE_CONTROL_REACTIVE_RANGE_MVAR = 5.0;
+
     private static final double TARGET_V_EPSILON = 1e-2;
 
     private static final double TARGET_Q_EPSILON = 1e-2;
@@ -1395,10 +1397,16 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         }
     }
 
-    private static Set<GeneratorVoltageControl> findControlZoneGeneratorVoltageControl(Network network, LfNetworkParameters parameters,
-                                                                                       LfNetwork lfNetwork, ControlZone controlZone) {
-        Set<GeneratorVoltageControl> generatorVoltageControls = new LinkedHashSet<>();
+    private record ResolvedSecondaryVoltageControlUnit(ControlUnit controlUnit, boolean participate, GeneratorVoltageControl generatorVoltageControl) {
+    }
+
+    private static List<ResolvedSecondaryVoltageControlUnit> findControlZoneControlUnits(Network network, LfNetworkParameters parameters,
+                                                                                         LfNetwork lfNetwork, ControlZone controlZone) {
+        List<ResolvedSecondaryVoltageControlUnit> controlUnits = new ArrayList<>();
         Set<String> controlUnitsNotFound = new LinkedHashSet<>();
+        Set<String> unsupportedControlUnits = new LinkedHashSet<>();
+        Set<String> controlUnitsWithoutRegulatingTerminal = new LinkedHashSet<>();
+        Set<String> controlUnitsWithRegulatingTerminalOutsideLfNetwork = new LinkedHashSet<>();
         Set<String> controlledBusesOfNotFoundVoltageControls = new LinkedHashSet<>();
         for (ControlUnit controlUnit : controlZone.getControlUnits()) {
             Identifiable<?> identifiable = network.getIdentifiable(controlUnit.getId());
@@ -1407,16 +1415,18 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
                 continue;
             }
             if (identifiable.getType() != IdentifiableType.GENERATOR && !HvdcConverterStations.isVsc(identifiable)) {
-                throw new PowsyblException("Control unit '" + controlUnit.getId() + "' of zone '"
-                        + controlZone.getName() + "' is expected to be either a generator or a VSC converter station");
+                unsupportedControlUnits.add(controlUnit.getId());
+                continue;
             }
             Terminal regulatingTerminal = Networks.getEquipmentRegulatingTerminal(identifiable).orElse(null);
             if (regulatingTerminal == null) {
+                controlUnitsWithoutRegulatingTerminal.add(controlUnit.getId());
                 continue;
             }
             LfBus controlledBus = getLfBus(regulatingTerminal, lfNetwork, parameters.isBreakers());
             if (controlledBus == null) {
                 // might happen if controlled bus is not in same component that controller buses
+                controlUnitsWithRegulatingTerminalOutsideLfNetwork.add(controlUnit.getId());
                 continue;
             }
             if (!controlledBus.isGeneratorVoltageControlled()) {
@@ -1426,15 +1436,110 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
                 continue;
             }
             GeneratorVoltageControl generatorVoltageControl = controlledBus.getGeneratorVoltageControl().orElseThrow();
-            generatorVoltageControls.add(generatorVoltageControl);
+            // a remotely controlling unit has to be moved to local control (see createSecondaryVoltageControls), which
+            // is only accurate if it defines an equivalent local target voltage. A locally controlling one already has
+            // a target voltage for its own bus, so it does not need any.
+            boolean localControl = identifiable instanceof Injection<?> injection
+                    && getLfBus(injection.getTerminal(), lfNetwork, parameters.isBreakers()) == controlledBus;
+            controlUnits.add(new ResolvedSecondaryVoltageControlUnit(controlUnit,
+                    controlUnit.isParticipate() && canParticipateInSecondaryVoltageControl(identifiable, localControl),
+                    generatorVoltageControl));
         }
         LOGGER.debug("{} control units of control zone '{}' have been mapped to {} generator voltage controls (controlled buses: {}, " +
-                "controlled buses without voltage control: {}, control units not found: {})",
-                controlZone.getControlUnits().size(), controlZone.getName(), generatorVoltageControls.size(),
-                generatorVoltageControls.stream().map(VoltageControl::getControlledBus).map(LfElement::getId).toList(),
+                "controlled buses without voltage control: {}, control units not found: {}, unsupported control units: {}, " +
+                "control units without regulating terminal: {}, control units with regulating terminal outside LF network: {})",
+                controlZone.getControlUnits().size(), controlZone.getName(),
+                controlUnits.stream().map(ResolvedSecondaryVoltageControlUnit::generatorVoltageControl).distinct().count(),
+                controlUnits.stream().map(ResolvedSecondaryVoltageControlUnit::generatorVoltageControl).distinct()
+                        .map(VoltageControl::getControlledBus).map(LfElement::getId).toList(),
                 controlledBusesOfNotFoundVoltageControls,
-                controlUnitsNotFound);
-        return generatorVoltageControls;
+                controlUnitsNotFound,
+                unsupportedControlUnits,
+                controlUnitsWithoutRegulatingTerminal,
+                controlUnitsWithRegulatingTerminalOutsideLfNetwork);
+        return controlUnits;
+    }
+
+    private static boolean canParticipateInSecondaryVoltageControl(Identifiable<?> identifiable, boolean localControl) {
+        return hasSecondaryVoltageControlReactiveRange(identifiable)
+                && (localControl || hasValidSecondaryVoltageControlTarget(identifiable));
+    }
+
+    private static boolean hasValidSecondaryVoltageControlTarget(Identifiable<?> identifiable) {
+        if (identifiable instanceof Generator generator) {
+            return isValidSecondaryVoltageControlTarget(generator.getEquivalentLocalTargetV());
+        }
+        if (identifiable instanceof VscConverterStation vsc) {
+            return isValidSecondaryVoltageControlTarget(vsc.getVoltageSetpoint());
+        }
+        return false;
+    }
+
+    private static boolean isValidSecondaryVoltageControlTarget(double targetV) {
+        return !Double.isNaN(targetV) && !Double.isInfinite(targetV) && targetV > 0.0;
+    }
+
+    private static boolean hasSecondaryVoltageControlReactiveRange(Identifiable<?> identifiable) {
+        if (!(identifiable instanceof ReactiveLimitsHolder holder)) {
+            return true;
+        }
+        ReactiveLimits limits = holder.getReactiveLimits();
+        if (limits == null) {
+            return true;
+        }
+        double p = 0.0;
+        if (identifiable instanceof Generator generator) {
+            p = generator.getTargetP();
+        }
+        return limits.getMaxQ(p) - limits.getMinQ(p) >= MIN_SECONDARY_VOLTAGE_CONTROL_REACTIVE_RANGE_MVAR;
+    }
+
+    /**
+     * A generator voltage control of a secondary voltage control zone is moved from remote to local control (see
+     * {@link #createSecondaryVoltageControls}). When its generators do not all define an equivalent local target
+     * voltage, their target voltage would have to be rescaled to the controller bus nominal voltage, which is not
+     * accurate enough. In that case:
+     * <ul>
+     *     <li>a shared remote voltage control is discarded from the zone, as keeping it cannot work: a unique
+     *         controlled bus cannot help to align reactive power of the controller buses generators</li>
+     *     <li>otherwise remote control is kept</li>
+     * </ul>
+     */
+    private static List<GeneratorVoltageControl> toLocalVoltageControlsForSecondaryVoltageControl(GeneratorVoltageControl generatorVoltageControl,
+                                                                                                  ControlZone controlZone) {
+        if (generatorVoltageControl.isLocalControl()) {
+            return List.of(generatorVoltageControl);
+        }
+        List<AbstractLfGenerator> generators = generatorVoltageControl.getMergedControllerElements().stream()
+                .flatMap(controllerBus -> controllerBus.getGenerators().stream())
+                .filter(generator -> generator.getGeneratorControlType() == LfGenerator.GeneratorControlType.VOLTAGE)
+                .filter(AbstractLfGenerator.class::isInstance)
+                .map(AbstractLfGenerator.class::cast)
+                .toList();
+        List<String> generatorsWithoutEquivalentLocalTargetV = generators.stream()
+                .filter(generator -> !generator.hasEquivalentLocalTargetV())
+                .map(LfGenerator::getId)
+                .toList();
+        if (!generatorsWithoutEquivalentLocalTargetV.isEmpty()) {
+            if (generatorVoltageControl.getMergedControllerElements().size() > 1) {
+                LOGGER.warn("Shared remote voltage control of controlled bus {} cannot be moved to local control for secondary voltage control of zone '{}' " +
+                        "because generators {} have no equivalent local target voltage: control units are discarded from the zone " +
+                        "as a unique controlled bus cannot help to align their reactive power",
+                        generatorVoltageControl.getControlledBus().getId(), controlZone.getName(), generatorsWithoutEquivalentLocalTargetV);
+                return List.of();
+            }
+            LOGGER.warn("Remote voltage control of controlled bus {} cannot be moved to local control for secondary voltage control of zone '{}' " +
+                    "because generators {} have no equivalent local target voltage: remote control is kept",
+                    generatorVoltageControl.getControlledBus().getId(), controlZone.getName(), generatorsWithoutEquivalentLocalTargetV);
+            return List.of(generatorVoltageControl);
+        }
+        // switch each generator to its equivalent local target voltage, then split the control per controller bus
+        generators.forEach(AbstractLfGenerator::switchToLocalVoltageControl);
+        return generatorVoltageControl.toLocalVoltageControls(controllerBus -> controllerBus.getGenerators().stream()
+                .filter(generator -> generator.getGeneratorControlType() == LfGenerator.GeneratorControlType.VOLTAGE)
+                .mapToDouble(LfGenerator::getTargetV)
+                .findFirst()
+                .orElseThrow());
     }
 
     private static void createSecondaryVoltageControls(Network network, LfNetworkParameters parameters, LfNetwork lfNetwork) {
@@ -1464,26 +1569,60 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         LfBus lfPilotBus = lfNetwork.getBusById(pilotBus.getId());
         if (lfPilotBus != null) { // could be in another LfNetwork (another component)
             double targetV = pilotPoint.getTargetV() / lfPilotBus.getNominalV();
-            // filter missing control units and find corresponding primary voltage control, controlled bus
-            Set<GeneratorVoltageControl> generatorVoltageControls = findControlZoneGeneratorVoltageControl(network, parameters, lfNetwork, controlZone);
-            if (!generatorVoltageControls.isEmpty()) {
+            // filter missing/unsupported control units and find corresponding primary voltage controls
+            List<ResolvedSecondaryVoltageControlUnit> controlUnits = findControlZoneControlUnits(network, parameters, lfNetwork, controlZone);
+            if (!controlUnits.isEmpty()) {
                 // remove remote control for generators that belongs to a secondary voltage control zone because
                 // - it does not make sens to mix generator remote control plus pilot point remote control
                 // - it cannot work in case of generator shared voltage control (no way to align K of generators
                 //   for a given shared voltage control as a unique controlled bus cannot help to align reactive
                 //   power of generators)
-                Set<GeneratorVoltageControl> splitGeneratorVoltageControls = generatorVoltageControls.stream()
-                    .flatMap(vc -> vc.toLocalVoltageControls().stream())
-                    .collect(Collectors.toCollection(LinkedHashSet::new));
-
-                Set<String> participatingControlUnitIds = controlZone.getControlUnits().stream()
-                    .filter(ControlUnit::isParticipate)
-                    .map(ControlUnit::getId).collect(Collectors.toSet());
+                Map<GeneratorVoltageControl, List<GeneratorVoltageControl>> splitGeneratorVoltageControlsByOriginalControl = controlUnits.stream()
+                        .map(ResolvedSecondaryVoltageControlUnit::generatorVoltageControl)
+                        .distinct()
+                        .collect(Collectors.toMap(vc -> vc, vc -> toLocalVoltageControlsForSecondaryVoltageControl(vc, controlZone)));
+                List<LfSecondaryVoltageControl.ControlUnit> lfControlUnits = createLfSecondaryVoltageControlUnits(controlZone,
+                        controlUnits, splitGeneratorVoltageControlsByOriginalControl);
                 var lfSvc = new LfSecondaryVoltageControl(controlZone.getName(), lfPilotBus, targetV,
-                    participatingControlUnitIds, splitGeneratorVoltageControls);
-                lfNetwork.addSecondaryVoltageControl(lfSvc);
+                        lfControlUnits);
+                if (!lfControlUnits.isEmpty()) {
+                    lfNetwork.addSecondaryVoltageControl(lfSvc);
+                }
             }
         }
+    }
+
+    private static List<LfSecondaryVoltageControl.ControlUnit> createLfSecondaryVoltageControlUnits(
+            ControlZone controlZone,
+            List<ResolvedSecondaryVoltageControlUnit> controlUnits,
+            Map<GeneratorVoltageControl, List<GeneratorVoltageControl>> splitGeneratorVoltageControlsByOriginalControl) {
+        List<LfSecondaryVoltageControl.ControlUnit> lfControlUnits = new ArrayList<>(controlUnits.size());
+        Set<String> controlUnitsWithoutControllerBus = new LinkedHashSet<>();
+        for (ResolvedSecondaryVoltageControlUnit controlUnit : controlUnits) {
+            List<GeneratorVoltageControl> splitGeneratorVoltageControls = splitGeneratorVoltageControlsByOriginalControl.get(controlUnit.generatorVoltageControl());
+            GeneratorVoltageControl splitGeneratorVoltageControl = findSplitGeneratorVoltageControl(controlUnit.controlUnit().getId(),
+                    splitGeneratorVoltageControls).orElse(null);
+            if (splitGeneratorVoltageControl == null) {
+                controlUnitsWithoutControllerBus.add(controlUnit.controlUnit().getId());
+                continue;
+            }
+            lfControlUnits.add(new LfSecondaryVoltageControl.ControlUnit(controlUnit.controlUnit().getId(),
+                    controlUnit.participate(), splitGeneratorVoltageControl));
+        }
+        if (!controlUnitsWithoutControllerBus.isEmpty()) {
+            LOGGER.debug("Control units {} of control zone '{}' have been discarded because they are not controller buses of a generator voltage control",
+                    controlUnitsWithoutControllerBus, controlZone.getName());
+        }
+        return lfControlUnits;
+    }
+
+    private static Optional<GeneratorVoltageControl> findSplitGeneratorVoltageControl(String controlUnitId, List<GeneratorVoltageControl> generatorVoltageControls) {
+        return generatorVoltageControls.stream()
+                .filter(generatorVoltageControl -> generatorVoltageControl.getMergedControllerElements().stream()
+                        .flatMap(controllerBus -> controllerBus.getGenerators().stream())
+                        .anyMatch(generator -> generator.getId().equals(controlUnitId)
+                                && generator.getGeneratorControlType() == LfGenerator.GeneratorControlType.VOLTAGE))
+                .findFirst();
     }
 
     private static Optional<Bus> findPilotBus(Network network, boolean breaker, List<String> busbarSectionsOrBusesId) {

--- a/src/test/java/com/powsybl/openloadflow/LoadFlowWithCachingTest.java
+++ b/src/test/java/com/powsybl/openloadflow/LoadFlowWithCachingTest.java
@@ -887,11 +887,11 @@ class LoadFlowWithCachingTest {
         PilotPoint pilotPoint = z1.getPilotPoint();
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
-        assertEquals(4, result.getComponentResults().get(0).getIterationCount());
+        assertEquals(5, result.getComponentResults().get(0).getIterationCount());
         var b10 = network.getBusBreakerView().getBus("B10");
         assertVoltageEquals(12.7, b10);
-        assertReactivePowerEquals(-17.854, network.getGenerator("B6-G").getTerminal());
-        assertReactivePowerEquals(-17.798, network.getGenerator("B8-G").getTerminal());
+        assertReactivePowerEquals(-17.825, network.getGenerator("B6-G").getTerminal());
+        assertReactivePowerEquals(-17.827, network.getGenerator("B8-G").getTerminal());
 
         // update pilot point target voltage
         pilotPoint.setTargetV(12.5);
@@ -899,10 +899,10 @@ class LoadFlowWithCachingTest {
 
         result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
-        assertEquals(2, result.getComponentResults().get(0).getIterationCount());
+        assertEquals(3, result.getComponentResults().get(0).getIterationCount());
         assertVoltageEquals(12.5, b10);
-        assertReactivePowerEquals(-11.818, network.getGenerator("B6-G").getTerminal());
-        assertReactivePowerEquals(-11.840, network.getGenerator("B8-G").getTerminal());
+        assertReactivePowerEquals(-11.832, network.getGenerator("B6-G").getTerminal());
+        assertReactivePowerEquals(-11.832, network.getGenerator("B8-G").getTerminal());
 
         ControlUnit b6g = z1.getControlUnit("B6-G").orElseThrow();
         b6g.setParticipate(false);
@@ -914,8 +914,8 @@ class LoadFlowWithCachingTest {
         // There is no re-run of secondary voltage control outer loop: the pilot point has already reached its target
         // voltage and the remaining participating control unit cannot improve the SVC objective.
         assertVoltageEquals(12.5, b10);
-        assertReactivePowerEquals(-11.821, network.getGenerator("B6-G").getTerminal());
-        assertReactivePowerEquals(-11.844, network.getGenerator("B8-G").getTerminal());
+        assertReactivePowerEquals(-11.832, network.getGenerator("B6-G").getTerminal());
+        assertReactivePowerEquals(-11.832, network.getGenerator("B8-G").getTerminal());
 
         pilotPoint.setTargetV(12.7);
         assertNotNull(NetworkCache.AC_LF_INSTANCE.findEntry(network).orElseThrow().getValues()); // check cache has not been invalidated
@@ -923,7 +923,7 @@ class LoadFlowWithCachingTest {
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
         assertEquals(4, result.getComponentResults().get(0).getIterationCount());
         assertVoltageEquals(12.613, b10); // we cannot reach back to 12.7 Kv with only one control unit
-        assertReactivePowerEquals(-6.765, network.getGenerator("B6-G").getTerminal());
+        assertReactivePowerEquals(-6.771, network.getGenerator("B6-G").getTerminal());
         assertReactivePowerEquals(-24.0, network.getGenerator("B8-G").getTerminal());
 
         // get b6 generator back

--- a/src/test/java/com/powsybl/openloadflow/LoadFlowWithCachingTest.java
+++ b/src/test/java/com/powsybl/openloadflow/LoadFlowWithCachingTest.java
@@ -887,11 +887,11 @@ class LoadFlowWithCachingTest {
         PilotPoint pilotPoint = z1.getPilotPoint();
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
-        assertEquals(5, result.getComponentResults().get(0).getIterationCount());
+        assertEquals(4, result.getComponentResults().get(0).getIterationCount());
         var b10 = network.getBusBreakerView().getBus("B10");
         assertVoltageEquals(12.7, b10);
-        assertReactivePowerEquals(-17.826, network.getGenerator("B6-G").getTerminal());
-        assertReactivePowerEquals(-17.827, network.getGenerator("B8-G").getTerminal());
+        assertReactivePowerEquals(-17.854, network.getGenerator("B6-G").getTerminal());
+        assertReactivePowerEquals(-17.798, network.getGenerator("B8-G").getTerminal());
 
         // update pilot point target voltage
         pilotPoint.setTargetV(12.5);
@@ -899,10 +899,10 @@ class LoadFlowWithCachingTest {
 
         result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
-        assertEquals(3, result.getComponentResults().get(0).getIterationCount());
+        assertEquals(2, result.getComponentResults().get(0).getIterationCount());
         assertVoltageEquals(12.5, b10);
-        assertReactivePowerEquals(-11.832, network.getGenerator("B6-G").getTerminal());
-        assertReactivePowerEquals(-11.832, network.getGenerator("B8-G").getTerminal());
+        assertReactivePowerEquals(-11.818, network.getGenerator("B6-G").getTerminal());
+        assertReactivePowerEquals(-11.840, network.getGenerator("B8-G").getTerminal());
 
         ControlUnit b6g = z1.getControlUnit("B6-G").orElseThrow();
         b6g.setParticipate(false);
@@ -911,11 +911,11 @@ class LoadFlowWithCachingTest {
         result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
         assertEquals(1, result.getComponentResults().get(0).getIterationCount());
-        // there is no re-run of secondary voltage control outer loop, this is expected as pilot point has already reached
-        // its target voltage and remaining control unit is necessarily aligned.
+        // There is no re-run of secondary voltage control outer loop: the pilot point has already reached its target
+        // voltage and the remaining participating control unit cannot improve the SVC objective.
         assertVoltageEquals(12.5, b10);
-        assertReactivePowerEquals(-11.832, network.getGenerator("B6-G").getTerminal());
-        assertReactivePowerEquals(-11.832, network.getGenerator("B8-G").getTerminal());
+        assertReactivePowerEquals(-11.821, network.getGenerator("B6-G").getTerminal());
+        assertReactivePowerEquals(-11.844, network.getGenerator("B8-G").getTerminal());
 
         pilotPoint.setTargetV(12.7);
         assertNotNull(NetworkCache.AC_LF_INSTANCE.findEntry(network).orElseThrow().getValues()); // check cache has not been invalidated
@@ -923,7 +923,7 @@ class LoadFlowWithCachingTest {
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
         assertEquals(4, result.getComponentResults().get(0).getIterationCount());
         assertVoltageEquals(12.613, b10); // we cannot reach back to 12.7 Kv with only one control unit
-        assertReactivePowerEquals(-6.771, network.getGenerator("B6-G").getTerminal());
+        assertReactivePowerEquals(-6.765, network.getGenerator("B6-G").getTerminal());
         assertReactivePowerEquals(-24.0, network.getGenerator("B8-G").getTerminal());
 
         // get b6 generator back

--- a/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
@@ -142,7 +142,7 @@ class SecondaryVoltageControlTest {
         pilotPoint.setTargetV(13.5);
         result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
-        assertEquals(6, result.getComponentResults().get(0).getIterationCount());
+        assertEquals(8, result.getComponentResults().get(0).getIterationCount());
         assertVoltageEquals(13.5, b10);
         assertVoltageEquals(13.358, b6);
         assertVoltageEquals(25.621, b8);
@@ -184,13 +184,13 @@ class SecondaryVoltageControlTest {
 
         result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
-        assertEquals(8, result.getComponentResults().get(0).getIterationCount());
+        assertEquals(7, result.getComponentResults().get(0).getIterationCount());
 
-        assertVoltageEquals(11.736, b10); // 11.5 kV was not feasible
-        assertVoltageEquals(11.924, b6);
-        assertVoltageEquals(19.537, b8);
+        assertVoltageEquals(11.817, b10); // 11.5 kV was not feasible
+        assertVoltageEquals(11.986, b6);
+        assertVoltageEquals(19.8, b8);
         assertReactivePowerEquals(6, g6.getTerminal()); // [-6, 24] => qmin
-        assertReactivePowerEquals(6, g8.getTerminal()); // [-6, 200] => qmin
+        assertReactivePowerEquals(3.150, g8.getTerminal()); // [-6, 200], not saturated after clipped correction
     }
 
     void modifyNetworkToUnblockGeneratorFromLimit() {
@@ -203,13 +203,13 @@ class SecondaryVoltageControlTest {
                 .add()
                 .add();
 
-        // to put g6 and g8 at q min
+        // Start g6 and g8 close to qmin so the SVC correction first interacts with reactive limit switching.
         g6.setTargetV(11.8);
         g8.setTargetV(19.5);
     }
 
     @Test
-    void testUnblockGeneratorFromLimit() throws IOException {
+    void testReEnableHelpfulControllerBusesFromReactiveLimit() throws IOException {
         modifyNetworkToUnblockGeneratorFromLimit();
         // This scenario works if the slack distribution fails and an injection is added at the slack bus
         parametersExt.setPlausibleActivePowerLimit(5000); // Remove large generators from slack distribution
@@ -222,11 +222,12 @@ class SecondaryVoltageControlTest {
                 .withMessageTemplate("test")
                 .build();
 
-        // try to put g6 and g8 at qmax to see if they are correctly unblock from qmin
+        // SVC must be able to re-enable a controller bus disabled by reactive limits when the zone still has another
+        // available controller. With the clipped correction, the controllers finally reach the opposite reactive limit.
         loadFlowRunParameters.setReportNode(node);
         var result = loadFlowRunner.run(network, loadFlowRunParameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
-        assertEquals(14, result.getComponentResults().get(0).getIterationCount());
+        assertEquals(24, result.getComponentResults().get(0).getIterationCount());
 
         assertVoltageEquals(15, b10);
         assertVoltageEquals(14.604, b6);
@@ -249,29 +250,39 @@ class SecondaryVoltageControlTest {
                          Outer loop DistributedSlack
                          Outer loop SecondaryVoltageControl
                          + Outer loop ReactiveLimits
-                            + Outer loop iteration 3
-                               + 3 buses switched PV -> PQ (2 buses remain PV)
-                                  Switch bus 'VL3_0' PV -> PQ, q=-18.051176 < minQ=0
-                                  Switch bus 'VL6_0' PV -> PQ, q=25.327554 > maxQ=24
-                                  Switch bus 'VL8_0' PV -> PQ, q=209.071622 > maxQ=200
+                            + Outer loop iteration 2
+                               + 1 buses switched PV -> PQ (4 buses remain PV)
+                                  Switch bus 'VL6_0' PV -> PQ, q=59.989159 > maxQ=24
+                         Outer loop DistributedSlack
+                         Outer loop SecondaryVoltageControl
+                         + Outer loop ReactiveLimits
                             + Outer loop iteration 4
-                               + 1 buses switched PV -> PQ (1 buses remain PV)
-                                  Switch bus 'VL2_0' PV -> PQ, q=-46.582673 < minQ=-40
+                               + 2 buses switched PV -> PQ (3 buses remain PV)
+                                  Switch bus 'VL3_0' PV -> PQ, q=-0.477767 < minQ=0
+                                  Switch bus 'VL6_0' PV -> PQ, q=122.625173 > maxQ=24
                             + Outer loop iteration 5
                                + 1 buses switched PQ -> PV (0 buses blocked PQ due to the max number of switches)
-                                  Switch bus 'VL6_0' PQ -> PV, q=maxQ and v=14.604872kV > targetV=14.596348kV
-                         + Outer loop DistributedSlack
-                            + Outer loop iteration 6
-                               Failed to distribute slack bus active power mismatch, 3.011164 MW remains
+                                  Switch bus 'VL3_0' PQ -> PV, q=minQ and v=134.067233kV < targetV=136.35kV
+                         Outer loop DistributedSlack
                          Outer loop SecondaryVoltageControl
                          + Outer loop ReactiveLimits
                             + Outer loop iteration 8
-                               + 2 buses switched PV -> PQ (1 buses remain PV)
-                                  Switch bus 'VL6_0' PV -> PQ, q=24.012062 > maxQ=24
-                                  Switch bus 'VL8_0' PV -> PQ, q=200.112821 > maxQ=200
+                               + 2 buses switched PV -> PQ (3 buses remain PV)
+                                  Switch bus 'VL3_0' PV -> PQ, q=-8.506687 < minQ=0
+                                  Switch bus 'VL6_0' PV -> PQ, q=59.686055 > maxQ=24
                          + Outer loop DistributedSlack
                             + Outer loop iteration 9
-                               Failed to distribute slack bus active power mismatch, 3.016519 MW remains
+                               Failed to distribute slack bus active power mismatch, 1.087632 MW remains
+                         Outer loop SecondaryVoltageControl
+                         + Outer loop ReactiveLimits
+                            + Outer loop iteration 11
+                               + 3 buses switched PV -> PQ (1 buses remain PV)
+                                  Switch bus 'VL2_0' PV -> PQ, q=-48.226659 < minQ=-40
+                                  Switch bus 'VL6_0' PV -> PQ, q=25.896434 > maxQ=24
+                                  Switch bus 'VL8_0' PV -> PQ, q=200.819982 > maxQ=200
+                         + Outer loop DistributedSlack
+                            + Outer loop iteration 12
+                               Failed to distribute slack bus active power mismatch, 3.012286 MW remains
                          Outer loop SecondaryVoltageControl
                          AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
                 """;
@@ -280,10 +291,10 @@ class SecondaryVoltageControlTest {
     }
 
     @Test
-    void testSecurityAnalysisWithUnblockedGenerator() {
+    void testSecurityAnalysisWithReEnabledControllerBus() {
         modifyNetworkToUnblockGeneratorFromLimit();
 
-        // Pilot point is set to test unblocking of generators without them turning back PQ
+        // Pilot point is set to test SVC re-enabling controller buses without them turning back PQ
         network.getExtension(SecondaryVoltageControl.class)
                 .getControlZone("z1").orElseThrow().getPilotPoint().setTargetV(14.95);
 
@@ -301,22 +312,23 @@ class SecondaryVoltageControlTest {
     }
 
     @Test
-    void testCannotUnblockGeneratorFromLimit() throws IOException {
+    void testBlockedReactiveLimitsPqPvSwitchDoesNotPreventSvcReEnable() throws IOException {
         modifyNetworkToUnblockGeneratorFromLimit();
 
         parametersExt.setSecondaryVoltageControl(true);
-        parametersExt.setReactiveLimitsMaxPqPvSwitch(0); // Will block PQ->PV move
+        // Blocks PQ->PV moves in ReactiveLimits. SVC may still re-enable helpful controller buses before computing its
+        // correction, which is the behavior this test protects.
+        parametersExt.setReactiveLimitsMaxPqPvSwitch(0);
 
         ReportNode node = ReportNode.newRootReportNode()
                 .withResourceBundles(PowsyblOpenLoadFlowReportResourceBundle.BASE_NAME, PowsyblTestReportResourceBundle.TEST_BASE_NAME)
                 .withMessageTemplate("test")
                 .build();
 
-        // try to put g6 and g8 at qmax to see if they are correctly unblock from qmin
         loadFlowRunParameters.setReportNode(node);
         var result = loadFlowRunner.run(network, loadFlowRunParameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
-        assertEquals(11, result.getComponentResults().get(0).getIterationCount());
+        assertEquals(25, result.getComponentResults().get(0).getIterationCount());
 
         assertVoltageEquals(15, b10);
         assertVoltageEquals(14.604, b6);
@@ -337,25 +349,40 @@ class SecondaryVoltageControlTest {
                          Outer loop DistributedSlack
                          Outer loop SecondaryVoltageControl
                          + Outer loop ReactiveLimits
-                            + Outer loop iteration 3
-                               + 3 buses switched PV -> PQ (2 buses remain PV)
-                                  Switch bus 'VL3_0' PV -> PQ, q=-18.051176 < minQ=0
-                                  Switch bus 'VL6_0' PV -> PQ, q=25.327554 > maxQ=24
-                                  Switch bus 'VL8_0' PV -> PQ, q=209.071622 > maxQ=200
-                            + Outer loop iteration 4
-                               + 1 buses switched PV -> PQ (1 buses remain PV)
-                                  Switch bus 'VL2_0' PV -> PQ, q=-46.582673 < minQ=-40
-                            + Outer loop iteration 5
-                               + 0 buses switched PQ -> PV (1 buses blocked PQ due to the max number of switches)
-                                  Bus 'VL6_0' blocked PQ as it has reached its max number of PQ -> PV switch (1)
-                         + Outer loop DistributedSlack
-                            + Outer loop iteration 5
-                               Slack bus active power (3.013536 MW) distributed in 1 distribution iteration(s)
+                            + Outer loop iteration 2
+                               + 1 buses switched PV -> PQ (4 buses remain PV)
+                                  Switch bus 'VL6_0' PV -> PQ, q=59.989159 > maxQ=24
+                         Outer loop DistributedSlack
                          Outer loop SecondaryVoltageControl
                          + Outer loop ReactiveLimits
-                            + Outer loop iteration 6
+                            + Outer loop iteration 4
+                               + 2 buses switched PV -> PQ (3 buses remain PV)
+                                  Switch bus 'VL3_0' PV -> PQ, q=-0.477767 < minQ=0
+                                  Switch bus 'VL6_0' PV -> PQ, q=122.625173 > maxQ=24
+                            + Outer loop iteration 5
                                + 0 buses switched PQ -> PV (1 buses blocked PQ due to the max number of switches)
-                                  Bus 'VL6_0' blocked PQ as it has reached its max number of PQ -> PV switch (1)
+                                  Bus 'VL3_0' blocked PQ as it has reached its max number of PQ -> PV switch (1)
+                         Outer loop DistributedSlack
+                         Outer loop SecondaryVoltageControl
+                         + Outer loop ReactiveLimits
+                            + Outer loop iteration 7
+                               + 1 buses switched PV -> PQ (3 buses remain PV)
+                                  Switch bus 'VL6_0' PV -> PQ, q=59.183534 > maxQ=24
+                         + Outer loop DistributedSlack
+                            + Outer loop iteration 8
+                               Slack bus active power (1.087638 MW) distributed in 1 distribution iteration(s)
+                         Outer loop SecondaryVoltageControl
+                         + Outer loop ReactiveLimits
+                            + Outer loop iteration 11
+                               + 3 buses switched PV -> PQ (1 buses remain PV)
+                                  Switch bus 'VL2_0' PV -> PQ, q=-48.439612 < minQ=-40
+                                  Switch bus 'VL6_0' PV -> PQ, q=25.942836 > maxQ=24
+                                  Switch bus 'VL8_0' PV -> PQ, q=200.747667 > maxQ=200
+                         + Outer loop DistributedSlack
+                            + Outer loop iteration 12
+                               Slack bus active power (1.89492 MW) distributed in 1 distribution iteration(s)
+                         Outer loop SecondaryVoltageControl
+                         Outer loop ReactiveLimits
                          AC load flow completed successfully (solverStatus=CONVERGED, outerloopStatus=STABLE)
                 """;
 
@@ -384,7 +411,7 @@ class SecondaryVoltageControlTest {
         parametersExt.setSecondaryVoltageControl(true);
         var result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
-        assertEquals(8, result.getComponentResults().get(0).getIterationCount());
+        assertEquals(15, result.getComponentResults().get(0).getIterationCount());
         assertVoltageEquals(142, b4);
         assertVoltageEquals(14.5, b10);
     }
@@ -408,10 +435,12 @@ class SecondaryVoltageControlTest {
 
         var result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
-        assertEquals(8, result.getComponentResults().get(0).getIterationCount());
-        assertVoltageEquals(14.4, b10);
-        assertVoltageEquals(14.151, b6);
-        assertVoltageEquals(28.913, b8);
+        assertEquals(6, result.getComponentResults().get(0).getIterationCount());
+        // This non-local topology issue still converges, but the clipped SVC correction no longer reaches the pilot
+        // target in one run.
+        assertVoltageEquals(13.503, b10);
+        assertVoltageEquals(14.093, b6);
+        assertVoltageEquals(23.8, b8);
     }
 
     @Test
@@ -511,9 +540,9 @@ class SecondaryVoltageControlTest {
     }
 
     @Test
-    void testNotPlausibleTargetV() {
-        // g8 generator is very far from pilot point bus b12, there is no way for generators of the zone to control
-        // the pilot point voltage, this is detected by secondary voltage control outer loop which fails
+    void testFarPilotPointTargetVoltageChangeIsClipped() {
+        // g8 generator is very far from pilot point bus b12. The secondary voltage control target voltage change is
+        // clipped, so the load-flow converges instead of failing on an implausible target voltage.
         network.newExtension(SecondaryVoltageControlAdder.class)
                 .newControlZone()
                 .withName("z1")
@@ -525,7 +554,29 @@ class SecondaryVoltageControlTest {
         parametersExt.setSecondaryVoltageControl(true);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
+        assertEquals(8, result.getComponentResults().get(0).getIterationCount());
+    }
+
+    @Test
+    void testNotPlausibleTargetV() {
+        // Same far pilot point as above, but with a tighter plausibility range. The first clipped SVC correction would
+        // move B8 target voltage below 1.0 pu, so the SVC outer loop must reject it.
+        network.newExtension(SecondaryVoltageControlAdder.class)
+                .newControlZone()
+                .withName("z1")
+                .newPilotPoint().withTargetV(11.5).withBusbarSectionsOrBusesIds(List.of("B12")).add()
+                .newControlUnit().withId("B8-G").add()
+                .add()
+                .add();
+
+        parametersExt.setSecondaryVoltageControl(true)
+                .setMinPlausibleTargetVoltage(1.0);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.FAILED, result.getComponentResults().get(0).getStatus());
+        assertEquals("Outer loop 'SecondaryVoltageControl' failed: Cannot adjust secondary voltage control because some calculated controlled bus target voltages are not plausible",
+                result.getComponentResults().get(0).getStatusText());
     }
 
     @Test
@@ -555,13 +606,15 @@ class SecondaryVoltageControlTest {
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
-        assertEquals(9, result.getComponentResults().get(0).getIterationCount());
+        // Target corrections are clipped to 2 kV, so the remote-controlled generator case now needs several SVC
+        // corrections. The exact count is a regression sentinel for the current clipped path.
+        assertEquals(14, result.getComponentResults().get(0).getIterationCount());
 
         assertVoltageEquals(13, b10);
         assertVoltageEquals(12.682, b6);
-        assertVoltageEquals(25.311, b8);
-        assertReactivePowerEquals(82.910, g5.getTerminal());
-        assertReactivePowerEquals(-97, g8.getTerminal());
+        assertVoltageEquals(25.321, b8);
+        assertReactivePowerEquals(82.932, g5.getTerminal());
+        assertReactivePowerEquals(-97.003, g8.getTerminal());
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
@@ -411,7 +411,7 @@ class SecondaryVoltageControlTest {
         parametersExt.setSecondaryVoltageControl(true);
         var result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
-        assertEquals(15, result.getComponentResults().get(0).getIterationCount());
+        assertEquals(16, result.getComponentResults().get(0).getIterationCount());
         assertVoltageEquals(142, b4);
         assertVoltageEquals(14.5, b10);
     }

--- a/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.CompletionException;
 
 import static com.powsybl.openloadflow.util.LoadFlowAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -479,7 +478,7 @@ class SecondaryVoltageControlTest {
     }
 
     @Test
-    void testOptionalNoValueIssue() {
+    void testUnsupportedControlUnitIsDiscarded() {
         network.newExtension(SecondaryVoltageControlAdder.class)
                 .newControlZone()
                 .withName("z1")
@@ -489,14 +488,19 @@ class SecondaryVoltageControlTest {
                 .add()
                 .add();
 
-        parametersExt.setSecondaryVoltageControl(true);
-
-        CompletionException e = assertThrows(CompletionException.class, () -> loadFlowRunner.run(network, parameters));
-        assertEquals("Control unit 'B9-SH' of zone 'z1' is expected to be either a generator or a VSC converter station", e.getCause().getMessage());
+        LfNetworkParameters networkParameters = new LfNetworkParameters().setSecondaryVoltageControl(true);
+        List<LfNetwork> lfNetworks = LfNetwork.load(network, new LfNetworkLoaderImpl(), networkParameters);
+        LfNetwork lfNetwork = lfNetworks.get(0);
+        List<LfSecondaryVoltageControl> secondaryVoltageControls = lfNetwork.getSecondaryVoltageControls();
+        assertEquals(1, secondaryVoltageControls.size());
+        assertEquals(1, secondaryVoltageControls.get(0).getControlUnits().size());
+        assertEquals("B6-G", secondaryVoltageControls.get(0).getControlUnits().get(0).getId());
     }
 
     @Test
-    void testAnotherOptionalNoValueIssue() {
+    void testControlUnitWithoutVoltageControlIsDiscarded() {
+        // reactive range is so small that B6-G is discarded from voltage control by the generic voltage control
+        // checks, so it cannot be a control unit of the zone at all
         Generator g6 = network.getGenerator("B6-G");
         g6.newMinMaxReactiveLimits()
                 .setMinQ(100)
@@ -509,11 +513,92 @@ class SecondaryVoltageControlTest {
                 .newPilotPoint().withTargetV(13).withBusbarSectionsOrBusesIds(List.of("B10")).add()
                 .newControlUnit().withId("B6-G").add()
                 .newControlUnit().withId("B8-G").add()
+                .add()
                 .add();
 
         parametersExt.setSecondaryVoltageControl(true);
 
+        LfNetworkParameters networkParameters = new LfNetworkParameters().setSecondaryVoltageControl(true);
+        List<LfNetwork> lfNetworks = LfNetwork.load(network, new LfNetworkLoaderImpl(), networkParameters);
+        LfNetwork lfNetwork = lfNetworks.get(0);
+        List<LfSecondaryVoltageControl> secondaryVoltageControls = lfNetwork.getSecondaryVoltageControls();
+        assertEquals(1, secondaryVoltageControls.size());
+        assertEquals(1, secondaryVoltageControls.get(0).getControlUnits().size());
+        assertEquals("B8-G", secondaryVoltageControls.get(0).getControlUnits().get(0).getId());
+
         assertDoesNotThrow(() -> loadFlowRunner.run(network, parameters));
+    }
+
+    @Test
+    void testLocalControlUnitParticipatesWithoutEquivalentLocalTargetV() {
+        // B6-G and B8-G control the voltage of their own bus: they already have a target voltage for it, so they do
+        // not need any equivalent local target voltage to participate to the secondary voltage control
+        assertTrue(Double.isNaN(g6.getEquivalentLocalTargetV()));
+        assertTrue(Double.isNaN(g8.getEquivalentLocalTargetV()));
+
+        network.newExtension(SecondaryVoltageControlAdder.class)
+                .newControlZone()
+                .withName("z1")
+                .newPilotPoint().withTargetV(13).withBusbarSectionsOrBusesIds(List.of("B10")).add()
+                .newControlUnit().withId("B6-G").add()
+                .newControlUnit().withId("B8-G").add()
+                .add()
+                .add();
+
+        LfNetworkParameters networkParameters = new LfNetworkParameters().setSecondaryVoltageControl(true);
+        LfSecondaryVoltageControl svc = LfNetwork.load(network, new LfNetworkLoaderImpl(), networkParameters)
+                .get(0).getSecondaryVoltageControls().get(0);
+
+        assertEquals(2, svc.getControlUnits().size());
+        assertTrue(controlUnit(svc, "B6-G").isParticipate());
+        assertTrue(controlUnit(svc, "B8-G").isParticipate());
+    }
+
+    @Test
+    void testZoneWithoutAnyRemainingControlUnitIsNotCreated() {
+        // the only control unit of the zone is a shunt, which is not supported: no secondary voltage control is created
+        network.newExtension(SecondaryVoltageControlAdder.class)
+                .newControlZone()
+                .withName("z1")
+                .newPilotPoint().withTargetV(13).withBusbarSectionsOrBusesIds(List.of("B10")).add()
+                .newControlUnit().withId("B9-SH").add()
+                .add()
+                .add();
+
+        LfNetworkParameters networkParameters = new LfNetworkParameters().setSecondaryVoltageControl(true);
+        LfNetwork lfNetwork = LfNetwork.load(network, new LfNetworkLoaderImpl(), networkParameters).get(0);
+        assertTrue(lfNetwork.getSecondaryVoltageControls().isEmpty());
+    }
+
+    @Test
+    void testControlUnitWithTooSmallSecondaryVoltageControlReactiveRangeDoesNotParticipate() {
+        Generator g6 = network.getGenerator("B6-G");
+        g6.newMinMaxReactiveLimits()
+                .setMinQ(100)
+                .setMaxQ(102)
+                .add();
+
+        network.newExtension(SecondaryVoltageControlAdder.class)
+                .newControlZone()
+                .withName("z1")
+                .newPilotPoint().withTargetV(13).withBusbarSectionsOrBusesIds(List.of("B10")).add()
+                .newControlUnit().withId("B6-G").withParticipate(true).add()
+                .newControlUnit().withId("B8-G").withParticipate(true).add()
+                .add()
+                .add();
+
+        LfNetworkParameters networkParameters = new LfNetworkParameters().setSecondaryVoltageControl(true);
+        LfSecondaryVoltageControl secondaryVoltageControl = LfNetwork.load(network, new LfNetworkLoaderImpl(), networkParameters)
+                .get(0)
+                .getSecondaryVoltageControls()
+                .get(0);
+
+        assertEquals(2, secondaryVoltageControl.getControlUnits().size());
+        assertFalse(secondaryVoltageControl.getControlUnits().stream()
+                .filter(controlUnit -> controlUnit.getId().equals("B6-G"))
+                .findFirst()
+                .orElseThrow()
+                .isParticipate());
     }
 
     @Test
@@ -556,6 +641,33 @@ class SecondaryVoltageControlTest {
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
         assertEquals(8, result.getComponentResults().get(0).getIterationCount());
+    }
+
+    @Test
+    void testStalledZoneIsDetected() {
+        // Pilot point target is far out of reach of the only control unit of the zone: its controlled bus target
+        // voltage gets pinned to the plausible range bound, so the same ineffective correction would be requested at
+        // each outer loop iteration. The stalled zone has to be detected and ignored, otherwise the outer loop would
+        // run until max iteration is reached.
+        network.newExtension(SecondaryVoltageControlAdder.class)
+                .newControlZone()
+                .withName("z1")
+                .newPilotPoint().withTargetV(20).withBusbarSectionsOrBusesIds(List.of("B12")).add()
+                .newControlUnit().withId("B8-G").add()
+                .add()
+                .add();
+
+        parameters.setUseReactiveLimits(false);
+        parametersExt.setSecondaryVoltageControl(true)
+                .setMaxPlausibleTargetVoltage(1.1);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
+        // B8 target voltage is pinned to the 1.1 pu plausible bound and the pilot point target remains out of reach
+        assertVoltageEquals(22.0, b8);
+        // the zone has been given up quickly instead of being adjusted until max outer loop iteration
+        assertTrue(result.getComponentResults().get(0).getIterationCount() < 10,
+                "SVC outer loop should stop early on a stalled zone");
     }
 
     @Test
@@ -607,15 +719,87 @@ class SecondaryVoltageControlTest {
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
-        // Target corrections are clipped to 2 kV, so the remote-controlled generator case now needs several SVC
-        // corrections. The exact count is a regression sentinel for the current clipped path.
-        assertEquals(14, result.getComponentResults().get(0).getIterationCount());
+        // B5-G has no equivalent local target voltage: it does not participate to the secondary voltage control and
+        // its remote voltage control is kept (B6 stays at its 12.8 kV target), so only B8-G is adjusted.
+        assertEquals(6, result.getComponentResults().get(0).getIterationCount());
 
         assertVoltageEquals(13, b10);
-        assertVoltageEquals(12.682, b6);
-        assertVoltageEquals(25.321, b8);
-        assertReactivePowerEquals(82.932, g5.getTerminal());
-        assertReactivePowerEquals(-97.003, g8.getTerminal());
+        assertVoltageEquals(12.8, b6);
+        assertVoltageEquals(24.622, b8);
+        assertReactivePowerEquals(40.875, g5.getTerminal());
+        assertReactivePowerEquals(-76.332, g8.getTerminal());
+
+        LfNetworkParameters networkParameters = new LfNetworkParameters().setSecondaryVoltageControl(true);
+        LfSecondaryVoltageControl svc = LfNetwork.load(network, new LfNetworkLoaderImpl(), networkParameters)
+                .get(0).getSecondaryVoltageControls().get(0);
+        assertFalse(controlUnit(svc, "B5-G").isParticipate()); // remote control without equivalent local target voltage
+        assertTrue(controlUnit(svc, "B8-G").isParticipate());
+        assertEquals("VL6_0", controlledBusId(svc, "B5-G")); // remote voltage control has been kept
+    }
+
+    @Test
+    void testWithGeneratorRemoteVoltageAndPartialEquivalentLocalTargetV() {
+        // Two units of the same zone have a remote voltage control, but only one of them defines an equivalent local
+        // target voltage: only that one is shifted to local control, the other one keeps its remote control.
+        network.getGenerator("B6-G").remove();
+        network.getVoltageLevel("VL5").newGenerator()
+                .setId("B5-G") // remote voltage control of B6, without equivalent local target voltage
+                .setBus("B5")
+                .setTargetP(0)
+                .setMinP(-9999)
+                .setMaxP(9999)
+                .setTargetV(12.8)
+                .setVoltageRegulatorOn(true)
+                .setRegulatingTerminal(network.getLoad("B6-L").getTerminal())
+                .add();
+        var g7 = network.getVoltageLevel("VL7").newGenerator()
+                .setId("B7-G") // remote voltage control of B9, with an equivalent local target voltage
+                .setBus("B7")
+                .setTargetP(0)
+                .setMinP(-9999)
+                .setMaxP(9999)
+                .setTargetV(12.4)
+                .setVoltageRegulatorOn(true)
+                .setRegulatingTerminal(network.getLoad("B9-L").getTerminal())
+                .add();
+        g7.setTargetV(12.4, 14.2);
+
+        network.newExtension(SecondaryVoltageControlAdder.class)
+                .newControlZone()
+                .withName("z1")
+                .newPilotPoint().withTargetV(13).withBusbarSectionsOrBusesIds(List.of("B10")).add()
+                .newControlUnit().withId("B5-G").add()
+                .newControlUnit().withId("B7-G").add()
+                .add()
+                .add();
+
+        LfNetworkParameters networkParameters = new LfNetworkParameters().setSecondaryVoltageControl(true);
+        LfSecondaryVoltageControl secondaryVoltageControl = LfNetwork.load(network, new LfNetworkLoaderImpl(), networkParameters)
+                .get(0)
+                .getSecondaryVoltageControls()
+                .get(0);
+
+        assertEquals(2, secondaryVoltageControl.getControlUnits().size());
+        // B5-G keeps its remote voltage control of B6
+        assertEquals("VL6_0", controlledBusId(secondaryVoltageControl, "B5-G"));
+        // B7-G has been shifted to a local voltage control of its own bus, using its equivalent local target voltage
+        assertEquals("VL7_0", controlledBusId(secondaryVoltageControl, "B7-G"));
+        assertEquals(14.2 / 14.0, targetV(secondaryVoltageControl, "B7-G"), DELTA_V);
+    }
+
+    private static LfSecondaryVoltageControl.ControlUnit controlUnit(LfSecondaryVoltageControl svc, String id) {
+        return svc.getControlUnits().stream()
+                .filter(controlUnit -> controlUnit.getId().equals(id))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static String controlledBusId(LfSecondaryVoltageControl svc, String id) {
+        return controlUnit(svc, id).getGeneratorVoltageControl().getControlledBus().getId();
+    }
+
+    private static double targetV(LfSecondaryVoltageControl svc, String id) {
+        return controlUnit(svc, id).getGeneratorVoltageControl().getTargetValue();
     }
 
     @Test
@@ -723,13 +907,20 @@ class SecondaryVoltageControlTest {
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
-        assertEquals(7, result.getComponentResults().get(0).getIterationCount());
+        // B99-G1 and B99-G2 share a remote voltage control of B6 and have no equivalent local target voltage, so they
+        // are discarded from the zone: the pilot bus is left at its natural voltage instead of its 12.5 kV target.
+        assertEquals(4, result.getComponentResults().get(0).getIterationCount());
 
-        assertVoltageEquals(12.5, b10);
-        assertVoltageEquals(5.548, b991);
-        assertVoltageEquals(4.93, b992);
-        assertReactivePowerEquals(-8.976, g991.getTerminal());
-        assertReactivePowerEquals(4.919, g992.getTerminal());
+        assertVoltageEquals(12.589, b10);
+        assertVoltageEquals(5.516, b991);
+        assertVoltageEquals(5.66, b992);
+        assertReactivePowerEquals(-5.715, g991.getTerminal());
+        assertReactivePowerEquals(-5.143, g992.getTerminal());
+
+        // the zone has no control unit left, so it is not created at all
+        LfNetworkParameters networkParameters = new LfNetworkParameters().setSecondaryVoltageControl(true);
+        assertTrue(LfNetwork.load(network, new LfNetworkLoaderImpl(), networkParameters)
+                .get(0).getSecondaryVoltageControls().isEmpty());
 
         // With secondary voltage set to false, check that the remote control remains active
         parametersExt.setSecondaryVoltageControl(false);

--- a/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/SecondaryVoltageControlTest.java
@@ -559,9 +559,9 @@ class SecondaryVoltageControlTest {
     }
 
     @Test
-    void testNotPlausibleTargetV() {
+    void testTargetVClippedToPlausibleRange() {
         // Same far pilot point as above, but with a tighter plausibility range. The first clipped SVC correction would
-        // move B8 target voltage below 1.0 pu, so the SVC outer loop must reject it.
+        // move B8 target voltage below 1.0 pu, so the SVC outer loop clips it to the plausible bound.
         network.newExtension(SecondaryVoltageControlAdder.class)
                 .newControlZone()
                 .withName("z1")
@@ -570,13 +570,14 @@ class SecondaryVoltageControlTest {
                 .add()
                 .add();
 
+        parameters.setUseReactiveLimits(false);
         parametersExt.setSecondaryVoltageControl(true)
                 .setMinPlausibleTargetVoltage(1.0);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
-        assertEquals(LoadFlowResult.ComponentResult.Status.FAILED, result.getComponentResults().get(0).getStatus());
-        assertEquals("Outer loop 'SecondaryVoltageControl' failed: Cannot adjust secondary voltage control because some calculated controlled bus target voltages are not plausible",
-                result.getComponentResults().get(0).getStatusText());
+        assertEquals(LoadFlowResult.ComponentResult.Status.CONVERGED, result.getComponentResults().get(0).getStatus());
+        assertEquals(5, result.getComponentResults().get(0).getIterationCount());
+        assertVoltageEquals(20.0, b8);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Secondary voltage control sometimes fails for many reasons.


**What is the new behavior (if this is a feature change)?**
We improve secondary voltage control robustness:
 - by better validating secondary voltage control zones an discarding inconsistent data
 - robustifying outer loops:
   * adding clipping of DV
   * relaxing outer loop stability criteria


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
