### PR TITLE
Droop control for voltage source converters

### DIFF
--- a/docs/loadflow/loadflow.md
+++ b/docs/loadflow/loadflow.md
@@ -347,19 +347,17 @@ When the Fast-Decoupled algorithm is used, we recommend these values for some co
 AC DC flows computing in OpenLoadFLow is similar to AC flows computing, but with AC and DC equations in the same system.
 The unknowns are voltage magnitude and phase angle for each AC bus, voltage for each DC bus, and active/reactive
 power for each voltage source converter.<br>
-Concerning AC side, the equations are the same as in AC flows computing, concerning DC side, the equations induced by DC
-components are the followings:
+The equations remain the same as AC load load flow for the AC parts of the network flows computing. The DC parts are modelled with the following equations.
 
 ### DC bus
 
 At least one DC bus must be connected to the ground in each DC network, its potential is therefore set to 0.
 Therefore, symmetrical configuration are currently not supported.<br>
-For the others DC buses, each one introduces an equation of current balance: $\sum_{i} I_i = 0$ where $I_i$ are the currents going out of the DC bus.
-These terms are introduced by the DC components connected to the DC bus.
+Each other DC bus introduces an equation of current balance: $\sum_{i} I_i = 0$ where $I_i$ are the currents going out of the DC bus.
 
 ### DC Line
 
-Each DC line adds one term in both of its two connected DC buses current balance:
+Each DC line adds one term to each of its two connected DC buses current balance:
 
 $\sum_{i} I_i + \frac{V_1 - V_2}{R}= 0$ for dcBus1
 
@@ -389,28 +387,27 @@ In addition to the control modes `P_PCC`, `V_DC` and `P_PCC_DROOP`, the voltage 
 
 **Warning:** At the moment, the active and reactive power control and the AC voltage control are enforced at the converter AC terminal, not at its PCC terminal.
 
-We note $P_{AC}$ the power flow injected by AC network into the converter.
-So $P_{AC}>0$ if the power flows from AC to DC and $P_{AC}<0$ otherwise.
+Let $P_{AC}$ be the power flow injected by the AC network into the converter.
+This sign convention means that $P_{AC}>0$ if the power flows from AC to DC and $P_{AC}<0$ otherwise.
 
-If the converter is in `P_PCC` control mode, we add an equation to impose $P_{AC}$ :
+If the converter is in `P_PCC` control mode, then $P_{AC}$ is set to $P_{Ref}$ :
 
-$P_{AC}$ = $P_{Ref}$
+$$P_{AC} = P_{Ref}$$
 
-Else the converter is in `V_DC` control mode, and we add an equation to impose the voltage between its two DC buses :
+Else the converter is in `V_DC` control mode, so the voltage between its two DC buses is set :
 
-$V_{1} - V_{2} = V_{Ref}$
+$$V_{1} - V_{2} = V_{Ref}$$
 
-Similarly, if the converter controls reactive power, we add an equation to impose $Q_{AC}$ :
+Similarly, if the converter controls reactive power, $Q_{AC}$ is set to $Q_{Ref}$:
 
-$Q_{AC}$ = $Q_{Ref}$
+$$Q_{AC} = Q_{Ref}$$
 
-Else the converter controls the AC voltage, and we add an equation to impose $V_{AC}$:
+Else the converter controls the AC voltage, $V_{AC}$ is set to $V_{Ref}$:
 
-$V_{AC}= V_{Ref}$
+$$V_{AC} = V_{Ref}$$
 
-On the AC bus, the active and reactive power injected into the converter is added to its power balance.<br>
-On the DC side, we introduce the variable $I_{Conv}$ which is the current flowing in the converter from dcBus1 to dcBus2.
-It is added to the current balances of dcBus1 and dcBus2
+On the AC bus, the active and reactive power injected into the converter are added to its power balance.<br>
+On the DC side, the current $I_{Conv}$ flowing in the converter from dcBus1 to dcBus2 is added to the current balances of dcBus1 and dcBus2
 
 $\sum_{i} I_i + I_{Conv} = 0$ for dcBus1
 
@@ -427,7 +424,7 @@ with:
 - $P_{Loss}$ (non-negative) the converter losses depending on AC current. Its computation is detailed below.
 - $P_{DC} = I_{Conv}*(V_1-V_2)$ the power injected by the DC network into the converter.
 
-If the converter acts as rectifier, AC injects power in DC, thus $P_{DC}<0$ and $P_{AC}>0$, so we have :
+If the converter acts as a rectifier, AC injects power in DC, thus $P_{DC}<0$ and $P_{AC}>0$, so we have :
 
 $$
 -|P_{DC}| + P_{AC} = P_{Loss}
@@ -436,7 +433,7 @@ $$
 |P_{DC}| = |P_{AC}| - P_{Loss}
 $$
 
-And if the converter acts as inverter, DC injects power in AC, thus $P_{DC}>0$ and $P_{AC}<0$, so we have :
+And if the converter acts as an inverter, DC injects power in AC, thus $P_{DC}>0$ and $P_{AC}<0$, so we have :
 
 $$
 P_{DC} - |P_{AC}| = P_{Loss}
@@ -449,9 +446,9 @@ In both cases, there is a loss of power when passing through the converter.
 
 
 $P_{Loss}$ is defined as :<br>
-$
+$$
 P_{Loss} = IdleLoss + SwitchingLoss * |I_{Conv}| + ResistiveLoss * I_{Conv}^{2}
-$
+$$
 
 
 Idle loss, switching loss and resistive loss are loss factors that depend on the converter.
@@ -461,42 +458,27 @@ $$
 I_{Conv}*(V_1-V_2) + P_{AC} = IdleLoss + SwitchingLoss*|I_{Conv}| + ResistiveLoss*I_{Conv}^{2}
 $$
 
-#### Droop control
+#### Multi-segment Droop control
 
 In `P_PCC_DROOP` control mode, the converter does not hold a fixed power or a fixed DC voltage.
 Instead it follows a **droop law** that ties its active power to its DC voltage, so that the
 converter naturally shares in regulating the DC voltage of the network:
 
-$$P_{AC} = P_{Ref} + k \cdot (U_{dc} - V_{Ref})$$
+$$P_{AC} = P_{Ref} + k (U_{dc}) \cdot (U_{dc} - V_{Ref})$$
 
 with:
 - $P_{AC}$ the active power injected by the AC network into the converter,
 - $U_{dc} = V_1 - V_2$ the pole-to-pole DC voltage of the converter,
 - $(V_{Ref}, P_{Ref})$ the reference point read from the droop curve,
-- $k$ the droop coefficient.
+- $k (U_{dc})$ the droop coefficient.
 
-With $k = 0$ the law reduces to the `P_PCC` mode ($P_{AC} = P_{Ref}$). A converter in
-`P_PCC_DROOP` mode therefore exchanges exactly $P_{Ref}$ only when $U_{dc} = V_{Ref}$, and
-otherwise settles on the droop line.
-
-The droop curve passes through the converter setpoint $(targetVdc, targetP)$, which anchors its
+$k (U_{dc})$ is piecewise constant, which makes $U_{dc} \rightarrow P_{AC}$ piecewise linear.
+The droop curve passes through the converter setpoint $(targetVdc, targetP)$. This anchors its
 position in the $(U_{dc}, P)$ plane. A `P_PCC_DROOP` converter must therefore have a droop curve
 **and** both `targetP` and `targetVdc` defined.
 
-The droop constrains only the
-active power versus DC voltage.
-
-##### Multi-segment droop curve
-
-The droop coefficient may be piecewise-constant: the curve is split into DC-voltage bands
-$[U_{min}, U_{max}]$, each carrying its own coefficient $k$ (and hence its own reference point).
-The coefficient in effect is the one of the band that contains the converter's solved $U_{dc}$:
-
-- A single band gives a constant slope over the whole DC-voltage range.
-- If the solved $U_{dc}$ falls below the lowest band or above the highest band, the nearest
+Note that if the solved $U_{dc}$ falls below the lowest band or above the highest band, the nearest
   band's coefficient is used (clamping), so $k$ is always defined.
 
-The reported solution is **self-consistent**: for each converter, the applied $k$ is the one its
-curve assigns to that converter's own solved $U_{dc}$. If no consistent converged solution
-exists, the load flow reports non-convergence.
-
+The reported solution is self-consistent: for each converter, the applied $k$ is the one its
+curve assigns to that converter's own solved $U_{dc}$, provided that the load flow computation converges.

--- a/docs/loadflow/loadflow.md
+++ b/docs/loadflow/loadflow.md
@@ -347,7 +347,7 @@ When the Fast-Decoupled algorithm is used, we recommend these values for some co
 AC DC flows computing in OpenLoadFLow is similar to AC flows computing, but with AC and DC equations in the same system.
 The unknowns are voltage magnitude and phase angle for each AC bus, voltage for each DC bus, and active/reactive
 power for each voltage source converter.<br>
-The equations remain the same as AC load load flow for the AC parts of the network flows computing. The DC parts are modelled with the following equations.
+The equations remain the same as AC load flow for the AC parts of the network flows computing. The DC parts are modelled with the following equations.
 
 ### DC bus
 
@@ -371,13 +371,15 @@ Line commutated converters are not supported yet by Open Load Flow.
 ### Voltage source converters
 
 Voltage source converters are the links between AC and DC networks. They are linked to a single AC bus and two
-DC buses. Additional AC buses are not supported for load flow computations.<br>
+DC buses. Additional AC buses are not supported for load flow computations.
+
+#### Control modes
 
 A converter can control either the power it exchanges with the AC network (`P_PCC` control mode),
 the voltage between its two DC buses (`V_DC` control mode), or follow a DC-voltage droop law
 relating the two (`P_PCC_DROOP` control mode, detailed [below](#droop-control)).
 At least one of the voltage source converters of the DC network must control the DC voltage,
-i.e. be in `V_DC` **or** `P_PCC_DROOP` mode.
+i.e. be in `V_DC` or `P_PCC_DROOP` mode.
 
 In addition to the control modes `P_PCC`, `V_DC` and `P_PCC_DROOP`, the voltage source converter can be set in two modes :
 - Reactive power control mode, in which it imposes the reactive power received from AC to DC, which is 0 by default.
@@ -422,7 +424,7 @@ $$P_{DC} + P_{AC} = P_{Loss}$$
 with:
 - $P_{AC}$ the power injected by the AC network into the converter
 - $P_{Loss}$ (non-negative) the converter losses depending on AC current. Its computation is detailed below.
-- $P_{DC} = I_{Conv}*(V_1-V_2)$ the power injected by the DC network into the converter.
+- $P_{DC} = I_{Conv} \cdot (V_1-V_2)$ the power injected by the DC network into the converter.
 
 If the converter acts as a rectifier, AC injects power in DC, thus $P_{DC}<0$ and $P_{AC}>0$, so we have :
 
@@ -446,16 +448,18 @@ In both cases, there is a loss of power when passing through the converter.
 
 
 $P_{Loss}$ is defined as :<br>
+
 $$
-P_{Loss} = IdleLoss + SwitchingLoss * |I_{Conv}| + ResistiveLoss * I_{Conv}^{2}
+P_{Loss} = IdleLoss + SwitchingLoss \cdot |I_{Conv}| + ResistiveLoss \cdot I_{Conv}^{2}
 $$
 
 
 Idle loss, switching loss and resistive loss are loss factors that depend on the converter.
 
 Using the previous equation of power conservation between AC and DC, we have
+
 $$
-I_{Conv}*(V_1-V_2) + P_{AC} = IdleLoss + SwitchingLoss*|I_{Conv}| + ResistiveLoss*I_{Conv}^{2}
+I_{Conv} \cdot (V_1-V_2) + P_{AC} = IdleLoss + SwitchingLoss \cdot |I_{Conv}| + ResistiveLoss \cdot I_{Conv}^{2}
 $$
 
 #### Multi-segment Droop control
@@ -472,10 +476,10 @@ with:
 - $(V_{Ref}, P_{Ref})$ the reference point read from the droop curve,
 - $k (U_{dc})$ the droop coefficient.
 
-$k (U_{dc})$ is piecewise constant, which makes $U_{dc} \rightarrow P_{AC}$ piecewise linear.
+$U_{dc} \rightarrow k (U_{dc})$ is piecewise constant, which makes $U_{dc} \rightarrow P_{AC}$ piecewise linear.
 The droop curve passes through the converter setpoint $(targetVdc, targetP)$. This anchors its
 position in the $(U_{dc}, P)$ plane. A `P_PCC_DROOP` converter must therefore have a droop curve
-**and** both `targetP` and `targetVdc` defined.
+and both `targetP` and `targetVdc` defined.
 
 Note that if the solved $U_{dc}$ falls below the lowest band or above the highest band, the nearest
   band's coefficient is used (clamping), so $k$ is always defined.

--- a/docs/loadflow/loadflow.md
+++ b/docs/loadflow/loadflow.md
@@ -5,7 +5,7 @@
 Open Load Flow computes power flows from IIDM grid model in bus/view topology. From the view, a very simple network, composed
 of only buses and branches is created. In the graph vision, we rely on a $\Pi$ model for branches (lines, transformers, boundary lines, etc.):
 
-- $R$ and $X$ are respectively the real part (resistance) and the imaginary part (reactance) of the complex impedance ;  
+- $R$ and $X$ are respectively the real part (resistance) and the imaginary part (reactance) of the complex impedance ;
 - $G_1$ and $G_2$ are the real parts (conductance) on respectively side 1 and side 2 of the branch ;
 - $B_1$ and $B_2$ are the imaginary parts (susceptance) on respectively side 1 and side 2 of the branch ;
 - $A_1$ is the angle shifting on side 1, before the series impedance. For classical branches, the default value is zero ;
@@ -23,7 +23,7 @@ Open Load Flow also supports networks with HVDC lines (High Voltage Direct Curre
 
 ### DC detailed model
 
-Additionally, Open Load Flow supports AC-DC load flow formulation with detailed model of DC elements.  
+Additionally, Open Load Flow supports AC-DC load flow formulation with detailed model of DC elements.
 There is no limitation on the number of synchronous components and DC components in a single connected component, except if specific load flow parameters are used (see [acDcNetwork parameter documentation](./parameters.md#acdcnetwork))
 
 (ac-flow-computing)=
@@ -59,7 +59,7 @@ The resulting non-linear system of equations is solved by default via the Newton
 The underlying principle of the algorithm is the following:
 - It starts at a certain point $x_0 = (v_0, \phi_0)$ as an approximate solution to the system of equations;
 - Then, in an iterative fashion, it generates a series $x_1, x_2,.., x_k$ of better approximate solutions to the system of equations;
-- These iterates $x_k$ are found by solving a system of equations using local Jacobian matrix $J(v,\phi)$ at the previous point $x_{k-1}$; 
+- These iterates $x_k$ are found by solving a system of equations using local Jacobian matrix $J(v,\phi)$ at the previous point $x_{k-1}$;
 
 See **acSolverType** below for more details.
 
@@ -68,7 +68,7 @@ See **acSolverType** below for more details.
 PQ-bus and PV-bus are used to model local voltage magnitude or local reactive power controls. Other controls are supported in OpenLoadFLow:
 - Remote voltage control for generators, static var compensators and two and three windings transformers with ratio tap changer. Control shared over several controllers buses is supported ;
 - Remote reactive power control for generators ;
-- For static var compensator with a voltage set point, the support of a voltage per reactive power control, also called slope, that modifies a bit the local voltage at connection bus. We only support a local control. 
+- For static var compensator with a voltage set point, the support of a voltage per reactive power control, also called slope, that modifies a bit the local voltage at connection bus. We only support a local control.
 
 #### Remote voltage control
 
@@ -79,7 +79,7 @@ In our explanation, we have two buses. A generator or more is connected to bus $
     - $P_{b_2}^{in} = \sum_{j \in v(b_2)} p_{b_2,j}$.
     - $Q_{b_2}^{in} = \sum_{j \in v(b_2)} q_{b_2,j}$.
     - $v_{b_2} = V^{c}_{b_1}$.
-    
+
 #### Remote reactive power control
 
 A bus $b_1$ has, through a generator, a remote reactive power control on a branch $(i,j)$. This controller bus is treated as a P-bus: only active power balance is fixed for that bus. The reactive power flowing at side i on line $(i,j)$ is fixed by the control (it could be at side j too). To resume:
@@ -87,8 +87,8 @@ A bus $b_1$ has, through a generator, a remote reactive power control on a branc
     - $P_{b_1}^{in} = \sum_{j \in v(b_1)} p_{b_1,j}$.
 - At controlled branch $(i,j)$:
     - $q_{i,j} = Q^{c}_{b_1}$.
-    
-#### Local voltage control for a static var compensator with a slope 
+
+#### Local voltage control for a static var compensator with a slope
 
 We only support the simple case where:
 - Only one generator controlling voltage is connected to a bus. If other generators are present, they should have a local reactive power control ;
@@ -105,7 +105,7 @@ Where $s$ is the slope of the static var compensator.
 
 #### LCC converters
 
-LCC converters can be considered as fixed loads in the load flow. Indeed, on one side of the line is the rectifier station, and on the other side of the line is the inverter station. 
+LCC converters can be considered as fixed loads in the load flow. Indeed, on one side of the line is the rectifier station, and on the other side of the line is the inverter station.
 The active power flows from the rectifier station to the inverter station, is fixed, and equals to a target value $P$ (AC side). The active power flow at each station at AC side is given by:
   - $P_{rectifier}= P$
   - $P_{inverter}= (1 - LossFactor_{inverter}) * ((1 - LossFactor_{rectifier}) * (P - P_{LineLoss}))$
@@ -127,8 +127,8 @@ from the rectifier station to the inverter station is fixed and equals to a targ
   - $P_{rectifier}= P$
   - $P_{inverter}= (1 - LossFactor_{inverter}) * ((1 - LossFactor_{rectifier}) * (P - P_{LineLoss}))$
 
-- In **AC emulation** mode, the active power flow between both stations is given by: $P = P_0 + k~(\phi_1 - \phi_2)$ 
-with $\phi_1$ and $\phi_2$ being the voltage angles at the bus connection for each converter station, and $P_0$ and $k$ being fixed parameters for the HVDC line. 
+- In **AC emulation** mode, the active power flow between both stations is given by: $P = P_0 + k~(\phi_1 - \phi_2)$
+with $\phi_1$ and $\phi_2$ being the voltage angles at the bus connection for each converter station, and $P_0$ and $k$ being fixed parameters for the HVDC line.
 If $P$ is positive, the converter station 1 is controller, else it is converter station 2. For example, if station 1 is controller, the
 active power flow at each station is given by the formula below (HVDC line losses are described in the next paragraph):
   - $P_{controller} = P_0 + k~(\phi_1 - \phi_2)$
@@ -139,10 +139,10 @@ The HVDC line losses are described in a dedicated section further below.
 In both control modes (active power setpoint mode or in AC emulation mode), the target value $P$ is bounded by a maximum active power $P_{max}$ that can be either:
 - the `maxP` configured for the HVDC line,
 - or alternatively separate limit values for both directions using the [HVDC operator active power range IIDM extension](inv:powsyblcore:*:*:#hvdc-operator-active-power-range-extension)
-In AC Emulation, these boundaries are handled through the HVDC AC emulation limit outer loop. After solving the equation system, if the computed active power flow through the HVDC overpasses the limits, saturation is applied by the outer loop. 
+In AC Emulation, these boundaries are handled through the HVDC AC emulation limit outer loop. After solving the equation system, if the computed active power flow through the HVDC overpasses the limits, saturation is applied by the outer loop.
 Note that this HVDC AC emulation outer loop is only available in AC calculation, and normal DC calculation (not available in DC Woodbury Security analysis and DC Woodbury Sensitivity Analysis).
 
-The reactive power flow on each side of the line depends on whether voltage regulation of the converters is enabled. If the voltage regulation is enabled, then the VSC converter behaves like a generator regulating the voltage. 
+The reactive power flow on each side of the line depends on whether voltage regulation of the converters is enabled. If the voltage regulation is enabled, then the VSC converter behaves like a generator regulating the voltage.
 Otherwise, reactive power of the converter at AC side is given by its reactive power setpoint.
 
 #### HVDC line losses
@@ -181,9 +181,9 @@ Else:
 
 $$J_{i,i} = \sum_{j \in \delta(i)} \frac{1}{X_{i,j}}$$
 
-$$J_{i,j} = - \frac{1}{X_{i,j}}, \quad \forall j \in \delta(i)$$ 
+$$J_{i,j} = - \frac{1}{X_{i,j}}, \quad \forall j \in \delta(i)$$
 
-where $\delta(i)$ is the set of buses linked to bus $i$ in the network graph. All other entries of $J$ are zero. 
+where $\delta(i)$ is the set of buses linked to bus $i$ in the network graph. All other entries of $J$ are zero.
 
 The right-hand-side $b$ of the system satisfied:
 
@@ -242,7 +242,7 @@ $$
 Where:<br>
 * "Interchange" is the sum of the power flows at the boundaries of the area (load sign convention i.e. counted positive for imports).<br>
 * "Interchange Target" is the interchange target parameter of the area.<br>
-* "Slack Injection" is the active power mismatch of the slack bus(es) present in the area (see [Slack bus mismatch attribution](#slack-bus-mismatch-attribution)). 
+* "Slack Injection" is the active power mismatch of the slack bus(es) present in the area (see [Slack bus mismatch attribution](#slack-bus-mismatch-attribution)).
 
 The outer loop iterates until the absolute value of this mismatch is below the configured [parameter `areaInterchangePMaxMismatch`](parameters.md#areainterchangepmaxmismatch) for all areas.
 
@@ -296,7 +296,7 @@ It is computed like this:<br>
 $Factor = sign(Slack Bus Mismatch) * Area Total Mismatch + areaInterchangePMaxMismatch $<br>
 Then factors are normalized to have sum of factors equal to 1.
 
-The distribution is iterative (inside the same outer loop iteration). 
+The distribution is iterative (inside the same outer loop iteration).
 Each area distributes its share, if some areas cannot fully distribute it, they are excluded from this distribution and the remaining slack is distributed among other areas at next iteration.
 The distribution iterates until all the mismatch has been distributed and fails if all areas cannot distribute anymore but some mismatch remains.
 
@@ -345,14 +345,14 @@ When the Fast-Decoupled algorithm is used, we recommend these values for some co
 ## AC DC flows computing
 
 AC DC flows computing in OpenLoadFLow is similar to AC flows computing, but with AC and DC equations in the same system.
-The unknowns are voltage magnitude and phase angle for each AC bus, voltage for each DC bus, and active/reactive 
+The unknowns are voltage magnitude and phase angle for each AC bus, voltage for each DC bus, and active/reactive
 power for each voltage source converter.<br>
 Concerning AC side, the equations are the same as in AC flows computing, concerning DC side, the equations induced by DC
 components are the followings:
 
 ### DC bus
 
-At least one DC bus must be connected to the ground in each DC network, its potential is therefore set to 0. 
+At least one DC bus must be connected to the ground in each DC network, its potential is therefore set to 0.
 Therefore, symmetrical configuration are currently not supported.<br>
 For the others DC buses, each one introduces an equation of current balance: $\sum_{i} I_i = 0$ where $I_i$ are the currents going out of the DC bus.
 These terms are introduced by the DC components connected to the DC bus.
@@ -372,16 +372,16 @@ Line commutated converters are not supported yet by Open Load Flow.
 
 ### Voltage source converters
 
-Let consider a network that is composed of one AC network, and one DC network.
-The voltage source converter is the link between AC and DC networks, it is linked to **one** AC bus at one side, and two 
-DC buses at the other side.<br>
-Please note that converters with a second optional AC terminal are not supported by Open Load Flow.
+Voltage source converters are the links between AC and DC networks. They are linked to a single AC bus and two
+DC buses. Additional AC buses are not supported for load flow computations.<br>
 
-The converter can control either the power received by the AC network (`P_PCC` control mode) 
-or the voltage between its two DC buses (`V_DC` control mode).
-At least one of the voltage source converters of the DC network must be in `V_DC` mode. Otherwise, an exception will be thrown.
+A converter can control either the power it exchanges with the AC network (`P_PCC` control mode),
+the voltage between its two DC buses (`V_DC` control mode), or follow a DC-voltage droop law
+relating the two (`P_PCC_DROOP` control mode, detailed [below](#droop-control)).
+At least one of the voltage source converters of the DC network must control the DC voltage,
+i.e. be in `V_DC` **or** `P_PCC_DROOP` mode.
 
-In addition to the control modes `P_PCC` and `V_DC`, the voltage source converter can be set in two modes :
+In addition to the control modes `P_PCC`, `V_DC` and `P_PCC_DROOP`, the voltage source converter can be set in two modes :
 - Reactive power control mode, in which it imposes the reactive power received from AC to DC, which is 0 by default.
   In this case, the AC voltage is not fixed.
 - Voltage regulator control mode, in which it imposes the voltage at its AC Bus. In this case the reactive power is not
@@ -389,7 +389,7 @@ In addition to the control modes `P_PCC` and `V_DC`, the voltage source converte
 
 **Warning:** At the moment, the active and reactive power control and the AC voltage control are enforced at the converter AC terminal, not at its PCC terminal.
 
-We note $P_{AC}$ the power flow injected by AC network into the converter. 
+We note $P_{AC}$ the power flow injected by AC network into the converter.
 So $P_{AC}>0$ if the power flows from AC to DC and $P_{AC}<0$ otherwise.
 
 If the converter is in `P_PCC` control mode, we add an equation to impose $P_{AC}$ :
@@ -424,7 +424,7 @@ $$P_{DC} + P_{AC} = P_{Loss}$$
 
 with:
 - $P_{AC}$ the power injected by the AC network into the converter
-- $P_{Loss}>=0$ the converter losses depending on AC current. Its computation is detailed below.
+- $P_{Loss}$ (non-negative) the converter losses depending on AC current. Its computation is detailed below.
 - $P_{DC} = I_{Conv}*(V_1-V_2)$ the power injected by the DC network into the converter.
 
 If the converter acts as rectifier, AC injects power in DC, thus $P_{DC}<0$ and $P_{AC}>0$, so we have :
@@ -460,4 +460,43 @@ Using the previous equation of power conservation between AC and DC, we have
 $$
 I_{Conv}*(V_1-V_2) + P_{AC} = IdleLoss + SwitchingLoss*|I_{Conv}| + ResistiveLoss*I_{Conv}^{2}
 $$
+
+#### Droop control
+
+In `P_PCC_DROOP` control mode, the converter does not hold a fixed power or a fixed DC voltage.
+Instead it follows a **droop law** that ties its active power to its DC voltage, so that the
+converter naturally shares in regulating the DC voltage of the network:
+
+$$P_{AC} = P_{Ref} + k \cdot (U_{dc} - V_{Ref})$$
+
+with:
+- $P_{AC}$ the active power injected by the AC network into the converter,
+- $U_{dc} = V_1 - V_2$ the pole-to-pole DC voltage of the converter,
+- $(V_{Ref}, P_{Ref})$ the reference point read from the droop curve,
+- $k$ the droop coefficient.
+
+With $k = 0$ the law reduces to the `P_PCC` mode ($P_{AC} = P_{Ref}$). A converter in
+`P_PCC_DROOP` mode therefore exchanges exactly $P_{Ref}$ only when $U_{dc} = V_{Ref}$, and
+otherwise settles on the droop line.
+
+The droop curve passes through the converter setpoint $(targetVdc, targetP)$, which anchors its
+position in the $(U_{dc}, P)$ plane. A `P_PCC_DROOP` converter must therefore have a droop curve
+**and** both `targetP` and `targetVdc` defined.
+
+The droop constrains only the
+active power versus DC voltage.
+
+##### Multi-segment droop curve
+
+The droop coefficient may be piecewise-constant: the curve is split into DC-voltage bands
+$[U_{min}, U_{max}]$, each carrying its own coefficient $k$ (and hence its own reference point).
+The coefficient in effect is the one of the band that contains the converter's solved $U_{dc}$:
+
+- A single band gives a constant slope over the whole DC-voltage range.
+- If the solved $U_{dc}$ falls below the lowest band or above the highest band, the nearest
+  band's coefficient is used (clamping), so $k$ is always defined.
+
+The reported solution is **self-consistent**: for each converter, the applied $k$ is the one its
+curve assigns to that converter's own solved $U_{dc}$. If no consistent converged solution
+exists, the load flow reports non-convergence.
 

--- a/docs/loadflow/loadflow.md
+++ b/docs/loadflow/loadflow.md
@@ -468,18 +468,22 @@ In `P_PCC_DROOP` control mode, the converter does not hold a fixed power or a fi
 Instead it follows a **droop law** that ties its active power to its DC voltage, so that the
 converter naturally shares in regulating the DC voltage of the network:
 
-$$P_{AC} = P_{Ref} + k (U_{dc}) \cdot (U_{dc} - V_{Ref})$$
+$$U_{dc} = V_{Ref} + k (U_{dc}) \cdot (P_{AC} - P_{Ref})$$
 
 with:
 - $P_{AC}$ the active power injected by the AC network into the converter,
 - $U_{dc} = V_1 - V_2$ the pole-to-pole DC voltage of the converter,
 - $(V_{Ref}, P_{Ref})$ the reference point read from the droop curve,
-- $k (U_{dc})$ the droop coefficient.
+- $k (U_{dc})$ the droop coefficient, i.e. the slope of $U_{dc}$ versus $P_{AC}$.
 
 $U_{dc} \rightarrow k (U_{dc})$ is piecewise constant, which makes $U_{dc} \rightarrow P_{AC}$ piecewise linear.
 The droop curve passes through the converter setpoint $(targetVdc, targetP)$. This anchors its
 position in the $(U_{dc}, P)$ plane. A `P_PCC_DROOP` converter must therefore have a droop curve
-and both `targetP` and `targetVdc` defined.
+and both `targetP` and `targetVdc` defined. All $k$ coefficients across the curve's bands must share
+the same strict sign (all positive or all negative): a $k=0$ band leaves its reference power undefined
+when positioning it on the curve, and a sign change would break the band lookup — two different
+$P_{AC}$ values could then land on the same $U_{dc}$, so a solved $U_{dc}$ would no longer point back
+to a single band.
 
 Note that if the solved $U_{dc}$ falls below the lowest band or above the highest band, the nearest
   band's coefficient is used (clamping), so $k$ is always defined.

--- a/docs/loadflow/loadflow.md
+++ b/docs/loadflow/loadflow.md
@@ -462,21 +462,21 @@ $$
 I_{Conv} \cdot (V_1-V_2) + P_{AC} = IdleLoss + SwitchingLoss \cdot |I_{Conv}| + ResistiveLoss \cdot I_{Conv}^{2}
 $$
 
-#### Multi-segment Droop control
+#### Multi-segment droop control
 
 In `P_PCC_DROOP` control mode, the converter does not hold a fixed power or a fixed DC voltage.
 Instead it follows a **droop law** that ties its active power to its DC voltage, so that the
 converter naturally shares in regulating the DC voltage of the network:
 
-$$U_{dc} = V_{Ref} + k (U_{dc}) \cdot (P_{AC} - P_{Ref})$$
+$$U_{dc} = V_{Ref} + k(U_{dc}) \cdot (P_{AC} - P_{Ref})$$
 
 with:
 - $P_{AC}$ the active power injected by the AC network into the converter,
 - $U_{dc} = V_1 - V_2$ the pole-to-pole DC voltage of the converter,
 - $(V_{Ref}, P_{Ref})$ the reference point read from the droop curve,
-- $k (U_{dc})$ the droop coefficient, i.e. the slope of $U_{dc}$ versus $P_{AC}$.
+- $k(U_{dc})$ the droop coefficient, i.e. the slope of $U_{dc}$ versus $P_{AC}$.
 
-$U_{dc} \rightarrow k (U_{dc})$ is piecewise constant, which makes $U_{dc} \rightarrow P_{AC}$ piecewise linear.
+$U_{dc} \rightarrow k(U_{dc})$ is piecewise constant, which makes $U_{dc} \rightarrow P_{AC}$ piecewise linear.
 The droop curve passes through the converter setpoint $(targetVdc, targetP)$. This anchors its
 position in the $(U_{dc}, P)$ plane. A `P_PCC_DROOP` converter must therefore have a droop curve
 and both `targetP` and `targetVdc` defined. All $k$ coefficients across the curve's bands must share

--- a/docs/loadflow/loadflow.md
+++ b/docs/loadflow/loadflow.md
@@ -377,11 +377,11 @@ DC buses. Please note that converters with a second optional AC terminal are not
 
 A converter can control either the power it exchanges with the AC network (`P_PCC` control mode),
 the voltage between its two DC buses (`V_DC` control mode), or follow a DC-voltage droop law
-relating the two (`P_PCC_DROOP` control mode, detailed [below](#droop-control)).
+relating the two (`DC_DROOP` control mode, detailed [below](#droop-control)).
 At least one of the voltage source converters of the DC network must control the DC voltage,
-i.e. be in `V_DC` or `P_PCC_DROOP` mode.
+i.e. be in `V_DC` or `DC_DROOP` mode.
 
-In addition to the control modes `P_PCC`, `V_DC` and `P_PCC_DROOP`, the voltage source converter can be set in two modes :
+In addition to the control modes `P_PCC`, `V_DC` and `DC_DROOP`, the voltage source converter can be set in two modes :
 - Reactive power control mode, in which it imposes the reactive power received from AC to DC, which is 0 by default.
   In this case, the AC voltage is not fixed.
 - Voltage regulator control mode, in which it imposes the voltage at its AC Bus. In this case the reactive power is not
@@ -396,9 +396,11 @@ If the converter is in `P_PCC` control mode, then $P_{AC}$ is set to $P_{Ref}$ :
 
 $$P_{AC} = P_{Ref}$$
 
-Else the converter is in `V_DC` control mode, so the voltage between its two DC buses is set :
+If the converter is in `V_DC` control mode, so the voltage between its two DC buses is set :
 
 $$V_{1} - V_{2} = V_{Ref}$$
+
+If the converter is in `DC_DROOP` control mode, then a relation `V_DC = f(P_AC)` is set (see [below](#droop-control))
 
 Similarly, if the converter controls reactive power, $Q_{AC}$ is set to $Q_{Ref}$:
 
@@ -415,7 +417,7 @@ $\sum_{i} I_i + I_{Conv} = 0$ for dcBus1
 
 $\sum_{i} I_i - I_{Conv}= 0$ for dcBus2
 
-#### Power Equations
+#### Power and loss equations
 
 The last equation of converters ensures the conservation of power between AC and DC.
 
@@ -464,7 +466,7 @@ $$
 
 #### Multi-segment droop control
 
-In `P_PCC_DROOP` control mode, the converter does not hold a fixed power or a fixed DC voltage.
+In `DC_DROOP` control mode, the converter does not hold a fixed power or a fixed DC voltage.
 Instead it follows a **droop law** that ties its active power to its DC voltage, so that the
 converter naturally shares in regulating the DC voltage of the network:
 
@@ -478,7 +480,7 @@ with:
 
 $U_{dc} \rightarrow k(U_{dc})$ is piecewise constant, which makes $U_{dc} \rightarrow P_{AC}$ piecewise linear.
 The droop curve passes through the converter setpoint $(targetVdc, targetP)$. This anchors its
-position in the $(U_{dc}, P)$ plane. A `P_PCC_DROOP` converter must therefore have a droop curve
+position in the $(U_{dc}, P)$ plane. A `DC_DROOP` converter must therefore have a droop curve
 and both `targetP` and `targetVdc` defined. All $k$ coefficients across the curve's bands must share
 the same strict sign (all positive or all negative): a $k=0$ band leaves its reference power undefined
 when positioning it on the curve, and a sign change would break the band lookup — two different

--- a/docs/loadflow/loadflow.md
+++ b/docs/loadflow/loadflow.md
@@ -371,7 +371,7 @@ Line commutated converters are not supported yet by Open Load Flow.
 ### Voltage source converters
 
 Voltage source converters are the links between AC and DC networks. They are linked to a single AC bus and two
-DC buses. Additional AC buses are not supported for load flow computations.
+DC buses. Please note that converters with a second optional AC terminal are not supported by Open Load Flow.
 
 #### Control modes
 

--- a/src/main/java/com/powsybl/openloadflow/ac/AcTargetVector.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcTargetVector.java
@@ -150,7 +150,6 @@ public class AcTargetVector extends TargetVector<AcVariableType, AcEquationType>
                  DC_BUS_TARGET_I,
                  DC_BUS_GROUND,
                  AC_CONV_TARGET_P_DROOP:
-                // the droop term carries the full (state-dependent) RHS, so the static target is zero
                 targets[column] = 0;
                 break;
 

--- a/src/main/java/com/powsybl/openloadflow/ac/AcTargetVector.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcTargetVector.java
@@ -148,7 +148,9 @@ public class AcTargetVector extends TargetVector<AcVariableType, AcEquationType>
                  BUS_TARGET_IX_NEGATIVE,
                  BUS_TARGET_IY_NEGATIVE,
                  DC_BUS_TARGET_I,
-                 DC_BUS_GROUND:
+                 DC_BUS_GROUND,
+                 AC_CONV_TARGET_P_DROOP:
+                // the droop term carries the full (state-dependent) RHS, so the static target is zero
                 targets[column] = 0;
                 break;
 

--- a/src/main/java/com/powsybl/openloadflow/ac/AcTargetVector.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/AcTargetVector.java
@@ -149,7 +149,7 @@ public class AcTargetVector extends TargetVector<AcVariableType, AcEquationType>
                  BUS_TARGET_IY_NEGATIVE,
                  DC_BUS_TARGET_I,
                  DC_BUS_GROUND,
-                 AC_CONV_TARGET_P_DROOP:
+                 ACDC_CONV_DC_DROOP:
                 targets[column] = 0;
                 break;
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
@@ -1012,6 +1012,7 @@ public class AcEquationSystemCreator {
                         .addTerm(v1)
                         .addTerm(v2.minus());
             }
+            default -> throw new IllegalStateException("Unsupported converter control mode: " + converter.getControlMode());
         }
 
         // The converter add its power pAc in AC power balance

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
@@ -8,7 +8,6 @@
 package com.powsybl.openloadflow.ac.equations;
 
 import com.powsybl.commons.PowsyblException;
-import com.powsybl.iidm.network.AcDcConverter;
 import com.powsybl.iidm.network.TwoSides;
 import com.powsybl.openloadflow.ac.equations.dcnetwork.*;
 import com.powsybl.openloadflow.equations.*;
@@ -993,20 +992,26 @@ public class AcEquationSystemCreator {
         LfBus bus = converter.getBus1();
         LfDcBus dcBus1 = converter.getDcBus1();
         LfDcBus dcBus2 = converter.getDcBus2();
-        if (converter.getControlMode() == AcDcConverter.ControlMode.P_PCC) {
-            // if a converter is in PCC Mode, we add an equation to set Pac injected into the converter
-            equationSystem.createEquation(converter, AcEquationType.AC_CONV_TARGET_P_REF)
-                    .addTerm(equationSystem.getVariable(converter.getNum(), AcVariableType.CONV_P_AC)
-                            .createTerm());
-        } else {
-            // if a converter is in V Mode, we add an equation to set V = v1 - v2 the tension of the two dc buses connected to the converter
-            EquationTerm<AcVariableType, AcEquationType> v1 = equationSystem.getVariable(dcBus1.getNum(), AcVariableType.DC_BUS_V)
-                    .createTerm();
-            EquationTerm<AcVariableType, AcEquationType> v2 = equationSystem.getVariable(dcBus2.getNum(), AcVariableType.DC_BUS_V)
-                    .createTerm();
-            equationSystem.createEquation(converter, AcEquationType.DC_BUS_TARGET_V_REF)
-                    .addTerm(v1)
-                    .addTerm(v2.minus());
+        switch (converter.getControlMode()) {
+            case P_PCC ->
+                // in PCC mode, we add an equation to set Pac injected into the converter
+                equationSystem.createEquation(converter, AcEquationType.AC_CONV_TARGET_P_REF)
+                        .addTerm(equationSystem.getVariable(converter.getNum(), AcVariableType.CONV_P_AC)
+                                .createTerm());
+            case P_PCC_DROOP ->
+                // in droop mode, we add an equation enforcing P = refP + k*(U_dc - refVdc), coupling Pac and the DC voltage
+                equationSystem.createEquation(converter, AcEquationType.AC_CONV_TARGET_P_DROOP)
+                        .addTerm(new ConverterDroopEquationTerm(converter, dcBus1, dcBus2, equationSystem.getVariableSet()));
+            case V_DC -> {
+                // in V mode, we add an equation to set V = v1 - v2 the tension of the two dc buses connected to the converter
+                EquationTerm<AcVariableType, AcEquationType> v1 = equationSystem.getVariable(dcBus1.getNum(), AcVariableType.DC_BUS_V)
+                        .createTerm();
+                EquationTerm<AcVariableType, AcEquationType> v2 = equationSystem.getVariable(dcBus2.getNum(), AcVariableType.DC_BUS_V)
+                        .createTerm();
+                equationSystem.createEquation(converter, AcEquationType.DC_BUS_TARGET_V_REF)
+                        .addTerm(v1)
+                        .addTerm(v2.minus());
+            }
         }
 
         // The converter add its power pAc in AC power balance

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
@@ -999,7 +999,7 @@ public class AcEquationSystemCreator {
                         .addTerm(equationSystem.getVariable(converter.getNum(), AcVariableType.CONV_P_AC)
                                 .createTerm());
             case P_PCC_DROOP ->
-                // in droop mode, we add an equation enforcing P = refP + k*(U_dc - refVdc), coupling Pac and the DC voltage
+                // in droop mode, we add an equation enforcing U_dc = refVdc + k*(P - refP), coupling Pac and the DC voltage
                 equationSystem.createEquation(converter, AcEquationType.AC_CONV_TARGET_P_DROOP)
                         .addTerm(new ConverterDroopEquationTerm(converter, dcBus1, dcBus2, equationSystem.getVariableSet()));
             case V_DC -> {

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
@@ -1003,7 +1003,7 @@ public class AcEquationSystemCreator {
                 equationSystem.createEquation(converter, AcEquationType.AC_CONV_TARGET_P_DROOP)
                         .addTerm(new ConverterDroopEquationTerm(converter, dcBus1, dcBus2, equationSystem.getVariableSet()));
             case V_DC -> {
-                // in V mode, we add an equation to set V = v1 - v2 the tension of the two dc buses connected to the converter
+                // in V mode, we add an equation to set V = v1 - v2 the voltage between the two dc buses connected to the converter
                 EquationTerm<AcVariableType, AcEquationType> v1 = equationSystem.getVariable(dcBus1.getNum(), AcVariableType.DC_BUS_V)
                         .createTerm();
                 EquationTerm<AcVariableType, AcEquationType> v2 = equationSystem.getVariable(dcBus2.getNum(), AcVariableType.DC_BUS_V)

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemCreator.java
@@ -998,9 +998,9 @@ public class AcEquationSystemCreator {
                 equationSystem.createEquation(converter, AcEquationType.AC_CONV_TARGET_P_REF)
                         .addTerm(equationSystem.getVariable(converter.getNum(), AcVariableType.CONV_P_AC)
                                 .createTerm());
-            case P_PCC_DROOP ->
+            case DC_DROOP ->
                 // in droop mode, we add an equation enforcing U_dc = refVdc + k*(P - refP), coupling Pac and the DC voltage
-                equationSystem.createEquation(converter, AcEquationType.AC_CONV_TARGET_P_DROOP)
+                equationSystem.createEquation(converter, AcEquationType.ACDC_CONV_DC_DROOP)
                         .addTerm(new ConverterDroopEquationTerm(converter, dcBus1, dcBus2, equationSystem.getVariableSet()));
             case V_DC -> {
                 // in V mode, we add an equation to set V = v1 - v2 the voltage between the two dc buses connected to the converter

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationType.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationType.java
@@ -38,6 +38,7 @@ public enum AcEquationType implements Quantity {
     DC_BUS_TARGET_I("dc_bus_target_i", ElementType.DC_BUS), // dcBus current target
     DC_BUS_GROUND("dc_bus_ground", ElementType.DC_BUS), // magnitude control for grounded DC buses
     AC_CONV_TARGET_P_REF("bus_target_p_ref", ElementType.CONVERTER), // AC active power control
+    AC_CONV_TARGET_P_DROOP("bus_target_p_droop", ElementType.CONVERTER), // AC active power droop control (P = refP + k*(U_dc - refVdc))
     AC_CONV_TARGET_Q_REF("bus_target_q_ref", ElementType.CONVERTER), // AC reactive power control
     DC_BUS_TARGET_V_REF("dc_bus_target_v_ref", ElementType.CONVERTER); // DC magnitude control
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationType.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationType.java
@@ -38,7 +38,7 @@ public enum AcEquationType implements Quantity {
     DC_BUS_TARGET_I("dc_bus_target_i", ElementType.DC_BUS), // dcBus current target
     DC_BUS_GROUND("dc_bus_ground", ElementType.DC_BUS), // magnitude control for grounded DC buses
     AC_CONV_TARGET_P_REF("bus_target_p_ref", ElementType.CONVERTER), // AC active power control
-    AC_CONV_TARGET_P_DROOP("bus_target_p_droop", ElementType.CONVERTER), // AC active power droop control (P = refP + k*(U_dc - refVdc))
+    AC_CONV_TARGET_P_DROOP("bus_target_p_droop", ElementType.CONVERTER), // AC active power droop control (U_dc = refVdc + k*(P - refP))
     AC_CONV_TARGET_Q_REF("bus_target_q_ref", ElementType.CONVERTER), // AC reactive power control
     DC_BUS_TARGET_V_REF("dc_bus_target_v_ref", ElementType.CONVERTER); // DC magnitude control
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationType.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationType.java
@@ -38,7 +38,7 @@ public enum AcEquationType implements Quantity {
     DC_BUS_TARGET_I("dc_bus_target_i", ElementType.DC_BUS), // dcBus current target
     DC_BUS_GROUND("dc_bus_ground", ElementType.DC_BUS), // magnitude control for grounded DC buses
     AC_CONV_TARGET_P_REF("bus_target_p_ref", ElementType.CONVERTER), // AC active power control
-    AC_CONV_TARGET_P_DROOP("bus_target_p_droop", ElementType.CONVERTER), // AC active power droop control (U_dc = refVdc + k*(P - refP))
+    ACDC_CONV_DC_DROOP("acdc_conv_dc_droop", ElementType.CONVERTER), // AC active power droop control (U_dc = refVdc + k*(P - refP))
     AC_CONV_TARGET_Q_REF("bus_target_q_ref", ElementType.CONVERTER), // AC reactive power control
     DC_BUS_TARGET_V_REF("dc_bus_target_v_ref", ElementType.CONVERTER); // DC magnitude control
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/dcnetwork/AbstractConverterDcFlowEquation.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/dcnetwork/AbstractConverterDcFlowEquation.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 /**
  * @author Denis Bonnand {@literal <denis.bonnand at supergrid-institute.com>}
  */
-public abstract class AbstractConverterDcCurrentEquationTerm extends AbstractElementEquationTerm<LfVoltageSourceConverter, AcVariableType, AcEquationType> {
+public abstract class AbstractConverterDcFlowEquation extends AbstractElementEquationTerm<LfVoltageSourceConverter, AcVariableType, AcEquationType> {
 
     protected final Variable<AcVariableType> v1Var;
 
@@ -38,7 +38,7 @@ public abstract class AbstractConverterDcCurrentEquationTerm extends AbstractEle
 
     protected LfDcBus dcBus2;
 
-    protected AbstractConverterDcCurrentEquationTerm(LfVoltageSourceConverter converter, LfDcBus dcBus1, LfDcBus dcBus2, double nominalV, VariableSet<AcVariableType> variableSet) {
+    protected AbstractConverterDcFlowEquation(LfVoltageSourceConverter converter, LfDcBus dcBus1, LfDcBus dcBus2, double nominalV, VariableSet<AcVariableType> variableSet) {
         super(converter);
         Objects.requireNonNull(converter);
         Objects.requireNonNull(variableSet);

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/dcnetwork/ConverterDcCurrentEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/dcnetwork/ConverterDcCurrentEquationTerm.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 /**
  * @author Denis Bonnand {@literal <denis.bonnand at supergrid-institute.com>}
  */
-public class ConverterDcCurrentEquationTerm extends AbstractConverterDcCurrentEquationTerm {
+public class ConverterDcCurrentEquationTerm extends AbstractConverterDcFlowEquation {
 
     private final double idleLoss;
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/dcnetwork/ConverterDroopEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/dcnetwork/ConverterDroopEquationTerm.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, SuperGrid Institute (http://www.supergrid-institute.com)
+ * Copyright (c) 2026, SuperGrid Institute (http://www.supergrid-institute.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/dcnetwork/ConverterDroopEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/dcnetwork/ConverterDroopEquationTerm.java
@@ -41,21 +41,14 @@ public class ConverterDroopEquationTerm extends AbstractConverterDcCurrentEquati
     @Override
     public double der(Variable<AcVariableType> variable) {
         Objects.requireNonNull(variable);
-        // The residual is expressed in the dcNominalV base, but the state variables v1Var/v2Var are per unit of their
-        // own DC bus nominal voltage (see v1()/v2() in the parent). The Jacobian must therefore be taken with respect
-        // to the raw state variables, which introduces the chain-rule factor dcBusX.getNominalV() / dcNominalV that
-        // converts from the equation base to the state-variable base.
-        // This factor is defensive programming: in a well-formed DC network the nominal voltage is the same everywhere
-        // (dcBusX.getNominalV() == dcNominalV) and the factor reduces to 1. We keep it explicit so the Jacobian stays
-        // consistent with the residual should that assumption ever be relaxed.
+        // All DC buses of a DC component share the same nominal voltage (enforced at network loading), which is the
+        // DC voltage base. So v1()/v2() are already in the equation base and dU_dc/dv1 = 1, dU_dc/dv2 = -1.
         if (variable.equals(pAcVar)) {
             return 1;
         } else if (variable.equals(v1Var)) {
-            double k = element.getDroopReference(v1() - v2()).k();
-            return -k * (dcBus1.getNominalV() / dcNominalV);
+            return -element.getDroopReference(v1() - v2()).k();
         } else if (variable.equals(v2Var)) {
-            double k = element.getDroopReference(v1() - v2()).k();
-            return k * (dcBus2.getNominalV() / dcNominalV);
+            return element.getDroopReference(v1() - v2()).k();
         } else {
             throw new IllegalStateException("Unknown variable: " + variable);
         }

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/dcnetwork/ConverterDroopEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/dcnetwork/ConverterDroopEquationTerm.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2025, SuperGrid Institute (http://www.supergrid-institute.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.openloadflow.ac.equations.dcnetwork;
+
+import com.powsybl.openloadflow.ac.equations.AcVariableType;
+import com.powsybl.openloadflow.equations.Variable;
+import com.powsybl.openloadflow.equations.VariableSet;
+import com.powsybl.openloadflow.network.LfDcBus;
+import com.powsybl.openloadflow.network.LfVoltageSourceConverter;
+
+import java.util.Objects;
+
+/**
+ * Droop-control equation of an AC/DC voltage source converter in {@code P_PCC_DROOP} mode:
+ * {@code CONV_P_AC = refP + k*(U_dc - refVdc)}, i.e. the residual is {@code CONV_P_AC - refP - k*(U_dc - refVdc)}.
+ * The reference point {@code (k, refVdc, refP)} is that of the droop-curve band containing the solved DC voltage
+ * {@code U_dc = v1 - v2}, so it is refreshed at every evaluation; at convergence the coefficient is self-consistent
+ * with the band the solution lands in. All quantities are per unit.
+ *
+ * @author Landry Huet {@literal <landry.huet at supergrid-institute.com>}
+ */
+public class ConverterDroopEquationTerm extends AbstractConverterDcCurrentEquationTerm {
+
+    public ConverterDroopEquationTerm(LfVoltageSourceConverter converter, LfDcBus dcBus1, LfDcBus dcBus2, VariableSet<AcVariableType> variableSet) {
+        // pass the DC voltage base as nominalV so that v1() - v2() is U_dc in per unit of that base
+        super(converter, dcBus1, dcBus2, converter.getDcVoltageBase(), variableSet);
+    }
+
+    @Override
+    public double eval() {
+        double uDc = v1() - v2();
+        LfVoltageSourceConverter.DroopReference ref = element.getDroopReference(uDc);
+        return pAc() - ref.refP() - ref.k() * (uDc - ref.refVdc());
+    }
+
+    @Override
+    public double der(Variable<AcVariableType> variable) {
+        Objects.requireNonNull(variable);
+        // The residual is expressed in the dcNominalV base, but the state variables v1Var/v2Var are per unit of their
+        // own DC bus nominal voltage (see v1()/v2() in the parent). The Jacobian must therefore be taken with respect
+        // to the raw state variables, which introduces the chain-rule factor dcBusX.getNominalV() / dcNominalV that
+        // converts from the equation base to the state-variable base.
+        // This factor is defensive programming: in a well-formed DC network the nominal voltage is the same everywhere
+        // (dcBusX.getNominalV() == dcNominalV) and the factor reduces to 1. We keep it explicit so the Jacobian stays
+        // consistent with the residual should that assumption ever be relaxed.
+        if (variable.equals(pAcVar)) {
+            return 1;
+        } else if (variable.equals(v1Var)) {
+            double k = element.getDroopReference(v1() - v2()).k();
+            return -k * (dcBus1.getNominalV() / dcNominalV);
+        } else if (variable.equals(v2Var)) {
+            double k = element.getDroopReference(v1() - v2()).k();
+            return k * (dcBus2.getNominalV() / dcNominalV);
+        } else {
+            throw new IllegalStateException("Unknown variable: " + variable);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "conv_p_droop";
+    }
+}

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/dcnetwork/ConverterDroopEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/dcnetwork/ConverterDroopEquationTerm.java
@@ -17,7 +17,11 @@ import java.util.Objects;
 
 /**
  * Droop-control equation of an AC/DC voltage source converter in {@code P_PCC_DROOP} mode:
- * {@code CONV_P_AC = refP + k*(U_dc - refVdc)}, i.e. the residual is {@code CONV_P_AC - refP - k*(U_dc - refVdc)}.
+ * {@code U_dc = refVdc + k*(CONV_P_AC - refP)}, i.e. the residual is
+ * {@code a*(CONV_P_AC - refP) - b*(U_dc - refVdc)}, with {@code a = k} and {@code b = 1} kept as separate
+ * coefficients (rather than folded into a single {@code k}) so that later work enforcing active-power limits
+ * can override them to switch this same term to a pure {@code CONV_P_AC = refP} constraint ({@code a=1},
+ * {@code b=0}) or a pure {@code U_dc = refVdc} constraint ({@code a=0}, {@code b=1}).
  * The reference point {@code (k, refVdc, refP)} is that of the droop-curve band containing the solved DC voltage
  * {@code U_dc = v1 - v2}, so it is refreshed at every evaluation; at convergence the coefficient is self-consistent
  * with the band the solution lands in. All quantities are per unit.
@@ -35,7 +39,9 @@ public class ConverterDroopEquationTerm extends AbstractConverterDcCurrentEquati
     public double eval() {
         double uDc = v1() - v2();
         LfVoltageSourceConverter.DroopReference ref = element.getDroopReference(uDc);
-        return pAc() - ref.refP() - ref.k() * (uDc - ref.refVdc());
+        double a = ref.k();
+        double b = 1;
+        return a * (pAc() - ref.refP()) - b * (uDc - ref.refVdc());
     }
 
     @Override
@@ -43,12 +49,13 @@ public class ConverterDroopEquationTerm extends AbstractConverterDcCurrentEquati
         Objects.requireNonNull(variable);
         // All DC buses of a DC component share the same nominal voltage (enforced at network loading), which is the
         // DC voltage base. So v1()/v2() are already in the equation base and dU_dc/dv1 = 1, dU_dc/dv2 = -1.
+        double b = 1;
         if (variable.equals(pAcVar)) {
-            return 1;
-        } else if (variable.equals(v1Var)) {
-            return -element.getDroopReference(v1() - v2()).k();
-        } else if (variable.equals(v2Var)) {
             return element.getDroopReference(v1() - v2()).k();
+        } else if (variable.equals(v1Var)) {
+            return -b;
+        } else if (variable.equals(v2Var)) {
+            return b;
         } else {
             throw new IllegalStateException("Unknown variable: " + variable);
         }

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/dcnetwork/ConverterDroopEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/dcnetwork/ConverterDroopEquationTerm.java
@@ -16,7 +16,7 @@ import com.powsybl.openloadflow.network.LfVoltageSourceConverter;
 import java.util.Objects;
 
 /**
- * Droop-control equation of an AC/DC voltage source converter in {@code P_PCC_DROOP} mode:
+ * Droop-control equation of an AC/DC voltage source converter in {@code DC_DROOP} mode:
  * {@code U_dc = refVdc + k*(CONV_P_AC - refP)}, i.e. the residual is
  * {@code a*(CONV_P_AC - refP) - b*(U_dc - refVdc)}, with {@code a = k} and {@code b = 1} kept as separate
  * coefficients (rather than folded into a single {@code k}) so that later work enforcing active-power limits

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/dcnetwork/ConverterDroopEquationTerm.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/dcnetwork/ConverterDroopEquationTerm.java
@@ -7,12 +7,15 @@
  */
 package com.powsybl.openloadflow.ac.equations.dcnetwork;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.openloadflow.ac.equations.AcVariableType;
 import com.powsybl.openloadflow.equations.Variable;
 import com.powsybl.openloadflow.equations.VariableSet;
 import com.powsybl.openloadflow.network.LfDcBus;
 import com.powsybl.openloadflow.network.LfVoltageSourceConverter;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -28,17 +31,24 @@ import java.util.Objects;
  *
  * @author Landry Huet {@literal <landry.huet at supergrid-institute.com>}
  */
-public class ConverterDroopEquationTerm extends AbstractConverterDcCurrentEquationTerm {
+public class ConverterDroopEquationTerm extends AbstractConverterDcFlowEquation {
+
+    private List<LfVoltageSourceConverter.LfDroopReference> droopBands;
 
     public ConverterDroopEquationTerm(LfVoltageSourceConverter converter, LfDcBus dcBus1, LfDcBus dcBus2, VariableSet<AcVariableType> variableSet) {
         // pass the DC voltage base as nominalV so that v1() - v2() is U_dc in per unit of that base
         super(converter, dcBus1, dcBus2, converter.getDcVoltageBase(), variableSet);
+        droopBands = new ArrayList<>(converter.getDroopCurve());
+        if (droopBands.isEmpty()) {
+            throw new PowsyblException("Cannot create a ConverterDroopEquationTerm for AC/DC converter '" + converter.getId()
+                    + "' which is not in DC_DROOP control mode");
+        }
     }
 
     @Override
     public double eval() {
         double uDc = v1() - v2();
-        LfVoltageSourceConverter.DroopReference ref = element.getDroopReference(uDc);
+        LfVoltageSourceConverter.LfDroopReference ref = getDroopReference(uDc);
         double a = ref.k();
         double b = 1;
         return a * (pAc() - ref.refP()) - b * (uDc - ref.refVdc());
@@ -51,7 +61,7 @@ public class ConverterDroopEquationTerm extends AbstractConverterDcCurrentEquati
         // DC voltage base. So v1()/v2() are already in the equation base and dU_dc/dv1 = 1, dU_dc/dv2 = -1.
         double b = 1;
         if (variable.equals(pAcVar)) {
-            return element.getDroopReference(v1() - v2()).k();
+            return getDroopReference(v1() - v2()).k();
         } else if (variable.equals(v1Var)) {
             return -b;
         } else if (variable.equals(v2Var)) {
@@ -64,5 +74,17 @@ public class ConverterDroopEquationTerm extends AbstractConverterDcCurrentEquati
     @Override
     public String getName() {
         return "conv_p_droop";
+    }
+
+    private LfVoltageSourceConverter.LfDroopReference getDroopReference(double uDc) {
+        // Note that the list is supposed to be sorted by refVdc.
+        // Linear search is faster for small lists.
+        int idx = 0; // default if uDc below min voltage.
+        for (idx = 0; idx < droopBands.size() - 1; idx++) {
+            if (uDc < droopBands.get(idx + 1).refVdc()) {
+                break;
+            }
+        } // if uDc is beyond voltage of last segment, idx stays clamped to droopBands.size() - 1
+        return droopBands.get(idx);
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/LfAcDcConverter.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfAcDcConverter.java
@@ -63,7 +63,7 @@ public interface LfAcDcConverter extends LfElement {
     double getTargetVdc();
 
     /**
-     * @return the per-unit base used for the DC voltage of this converter (nominal voltage of the non-grounded DC bus, in kV).
+     * @return the per-unit base used for the DC voltage of this converter.
      */
     double getDcVoltageBase();
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfAcDcConverter.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfAcDcConverter.java
@@ -63,6 +63,11 @@ public interface LfAcDcConverter extends LfElement {
     double getTargetVdc();
 
     /**
+     * @return the per-unit base used for the DC voltage of this converter (nominal voltage of the non-grounded DC bus, in kV).
+     */
+    double getDcVoltageBase();
+
+    /**
      * The three loss factors of the converter
      *
      * @param idleLoss      losses independent of the DC current. In MW.

--- a/src/main/java/com/powsybl/openloadflow/network/LfVoltageSourceConverter.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfVoltageSourceConverter.java
@@ -39,11 +39,6 @@ public interface LfVoltageSourceConverter extends LfAcDcConverter {
     }
 
     /**
-     * @return the per-unit base used for the DC voltage of this converter (nominal voltage of the non-grounded DC bus, in kV).
-     */
-    double getDcVoltageBase();
-
-    /**
      * Look up the droop reference point for a given solved DC voltage. Only relevant when the converter is in
      * {@code P_PCC_DROOP} control mode.
      *

--- a/src/main/java/com/powsybl/openloadflow/network/LfVoltageSourceConverter.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfVoltageSourceConverter.java
@@ -27,4 +27,29 @@ public interface LfVoltageSourceConverter extends LfAcDcConverter {
      * @return the target AC voltage magnitude at the converter AC bus. In per unit.
      */
     double getTargetVac();
+
+    /**
+     * Reference point of the droop law {@code P = refP + k*(U_dc - refVdc)} for a solved DC voltage, all in per unit.
+     *
+     * @param k      the droop coefficient of the band containing the solved DC voltage.
+     * @param refVdc the reference DC voltage of that band (its lower bound).
+     * @param refP   the reference active power of that band (the anchored power at {@code refVdc}).
+     */
+    record DroopReference(double k, double refVdc, double refP) {
+    }
+
+    /**
+     * @return the per-unit base used for the DC voltage of this converter (nominal voltage of the non-grounded DC bus, in kV).
+     */
+    double getDcVoltageBase();
+
+    /**
+     * Look up the droop reference point for a given solved DC voltage. Only relevant when the converter is in
+     * {@code P_PCC_DROOP} control mode.
+     *
+     * @param uDc the solved pole-to-pole DC voltage, in per unit of {@link #getDcVoltageBase()}.
+     * @return the droop reference {@code (k, refVdc, refP)} of the band containing {@code uDc} (clamped to the
+     * nearest band outside the curve range), all in per unit.
+     */
+    DroopReference getDroopReference(double uDc);
 }

--- a/src/main/java/com/powsybl/openloadflow/network/LfVoltageSourceConverter.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfVoltageSourceConverter.java
@@ -7,6 +7,8 @@
  */
 package com.powsybl.openloadflow.network;
 
+import java.util.List;
+
 /**
  * @author Denis Bonnand {@literal <denis.bonnand at supergrid-institute.com>}
  */
@@ -35,16 +37,13 @@ public interface LfVoltageSourceConverter extends LfAcDcConverter {
      * @param refVdc the reference DC voltage of that band (its lower bound).
      * @param refP   the reference active power of that band (the anchored power at {@code refVdc}).
      */
-    record DroopReference(double k, double refVdc, double refP) {
+    record LfDroopReference(double k, double refVdc, double refP) {
     }
 
     /**
-     * Look up the droop reference point for a given solved DC voltage. Only relevant when the converter is in
-     * {@code DC_DROOP} control mode.
-     *
-     * @param uDc the solved pole-to-pole DC voltage, in per unit of {@link #getDcVoltageBase()}.
-     * @return the droop reference {@code (k, refVdc, refP)} of the band containing {@code uDc} (clamped to the
-     * nearest band outside the curve range), all in per unit.
+     * Get the droop curve as a sorted list of segments, each with its min voltage,
+     * reference active power and droop coefficient.
+     * @return Droop curve as sorted list.
      */
-    DroopReference getDroopReference(double uDc);
+    List<LfDroopReference> getDroopCurve();
 }

--- a/src/main/java/com/powsybl/openloadflow/network/LfVoltageSourceConverter.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfVoltageSourceConverter.java
@@ -40,7 +40,7 @@ public interface LfVoltageSourceConverter extends LfAcDcConverter {
 
     /**
      * Look up the droop reference point for a given solved DC voltage. Only relevant when the converter is in
-     * {@code P_PCC_DROOP} control mode.
+     * {@code DC_DROOP} control mode.
      *
      * @param uDc the solved pole-to-pole DC voltage, in per unit of {@link #getDcVoltageBase()}.
      * @return the droop reference {@code (k, refVdc, refP)} of the band containing {@code uDc} (clamped to the

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfAcDcConverter.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfAcDcConverter.java
@@ -35,6 +35,8 @@ public abstract class AbstractLfAcDcConverter extends AbstractElement implements
 
     protected double targetVdc; // in pu
 
+    protected final double vBase; // nominal voltage of the non-grounded DC bus, in kV; per-unit base of the DC voltage
+
     protected final AcDcConverter.ControlMode controlMode;
 
     protected final LfDcBus dcBus1;
@@ -52,7 +54,8 @@ public abstract class AbstractLfAcDcConverter extends AbstractElement implements
         this.lossFactors = new LossFactors(converter.getIdleLoss(), converter.getSwitchingLoss(), converter.getResistiveLoss());
         this.controlMode = converter.getControlMode();
         this.targetP = converter.getTargetP() / PerUnit.SB;
-        targetVdc = dcBus1.isGrounded() ? converter.getTargetVdc() / dcBus2.getNominalV() : converter.getTargetVdc() / dcBus1.getNominalV();
+        this.vBase = dcBus1.isGrounded() ? dcBus2.getNominalV() : dcBus1.getNominalV();
+        targetVdc = converter.getTargetVdc() / vBase;
         this.pAc = converter.getTerminal1().getP();
         this.qAc = converter.getTerminal1().getQ();
     }
@@ -105,6 +108,10 @@ public abstract class AbstractLfAcDcConverter extends AbstractElement implements
     @Override
     public double getTargetVdc() {
         return targetVdc;
+    }
+
+    public double getDcVoltageBase() {
+        return vBase;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfAcDcConverter.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfAcDcConverter.java
@@ -35,8 +35,6 @@ public abstract class AbstractLfAcDcConverter extends AbstractElement implements
 
     protected double targetVdc; // in pu
 
-    protected final double vBase; // nominal voltage of the non-grounded DC bus, in kV; per-unit base of the DC voltage
-
     protected final AcDcConverter.ControlMode controlMode;
 
     protected final LfDcBus dcBus1;
@@ -54,8 +52,7 @@ public abstract class AbstractLfAcDcConverter extends AbstractElement implements
         this.lossFactors = new LossFactors(converter.getIdleLoss(), converter.getSwitchingLoss(), converter.getResistiveLoss());
         this.controlMode = converter.getControlMode();
         this.targetP = converter.getTargetP() / PerUnit.SB;
-        this.vBase = dcBus1.isGrounded() ? dcBus2.getNominalV() : dcBus1.getNominalV();
-        targetVdc = converter.getTargetVdc() / vBase;
+        targetVdc = converter.getTargetVdc() / getDcVoltageBase();
         this.pAc = converter.getTerminal1().getP();
         this.qAc = converter.getTerminal1().getQ();
     }
@@ -112,7 +109,8 @@ public abstract class AbstractLfAcDcConverter extends AbstractElement implements
 
     @Override
     public double getDcVoltageBase() {
-        return vBase;
+        // Hypothesis: all buses in the DC voltage have the same nominal DC voltage.
+        return dcBus1.getNominalV();
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfAcDcConverter.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfAcDcConverter.java
@@ -111,6 +111,11 @@ public abstract class AbstractLfAcDcConverter extends AbstractElement implements
     }
 
     @Override
+    public double getDcVoltageBase() {
+        return vBase;
+    }
+
+    @Override
     public double getQac() {
         return qAc / PerUnit.SB;
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfAcDcConverter.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfAcDcConverter.java
@@ -110,10 +110,6 @@ public abstract class AbstractLfAcDcConverter extends AbstractElement implements
         return targetVdc;
     }
 
-    public double getDcVoltageBase() {
-        return vBase;
-    }
-
     @Override
     public double getQac() {
         return qAc / PerUnit.SB;

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -1365,16 +1365,18 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
                     throw new PowsyblException("DcSwitch " + s.getId() + " has non zero resistance: not handled yet in AC DC load flow (R = " + s.getR() + ")");
                 });
 
-        // Ensure at least one converter controls V_DC
+        // Ensure at least one converter controls the DC voltage. V_DC controls it directly; P_PCC_DROOP also counts
+        // as DC-voltage control since the droop law settles the DC voltage.
         boolean isVdcControlled = false;
         for (AcDcConverter<?> converter : loadingContext.acDcConverterSet) {
-            if (converter.getControlMode() == AcDcConverter.ControlMode.V_DC) {
+            AcDcConverter.ControlMode controlMode = converter.getControlMode();
+            if (controlMode == AcDcConverter.ControlMode.V_DC || controlMode == AcDcConverter.ControlMode.P_PCC_DROOP) {
                 isVdcControlled = true;
                 break;
             }
         }
         if (!isVdcControlled) {
-            throw new PowsyblException("At least one AC/DC converter control mode must be V_DC in each DC component, but DC component " + numDcc + " does not have any");
+            throw new PowsyblException("At least one AC/DC converter control mode must be V_DC or P_PCC_DROOP in each DC component, but DC component " + numDcc + " does not have any");
         }
 
         postProcessors.forEach(pp -> pp.onLfNetworkLoaded(network, lfNetwork));

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -1365,18 +1365,18 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
                     throw new PowsyblException("DcSwitch " + s.getId() + " has non zero resistance: not handled yet in AC DC load flow (R = " + s.getR() + ")");
                 });
 
-        // Ensure at least one converter controls the DC voltage. V_DC controls it directly; P_PCC_DROOP also counts
+        // Ensure at least one converter controls the DC voltage. V_DC controls it directly; DC_DROOP also counts
         // as DC-voltage control since the droop law settles the DC voltage.
         boolean isVdcControlled = false;
         for (AcDcConverter<?> converter : loadingContext.acDcConverterSet) {
             AcDcConverter.ControlMode controlMode = converter.getControlMode();
-            if (controlMode == AcDcConverter.ControlMode.V_DC || controlMode == AcDcConverter.ControlMode.P_PCC_DROOP) {
+            if (controlMode == AcDcConverter.ControlMode.V_DC || controlMode == AcDcConverter.ControlMode.DC_DROOP) {
                 isVdcControlled = true;
                 break;
             }
         }
         if (!isVdcControlled) {
-            throw new PowsyblException("At least one AC/DC converter control mode must be V_DC or P_PCC_DROOP in each DC component, but DC component " + numDcc + " does not have any");
+            throw new PowsyblException("At least one AC/DC converter control mode must be V_DC or DC_DROOP in each DC component, but DC component " + numDcc + " does not have any");
         }
 
         postProcessors.forEach(pp -> pp.onLfNetworkLoaded(network, lfNetwork));

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
@@ -147,7 +147,16 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
     }
 
     @Override
+    public double getDcVoltageBase() {
+        return vBase;
+    }
+
+    @Override
     public DroopReference getDroopReference(double uDc) {
+        if (droopBands.isEmpty()) {
+            throw new PowsyblException("getDroopReference called on AC/DC converter '" + getId()
+                    + "' which is not in P_PCC_DROOP control mode");
+        }
         DroopBand band = selectBand(uDc);
         return new DroopReference(band.kPu(), band.minVpu(), band.refPpu());
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.ToDoubleFunction;
 
 /**
  * @author Denis Bonnand {@literal <denis.bonnand at supergrid-institute.com>}
@@ -78,7 +79,7 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
 
         // Anchored active power (MW) at each band's lower voltage bound.
         double[] refP = new double[n];
-        int anchor = bandIndex(segments, targetVdc);
+        int anchor = clampedBandIndex(segments, targetVdc, DroopCurve.Segment::getMinV, DroopCurve.Segment::getMaxV);
         DroopCurve.Segment anchorSeg = segments.get(anchor);
         refP[anchor] = targetP - anchorSeg.getK() * (targetVdc - anchorSeg.getMinV());
         for (int i = anchor + 1; i < n; i++) {
@@ -102,18 +103,23 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
         return bands;
     }
 
-    // Index of the band containing v, clamped to the nearest band outside the curve range (mirrors DroopCurveImpl#getK).
-    private static int bandIndex(List<DroopCurve.Segment> segments, double v) {
-        if (v <= segments.getFirst().getMinV()) {
+    /**
+     * Index of the band containing {@code v} in an ordered list of {@code [minV, maxV)} ranges, clamped to the nearest
+     * band when {@code v} falls below the first or on/above the last (mirrors {@code DroopCurveImpl#getK}). Used both at
+     * build time over {@link DroopCurve.Segment} (kV) and at solve time over {@link DroopBand} (per unit), hence the
+     * min/max accessors rather than a fixed element type.
+     */
+    private static <T> int clampedBandIndex(List<T> bands, double v, ToDoubleFunction<T> minV, ToDoubleFunction<T> maxV) {
+        if (v <= minV.applyAsDouble(bands.getFirst())) {
             return 0;
         }
-        for (int i = 0; i < segments.size(); i++) {
-            DroopCurve.Segment seg = segments.get(i);
-            if (v >= seg.getMinV() && v < seg.getMaxV()) {
+        for (int i = 0; i < bands.size(); i++) {
+            T band = bands.get(i);
+            if (v >= minV.applyAsDouble(band) && v < maxV.applyAsDouble(band)) {
                 return i;
             }
         }
-        return segments.size() - 1;
+        return bands.size() - 1;
     }
 
     public static LfVoltageSourceConverterImpl create(VoltageSourceConverter acDcConverter, LfNetwork network, LfDcBus dcBus1, LfDcBus dcBus2, LfBus bus1, LfNetworkParameters parameters) {
@@ -157,22 +163,9 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
             throw new PowsyblException("getDroopReference called on AC/DC converter '" + getId()
                     + "' which is not in P_PCC_DROOP control mode");
         }
-        DroopBand band = selectBand(uDc);
+        // Band containing the solved DC voltage uDc (per unit), clamped to the nearest band outside the curve range.
+        DroopBand band = droopBands.get(clampedBandIndex(droopBands, uDc, DroopBand::minVpu, DroopBand::maxVpu));
         return new DroopReference(band.kPu(), band.minVpu(), band.refPpu());
-    }
-
-    // Band containing the solved DC voltage uDc (per unit), clamped to the nearest band outside the curve range.
-    private DroopBand selectBand(double uDc) {
-        DroopBand first = droopBands.getFirst();
-        if (uDc <= first.minVpu()) {
-            return first;
-        }
-        for (DroopBand band : droopBands) {
-            if (uDc >= band.minVpu() && uDc < band.maxVpu()) {
-                return band;
-            }
-        }
-        return droopBands.getLast();
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
@@ -7,10 +7,16 @@
  */
 package com.powsybl.openloadflow.network.impl;
 
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.AcDcConverter;
+import com.powsybl.iidm.network.DroopCurve;
 import com.powsybl.iidm.network.VoltageSourceConverter;
 import com.powsybl.openloadflow.network.*;
 import com.powsybl.openloadflow.util.PerUnit;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -26,6 +32,12 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
 
     protected double targetVac; // In pu
 
+    // Droop curve bands (only populated in P_PCC_DROOP control mode), sorted by DC voltage, all values in per unit.
+    private final List<DroopBand> droopBands;
+
+    private record DroopBand(double kPu, double minVpu, double maxVpu, double refPpu) {
+    }
+
     public LfVoltageSourceConverterImpl(VoltageSourceConverter converter, LfNetwork network, LfDcBus dcBus1, LfDcBus dcBus2, LfBus bus1,
                                         LfNetworkParameters parameters) {
         super(converter, network, dcBus1, dcBus2, bus1);
@@ -37,6 +49,71 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
         } else {
             this.targetQ = converter.getReactivePowerSetpoint() / PerUnit.SB;
         }
+        this.droopBands = getControlMode() == AcDcConverter.ControlMode.P_PCC_DROOP
+                ? buildDroopBands(converter, getDcVoltageBase())
+                : List.of();
+    }
+
+    /**
+     * Precompute the per-band droop reference points in per unit. The droop curve gives, per DC-voltage band, a
+     * coefficient {@code k}; the piecewise-linear power {@code P(U_dc)} is anchored at {@code (targetVdc, targetP)}
+     * and made continuous by integrating {@code k} across bands. For each band we store {@code refP},
+     * the anchored power at the band's lower voltage bound {@code refVdc = minV}.
+     */
+    private static List<DroopBand> buildDroopBands(VoltageSourceConverter converter, double vBase) {
+        DroopCurve curve = converter.getDroopCurve();
+        List<DroopCurve.Segment> segments = new ArrayList<>(curve.getSegments());
+        if (segments.isEmpty()) {
+            throw new PowsyblException("AC/DC converter '" + converter.getId()
+                    + "' in P_PCC_DROOP control mode must have a droop curve");
+        }
+        double targetVdc = converter.getTargetVdc();
+        double targetP = converter.getTargetP();
+        if (Double.isNaN(targetVdc) || Double.isNaN(targetP)) {
+            throw new PowsyblException("AC/DC converter '" + converter.getId()
+                    + "' in P_PCC_DROOP control mode must have targetP and targetVdc defined");
+        }
+        segments.sort(Comparator.comparingDouble(DroopCurve.Segment::getMinV));
+        int n = segments.size();
+
+        // Anchored active power (MW) at each band's lower voltage bound.
+        double[] refP = new double[n];
+        int anchor = bandIndex(segments, targetVdc);
+        DroopCurve.Segment anchorSeg = segments.get(anchor);
+        refP[anchor] = targetP - anchorSeg.getK() * (targetVdc - anchorSeg.getMinV());
+        for (int i = anchor + 1; i < n; i++) {
+            DroopCurve.Segment prev = segments.get(i - 1);
+            refP[i] = refP[i - 1] + prev.getK() * (prev.getMaxV() - prev.getMinV());
+        }
+        for (int i = anchor - 1; i >= 0; i--) {
+            DroopCurve.Segment seg = segments.get(i);
+            refP[i] = refP[i + 1] - seg.getK() * (seg.getMaxV() - seg.getMinV());
+        }
+
+        List<DroopBand> bands = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            DroopCurve.Segment seg = segments.get(i);
+            // k is in MW/kV: k_pu = k * vBase / SB so that P_pu = k_pu * (U_dc_pu - refVdc_pu).
+            bands.add(new DroopBand(seg.getK() * vBase / PerUnit.SB,
+                    seg.getMinV() / vBase,
+                    seg.getMaxV() / vBase,
+                    refP[i] / PerUnit.SB));
+        }
+        return bands;
+    }
+
+    // Index of the band containing v, clamped to the nearest band outside the curve range (mirrors DroopCurveImpl#getK).
+    private static int bandIndex(List<DroopCurve.Segment> segments, double v) {
+        if (v <= segments.getFirst().getMinV()) {
+            return 0;
+        }
+        for (int i = 0; i < segments.size(); i++) {
+            DroopCurve.Segment seg = segments.get(i);
+            if (v >= seg.getMinV() && v < seg.getMaxV()) {
+                return i;
+            }
+        }
+        return segments.size() - 1;
     }
 
     public static LfVoltageSourceConverterImpl create(VoltageSourceConverter acDcConverter, LfNetwork network, LfDcBus dcBus1, LfDcBus dcBus2, LfBus bus1, LfNetworkParameters parameters) {
@@ -67,6 +144,26 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
     @Override
     public double getTargetVac() {
         return targetVac;
+    }
+
+    @Override
+    public DroopReference getDroopReference(double uDc) {
+        DroopBand band = selectBand(uDc);
+        return new DroopReference(band.kPu(), band.minVpu(), band.refPpu());
+    }
+
+    // Band containing the solved DC voltage uDc (per unit), clamped to the nearest band outside the curve range.
+    private DroopBand selectBand(double uDc) {
+        DroopBand first = droopBands.getFirst();
+        if (uDc <= first.minVpu()) {
+            return first;
+        }
+        for (DroopBand band : droopBands) {
+            if (uDc >= band.minVpu() && uDc < band.maxVpu()) {
+                return band;
+            }
+        }
+        return droopBands.getLast();
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
@@ -68,6 +68,12 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
             throw new PowsyblException("AC/DC converter '" + converter.getId()
                     + "' in P_PCC_DROOP control mode must have a droop curve");
         }
+        // An all-zero droop curve is flat: the power no longer depends on the DC voltage, which makes it equivalent
+        // to P_PCC control and unable to settle the DC voltage. Reject it rather than silently degrade to P_PCC.
+        if (segments.stream().allMatch(segment -> segment.getK() == 0)) {
+            throw new PowsyblException("AC/DC converter '" + converter.getId()
+                    + "' in P_PCC_DROOP control mode must have a droop curve with at least one non-zero coefficient");
+        }
         double targetVdc = converter.getTargetVdc();
         double targetP = converter.getTargetP();
         if (Double.isNaN(targetVdc) || Double.isNaN(targetP)) {
@@ -150,11 +156,6 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
     @Override
     public double getTargetVac() {
         return targetVac;
-    }
-
-    @Override
-    public double getDcVoltageBase() {
-        return vBase;
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
@@ -91,9 +91,7 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
         // Convert everything to per unit first, then anchor and integrate refP in that same per-unit system:
         // the equation actually solved (see ConverterDroopEquationTerm) is
         // U_dc_pu = refVdc_pu + k_pu * (P_pu - refP_pu). k is in kV/MW (the slope of U_dc versus P), so
-        // k_pu = dU_dc_pu/dP_pu = (dU_dc/vBase) / (dP/SB) = k * SB / vBase. Integrating refP in raw units
-        // first and converting to per unit afterwards would not be equivalent, since a per-unit slope isn't
-        // simply the raw slope carried over unchanged.
+        // k_pu = dU_dc_pu/dP_pu = (dU_dc/vBase) / (dP/SB) = k * SB / vBase.
         double[] kPu = new double[n];
         double[] minVpu = new double[n];
         double[] maxVpu = new double[n];

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
@@ -57,9 +57,11 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
 
     /**
      * Precompute the per-band droop reference points in per unit. The droop curve gives, per DC-voltage band, a
-     * coefficient {@code k}; the piecewise-linear power {@code P(U_dc)} is anchored at {@code (targetVdc, targetP)}
-     * and made continuous by integrating {@code k} across bands. For each band we store {@code refP},
-     * the anchored power at the band's lower voltage bound {@code refVdc = minV}.
+     * coefficient {@code k} that is the slope of {@code U_dc} versus {@code P}
+     * (see {@link com.powsybl.openloadflow.ac.equations.dcnetwork.ConverterDroopEquationTerm}).
+     * The piecewise-linear curve is anchored at {@code (targetVdc, targetP)} and {@code refP} is propagated from
+     * band to band so the curve stays continuous at each band boundary. For each band we store {@code refP}, the
+     * anchored power at the band's lower voltage bound {@code refVdc = minV}.
      */
     private static List<DroopBand> buildDroopBands(VoltageSourceConverter converter, double vBase) {
         DroopCurve curve = converter.getDroopCurve();
@@ -68,11 +70,14 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
             throw new PowsyblException("AC/DC converter '" + converter.getId()
                     + "' in P_PCC_DROOP control mode must have a droop curve");
         }
-        // An all-zero droop curve is flat: the power no longer depends on the DC voltage, which makes it equivalent
-        // to P_PCC control and unable to settle the DC voltage. Reject it rather than silently degrade to P_PCC.
-        if (segments.stream().allMatch(segment -> segment.getK() == 0)) {
+        // All coefficients must share the same strict sign: a k=0 band leaves its reference power undefined
+        // (division by zero below), and a sign change would break the band lookup, since two different P values
+        // could then land on the same U_dc.
+        boolean allPositive = segments.stream().allMatch(segment -> segment.getK() > 0);
+        boolean allNegative = segments.stream().allMatch(segment -> segment.getK() < 0);
+        if (!allPositive && !allNegative) {
             throw new PowsyblException("AC/DC converter '" + converter.getId()
-                    + "' in P_PCC_DROOP control mode must have a droop curve with at least one non-zero coefficient");
+                    + "' in P_PCC_DROOP control mode must have a droop curve with all coefficients of the same strict sign (all positive or all negative)");
         }
         double targetVdc = converter.getTargetVdc();
         double targetP = converter.getTargetP();
@@ -83,28 +88,38 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
         segments.sort(Comparator.comparingDouble(DroopCurve.Segment::getMinV));
         int n = segments.size();
 
-        // Anchored active power (MW) at each band's lower voltage bound.
-        double[] refP = new double[n];
+        // Convert everything to per unit first, then anchor and integrate refP in that same per-unit system:
+        // the equation actually solved (see ConverterDroopEquationTerm) is
+        // U_dc_pu = refVdc_pu + k_pu * (P_pu - refP_pu). k is in kV/MW (the slope of U_dc versus P), so
+        // k_pu = dU_dc_pu/dP_pu = (dU_dc/vBase) / (dP/SB) = k * SB / vBase. Integrating refP in raw units
+        // first and converting to per unit afterwards would not be equivalent, since a per-unit slope isn't
+        // simply the raw slope carried over unchanged.
+        double[] kPu = new double[n];
+        double[] minVpu = new double[n];
+        double[] maxVpu = new double[n];
+        for (int i = 0; i < n; i++) {
+            DroopCurve.Segment seg = segments.get(i);
+            kPu[i] = seg.getK() * PerUnit.SB / vBase;
+            minVpu[i] = seg.getMinV() / vBase;
+            maxVpu[i] = seg.getMaxV() / vBase;
+        }
+        double targetVdcPu = targetVdc / vBase;
+        double targetPpu = targetP / PerUnit.SB;
+
+        // Anchored active power (per unit) at each band's lower voltage bound.
+        double[] refPpu = new double[n];
         int anchor = clampedBandIndex(segments, targetVdc, DroopCurve.Segment::getMinV, DroopCurve.Segment::getMaxV);
-        DroopCurve.Segment anchorSeg = segments.get(anchor);
-        refP[anchor] = targetP - anchorSeg.getK() * (targetVdc - anchorSeg.getMinV());
+        refPpu[anchor] = targetPpu - (targetVdcPu - minVpu[anchor]) / kPu[anchor];
         for (int i = anchor + 1; i < n; i++) {
-            DroopCurve.Segment prev = segments.get(i - 1);
-            refP[i] = refP[i - 1] + prev.getK() * (prev.getMaxV() - prev.getMinV());
+            refPpu[i] = refPpu[i - 1] + (maxVpu[i - 1] - minVpu[i - 1]) / kPu[i - 1];
         }
         for (int i = anchor - 1; i >= 0; i--) {
-            DroopCurve.Segment seg = segments.get(i);
-            refP[i] = refP[i + 1] - seg.getK() * (seg.getMaxV() - seg.getMinV());
+            refPpu[i] = refPpu[i + 1] - (maxVpu[i] - minVpu[i]) / kPu[i];
         }
 
         List<DroopBand> bands = new ArrayList<>(n);
         for (int i = 0; i < n; i++) {
-            DroopCurve.Segment seg = segments.get(i);
-            // k is in MW/kV: k_pu = k * vBase / SB so that P_pu = k_pu * (U_dc_pu - refVdc_pu).
-            bands.add(new DroopBand(seg.getK() * vBase / PerUnit.SB,
-                    seg.getMinV() / vBase,
-                    seg.getMaxV() / vBase,
-                    refP[i] / PerUnit.SB));
+            bands.add(new DroopBand(kPu[i], minVpu[i], maxVpu[i], refPpu[i]));
         }
         return bands;
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.ToDoubleFunction;
 
 /**
  * @author Denis Bonnand {@literal <denis.bonnand at supergrid-institute.com>}
@@ -34,10 +33,7 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
     protected double targetVac; // In pu
 
     // Droop curve bands (only populated in DC_DROOP control mode), sorted by DC voltage, all values in per unit.
-    private final List<DroopBand> droopBands;
-
-    private record DroopBand(double kPu, double minVpu, double maxVpu, double refPpu) {
-    }
+    private final List<LfDroopReference> droopBands;
 
     public LfVoltageSourceConverterImpl(VoltageSourceConverter converter, LfNetwork network, LfDcBus dcBus1, LfDcBus dcBus2, LfBus bus1,
                                         LfNetworkParameters parameters) {
@@ -63,22 +59,15 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
      * band to band so the curve stays continuous at each band boundary. For each band we store {@code refP}, the
      * anchored power at the band's lower voltage bound {@code refVdc = minV}.
      */
-    private static List<DroopBand> buildDroopBands(VoltageSourceConverter converter, double vBase) {
+    private static List<LfDroopReference> buildDroopBands(VoltageSourceConverter converter, double vBase) {
         DroopCurve curve = converter.getDroopCurve();
         List<DroopCurve.Segment> segments = new ArrayList<>(curve.getSegments());
         if (segments.isEmpty()) {
             throw new PowsyblException("AC/DC converter '" + converter.getId()
                     + "' in DC_DROOP control mode must have a droop curve");
         }
-        // All coefficients must share the same strict sign: a k=0 band leaves its reference power undefined
-        // (division by zero below), and a sign change would break the band lookup, since two different P values
-        // could then land on the same U_dc.
-        boolean allPositive = segments.stream().allMatch(segment -> segment.getK() > 0);
-        boolean allNegative = segments.stream().allMatch(segment -> segment.getK() < 0);
-        if (!allPositive && !allNegative) {
-            throw new PowsyblException("AC/DC converter '" + converter.getId()
-                    + "' in DC_DROOP control mode must have a droop curve with all coefficients of the same strict sign (all positive or all negative)");
-        }
+        // All coefficients must share the same strict sign, but this is already checked in IIDM.
+
         double targetVdc = converter.getTargetVdc();
         double targetP = converter.getTargetP();
         if (Double.isNaN(targetVdc) || Double.isNaN(targetP)) {
@@ -106,7 +95,7 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
 
         // Anchored active power (per unit) at each band's lower voltage bound.
         double[] refPpu = new double[n];
-        int anchor = clampedBandIndex(segments, targetVdc, DroopCurve.Segment::getMinV, DroopCurve.Segment::getMaxV);
+        int anchor = clampedBandIndex(segments, targetVdc);
         refPpu[anchor] = targetPpu - (targetVdcPu - minVpu[anchor]) / kPu[anchor];
         for (int i = anchor + 1; i < n; i++) {
             refPpu[i] = refPpu[i - 1] + (maxVpu[i - 1] - minVpu[i - 1]) / kPu[i - 1];
@@ -115,30 +104,28 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
             refPpu[i] = refPpu[i + 1] - (maxVpu[i] - minVpu[i]) / kPu[i];
         }
 
-        List<DroopBand> bands = new ArrayList<>(n);
+        List<LfDroopReference> bands = new ArrayList<>(n);
         for (int i = 0; i < n; i++) {
-            bands.add(new DroopBand(kPu[i], minVpu[i], maxVpu[i], refPpu[i]));
+            bands.add(new LfDroopReference(kPu[i], minVpu[i], refPpu[i]));
         }
         return bands;
     }
 
     /**
-     * Index of the band containing {@code v} in an ordered list of {@code [minV, maxV)} ranges, clamped to the nearest
-     * band when {@code v} falls below the first or on/above the last (mirrors {@code DroopCurveImpl#getK}). Used both at
-     * build time over {@link DroopCurve.Segment} (kV) and at solve time over {@link DroopBand} (per unit), hence the
-     * min/max accessors rather than a fixed element type.
+     * Index of the band containing {@code v} in the ordered list of {@code [minV, maxV)} segments, clamped to the
+     * nearest band when {@code v} falls below the first or on/above the last (mirrors {@code DroopCurveImpl#getK}).
      */
-    private static <T> int clampedBandIndex(List<T> bands, double v, ToDoubleFunction<T> minV, ToDoubleFunction<T> maxV) {
-        if (v <= minV.applyAsDouble(bands.getFirst())) {
+    private static int clampedBandIndex(List<DroopCurve.Segment> segments, double v) {
+        if (v <= segments.getFirst().getMinV()) {
             return 0;
         }
-        for (int i = 0; i < bands.size(); i++) {
-            T band = bands.get(i);
-            if (v >= minV.applyAsDouble(band) && v < maxV.applyAsDouble(band)) {
+        for (int i = 0; i < segments.size(); i++) {
+            DroopCurve.Segment segment = segments.get(i);
+            if (v >= segment.getMinV() && v < segment.getMaxV()) {
                 return i;
             }
         }
-        return bands.size() - 1;
+        return segments.size() - 1;
     }
 
     public static LfVoltageSourceConverterImpl create(VoltageSourceConverter acDcConverter, LfNetwork network, LfDcBus dcBus1, LfDcBus dcBus2, LfBus bus1, LfNetworkParameters parameters) {
@@ -172,17 +159,6 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
     }
 
     @Override
-    public DroopReference getDroopReference(double uDc) {
-        if (droopBands.isEmpty()) {
-            throw new PowsyblException("getDroopReference called on AC/DC converter '" + getId()
-                    + "' which is not in DC_DROOP control mode");
-        }
-        // Band containing the solved DC voltage uDc (per unit), clamped to the nearest band outside the curve range.
-        DroopBand band = droopBands.get(clampedBandIndex(droopBands, uDc, DroopBand::minVpu, DroopBand::maxVpu));
-        return new DroopReference(band.kPu(), band.minVpu(), band.refPpu());
-    }
-
-    @Override
     public String getId() {
         return getConverter().getId();
     }
@@ -210,5 +186,10 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
         // Active and reactive power injected by the AC network in the converter
         converter.getTerminal1().setP(pAc * PerUnit.SB);
         converter.getTerminal1().setQ(qAc * PerUnit.SB);
+    }
+
+    @Override
+    public List<LfDroopReference> getDroopCurve() {
+        return droopBands;
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
@@ -33,7 +33,7 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
 
     protected double targetVac; // In pu
 
-    // Droop curve bands (only populated in P_PCC_DROOP control mode), sorted by DC voltage, all values in per unit.
+    // Droop curve bands (only populated in DC_DROOP control mode), sorted by DC voltage, all values in per unit.
     private final List<DroopBand> droopBands;
 
     private record DroopBand(double kPu, double minVpu, double maxVpu, double refPpu) {
@@ -50,7 +50,7 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
         } else {
             this.targetQ = converter.getReactivePowerSetpoint() / PerUnit.SB;
         }
-        this.droopBands = getControlMode() == AcDcConverter.ControlMode.P_PCC_DROOP
+        this.droopBands = getControlMode() == AcDcConverter.ControlMode.DC_DROOP
                 ? buildDroopBands(converter, getDcVoltageBase())
                 : List.of();
     }
@@ -68,7 +68,7 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
         List<DroopCurve.Segment> segments = new ArrayList<>(curve.getSegments());
         if (segments.isEmpty()) {
             throw new PowsyblException("AC/DC converter '" + converter.getId()
-                    + "' in P_PCC_DROOP control mode must have a droop curve");
+                    + "' in DC_DROOP control mode must have a droop curve");
         }
         // All coefficients must share the same strict sign: a k=0 band leaves its reference power undefined
         // (division by zero below), and a sign change would break the band lookup, since two different P values
@@ -77,13 +77,13 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
         boolean allNegative = segments.stream().allMatch(segment -> segment.getK() < 0);
         if (!allPositive && !allNegative) {
             throw new PowsyblException("AC/DC converter '" + converter.getId()
-                    + "' in P_PCC_DROOP control mode must have a droop curve with all coefficients of the same strict sign (all positive or all negative)");
+                    + "' in DC_DROOP control mode must have a droop curve with all coefficients of the same strict sign (all positive or all negative)");
         }
         double targetVdc = converter.getTargetVdc();
         double targetP = converter.getTargetP();
         if (Double.isNaN(targetVdc) || Double.isNaN(targetP)) {
             throw new PowsyblException("AC/DC converter '" + converter.getId()
-                    + "' in P_PCC_DROOP control mode must have targetP and targetVdc defined");
+                    + "' in DC_DROOP control mode must have targetP and targetVdc defined");
         }
         segments.sort(Comparator.comparingDouble(DroopCurve.Segment::getMinV));
         int n = segments.size();
@@ -175,7 +175,7 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
     public DroopReference getDroopReference(double uDc) {
         if (droopBands.isEmpty()) {
             throw new PowsyblException("getDroopReference called on AC/DC converter '" + getId()
-                    + "' which is not in P_PCC_DROOP control mode");
+                    + "' which is not in DC_DROOP control mode");
         }
         // Band containing the solved DC voltage uDc (per unit), clamped to the nearest band outside the curve range.
         DroopBand band = droopBands.get(clampedBandIndex(droopBands, uDc, DroopBand::minVpu, DroopBand::maxVpu));

--- a/src/test/java/com/powsybl/openloadflow/EquationsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/EquationsTest.java
@@ -396,4 +396,45 @@ class EquationsTest {
         assertArrayEquals(new double[]{655.5332962269079, 222991.01420562976, -222991.01420562976, 340.16733473206085, Double.NaN, Double.NaN},
                 eval(new ConverterDcCurrentEquationTerm(converter, dcBus1, dcBus2, dcBus1.getNominalV(), variableSet), variables, sv));
     }
+
+    @Test
+    void converterDroopEquationTermTest() {
+        // Droop equation: a*(P_AC - refP) - b*(U_dc - refVdc) = 0, with a = k (from the droop curve) and b = 1,
+        // i.e. U_dc = refVdc + k*(P_AC - refP): k is the slope of U_dc versus P_AC.
+        var converter = Mockito.mock(LfVoltageSourceConverter.class, new RuntimeExceptionAnswer());
+        Mockito.doReturn(0).when(converter).getNum();
+        Mockito.doReturn(false).when(converter).isDisabled();
+        Mockito.doReturn(400.0).when(converter).getDcVoltageBase();
+        double k = 2.0;
+        double refVdc = 0.125;
+        double refP = 0.5;
+        Mockito.doReturn(new LfVoltageSourceConverter.DroopReference(k, refVdc, refP))
+                .when(converter).getDroopReference(Mockito.anyDouble());
+
+        VariableSet<AcVariableType> variableSet = new VariableSet<>();
+        Variable<AcVariableType> v1Var = variableSet.getVariable(0, AcVariableType.DC_BUS_V);
+        Variable<AcVariableType> v2Var = variableSet.getVariable(1, AcVariableType.DC_BUS_V);
+        Variable<AcVariableType> pAcVar = variableSet.getVariable(0, AcVariableType.CONV_P_AC);
+        Variable<AcVariableType> unknownVar = variableSet.getVariable(999, AcVariableType.DUMMY_P);
+
+        var variables = List.of(v1Var, v2Var, pAcVar, unknownVar);
+        v1Var.setRow(0);
+        v2Var.setRow(1);
+        pAcVar.setRow(2);
+        unknownVar.setRow(3);
+
+        ConverterDroopEquationTerm term = new ConverterDroopEquationTerm(converter, dcBus1, dcBus2, variableSet);
+        assertEquals("conv_p_droop", term.getName());
+
+        // U_dc = 1.0 - 0.75 = 0.25, P_AC = 0.25: an arbitrary (non-solution) point.
+        // eval = k*(P_AC - refP) - (U_dc - refVdc) = -0.625.
+        // der(pAc) = k = 2.0 ; der(v1) = -b = -1.0 ; der(v2) = +b = 1.0.
+        var sv = new StateVector(new double[]{1.0, 0.75, 0.25, 0});
+        assertArrayEquals(new double[]{-0.625, -1.0, 1.0, 2.0, Double.NaN, Double.NaN},
+                eval(term, variables, sv));
+
+        // At U_dc = refVdc (0.125) and P_AC = refP (0.5), the residual is exactly zero.
+        term.setStateVector(new StateVector(new double[]{1.0, 0.875, 0.5, 0}));
+        assertEquals(0.0, term.eval());
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/EquationsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/EquationsTest.java
@@ -408,8 +408,8 @@ class EquationsTest {
         double k = 2.0;
         double refVdc = 0.125;
         double refP = 0.5;
-        Mockito.doReturn(new LfVoltageSourceConverter.DroopReference(k, refVdc, refP))
-                .when(converter).getDroopReference(Mockito.anyDouble());
+        Mockito.doReturn(List.of(new LfVoltageSourceConverter.LfDroopReference(k, refVdc, refP)))
+                .when(converter).getDroopCurve();
 
         VariableSet<AcVariableType> variableSet = new VariableSet<>();
         Variable<AcVariableType> v1Var = variableSet.getVariable(0, AcVariableType.DC_BUS_V);

--- a/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
@@ -21,6 +21,7 @@ import com.powsybl.openloadflow.ServiceParameterResolver;
 import com.powsybl.openloadflow.network.AcDcNetworkFactory;
 import com.powsybl.openloadflow.network.FirstSlackBusSelector;
 import com.powsybl.openloadflow.network.LfNetwork;
+import com.powsybl.openloadflow.network.LfNetworkLoader;
 import com.powsybl.openloadflow.network.LfNetworkParameters;
 import com.powsybl.openloadflow.network.LfVoltageSourceConverter;
 import com.powsybl.openloadflow.network.SlackBusSelectionMode;
@@ -1156,8 +1157,9 @@ class AcDcLoadFlowTest {
                 .setSlackBusSelector(new FirstSlackBusSelector())
                 .setAcDcNetwork(true);
 
+        LfNetworkLoader<Network> loader = new LfNetworkLoaderImpl();
         PowsyblException e = assertThrows(PowsyblException.class,
-                () -> LfNetwork.load(network, new LfNetworkLoaderImpl(), lfParameters));
+                () -> LfNetwork.load(network, loader, lfParameters));
         assertEquals("AC/DC converter 'convDroop' in P_PCC_DROOP control mode must have a droop curve with at least one non-zero coefficient",
                 e.getMessage());
     }

--- a/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
@@ -992,7 +992,7 @@ class AcDcLoadFlowTest {
 
         // Run load flow
         CompletionException e5 = assertThrows(CompletionException.class, () -> loadFlowRunner.run(network, parameters));
-        assertEquals("At least one AC/DC converter control mode must be V_DC in each DC component, but DC component 1 does not have any", e5.getCause().getMessage());
+        assertEquals("At least one AC/DC converter control mode must be V_DC or P_PCC_DROOP in each DC component, but DC component 1 does not have any", e5.getCause().getMessage());
     }
 
     @Test
@@ -1091,13 +1091,15 @@ class AcDcLoadFlowTest {
     }
 
     private void checkDroopResult(Network network, double vdc, double expectedPac) {
-        VoltageSourceConverter droopConverter = network.getVoltageSourceConverter("convDroop");
-        droopConverter.setTargetVdc(vdc);
+        // The V_DC converter (convVdc) pins U_dc, so sweeping its targetVdc walks the droop converter's solved
+        // U_dc through the curve bands. The droop converter's own anchor (targetVdc, targetP) stays fixed.
+        network.getVoltageSourceConverter("convVdc").setTargetVdc(vdc);
 
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged(), "load flow did not converge for targetVdc=" + vdc);
 
-        assertActivePowerEquals(expectedPac, droopConverter.getTerminal1());
+        Terminal droopConverterAcTerminal = network.getVoltageSourceConverter("convDroop").getTerminal1();
+        assertActivePowerEquals(expectedPac, droopConverterAcTerminal);
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
@@ -1143,4 +1143,23 @@ class AcDcLoadFlowTest {
                 e.getMessage());
     }
 
+    @Test
+    void testDroopCurveWithAllZeroCoefficientsThrows() {
+        // A P_PCC_DROOP converter whose droop curve is flat (all coefficients zero) is equivalent to constant-power
+        // P_PCC control and cannot settle the DC voltage. Such a curve makes no sense, so loading must fail fast.
+        Network network = AcDcNetworkFactory.createAcDcNetworkWithDroopControl();
+        network.getVoltageSourceConverter("convDroop").newDroopCurve()
+                .beginSegment().setK(0.).setMinV(380.).setMaxV(420.).endSegment()
+                .add();
+
+        LfNetworkParameters lfParameters = new LfNetworkParameters()
+                .setSlackBusSelector(new FirstSlackBusSelector())
+                .setAcDcNetwork(true);
+
+        PowsyblException e = assertThrows(PowsyblException.class,
+                () -> LfNetwork.load(network, new LfNetworkLoaderImpl(), lfParameters));
+        assertEquals("AC/DC converter 'convDroop' in P_PCC_DROOP control mode must have a droop curve with at least one non-zero coefficient",
+                e.getMessage());
+    }
+
 }

--- a/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
@@ -8,6 +8,7 @@
 package com.powsybl.openloadflow.acdc;
 
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.AcDcConverter.ControlMode;
 import com.powsybl.iidm.network.test.DcDetailedNetworkFactory;
 import com.powsybl.loadflow.LoadFlow;
 import com.powsybl.loadflow.LoadFlowParameters;
@@ -1048,4 +1049,70 @@ class AcDcLoadFlowTest {
         result = loadFlowRunner.run(network, parameters);
         assertFalse(result.isFullyConverged()); // Load flow do not succeed but no exception is thrown because of open switch
     }
+
+    @Test
+    void testDroopLaw() {
+        // A P_PCC_DROOP converter enforces P = refP + k*(U_dc - refVdc), where:
+        //   - k      = curve.getK(U_dc), the coefficient of the band containing the solved U_dc (clamped),
+        //   - refVdc = the min voltage of that band.
+        //   - refP   = the reference power, corresponding to the previous point in the curve.
+        // The paired V_DC converter (convVdc) pins the DC voltage, so sweeping its targetVdc walks the
+        // droop converter's solved U_dc through each band and past the extremes. The assertion reads the
+        // SOLVED U_dc, so it stays exact regardless of the DC-line voltage drop.
+        //
+        // Note that the droop curve has the following reference points:
+        // V = 380 kV => P = 35 MW
+        // V = 390 kV => P = 40 MW
+        // V = 410 kV => P = 60 MW
+        // V = 420 kV => P = 80 MW
+        Network network = AcDcNetworkFactory.createAcDcNetworkWithDroopControl();
+        parametersExt.setSlackBusSelectionMode(SlackBusSelectionMode.FIRST);
+
+        VoltageSourceConverter droopConverter = network.getVoltageSourceConverter("convDroop");
+        final double targetP = 50.0;
+        final double targetVdc = 400.0;
+
+        // Sanity check: let's make sure we have kept consistency.
+        assertEquals(targetP, droopConverter.getTargetP());
+        assertEquals(targetVdc, droopConverter.getTargetVdc());
+
+        // Basic check: when Vdc = targetVdc, then Pac must be equal to targetP.
+        // This is also right in the middle of the middle droop segment.
+        checkDroopResult(network, targetVdc, targetP);
+
+        // Then check expected values on each segment.
+        // We take midpoints to simplify computations.
+        checkDroopResult(network, 385., 37.5);
+        checkDroopResult(network, 415., 70.);
+
+        // Finally check extrapolation
+        checkDroopResult(network, 370., 30.);
+        checkDroopResult(network, 430., 100.);
+    }
+
+    private void checkDroopResult(Network network, double vdc, double expectedPac) {
+        VoltageSourceConverter droopConverter = network.getVoltageSourceConverter("convDroop");
+        droopConverter.setTargetVdc(vdc);
+
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isFullyConverged(), "load flow did not converge for targetVdc=" + vdc);
+
+        assertActivePowerEquals(expectedPac, droopConverter.getTerminal1());
+    }
+
+    @Test
+    void testDroopCountsAsVdcControl() {
+        // Check a DC component whose only DC-voltage-controlling converter is in P_PCC_DROOP mode
+        // is accepted.
+        // This is the mirror of testNoVdcControl, which rejects a component with only P_PCC converters.
+        Network network = AcDcNetworkFactory.createAcDcNetworkWithDroopControl();
+        network.getVoltageSourceConverter("convVdc").setId("convPAC")
+                .setTargetP(50.)
+                .setControlMode(ControlMode.P_PCC);
+
+        parametersExt.setSlackBusSelectionMode(SlackBusSelectionMode.FIRST);
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isFullyConverged());
+    }
+
 }

--- a/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.openloadflow.acdc;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.AcDcConverter.ControlMode;
 import com.powsybl.iidm.network.test.DcDetailedNetworkFactory;
@@ -18,7 +19,12 @@ import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.OpenLoadFlowProvider;
 import com.powsybl.openloadflow.ServiceParameterResolver;
 import com.powsybl.openloadflow.network.AcDcNetworkFactory;
+import com.powsybl.openloadflow.network.FirstSlackBusSelector;
+import com.powsybl.openloadflow.network.LfNetwork;
+import com.powsybl.openloadflow.network.LfNetworkParameters;
+import com.powsybl.openloadflow.network.LfVoltageSourceConverter;
 import com.powsybl.openloadflow.network.SlackBusSelectionMode;
+import com.powsybl.openloadflow.network.impl.LfNetworkLoaderImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -1115,6 +1121,26 @@ class AcDcLoadFlowTest {
         parametersExt.setSlackBusSelectionMode(SlackBusSelectionMode.FIRST);
         LoadFlowResult result = loadFlowRunner.run(network, parameters);
         assertTrue(result.isFullyConverged());
+    }
+
+    @Test
+    void testGetDroopReferenceThrowsOnNonDroopConverter() {
+        // getDroopReference is only meaningful in P_PCC_DROOP mode. On any other converter the droop bands are
+        // empty; the call must fail fast with a clear message.
+        Network network = AcDcNetworkFactory.createAcDcNetworkWithDroopControl();
+        LfNetworkParameters lfParameters = new LfNetworkParameters()
+                .setSlackBusSelector(new FirstSlackBusSelector())
+                .setAcDcNetwork(true);
+        LfNetwork lfNetwork = LfNetwork.load(network, new LfNetworkLoaderImpl(), lfParameters).get(0);
+
+        // convVdc is in V_DC control mode, so it has no droop bands.
+        LfVoltageSourceConverter vdcConverter = lfNetwork.getVoltageSourceConverters().stream()
+                .filter(c -> "convVdc".equals(c.getId()))
+                .findFirst().orElseThrow();
+
+        PowsyblException e = assertThrows(PowsyblException.class, () -> vdcConverter.getDroopReference(1.0));
+        assertEquals("getDroopReference called on AC/DC converter 'convVdc' which is not in P_PCC_DROOP control mode",
+                e.getMessage());
     }
 
 }

--- a/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
@@ -1064,7 +1064,7 @@ class AcDcLoadFlowTest {
         //   - refP   = the reference power, corresponding to the previous point in the curve.
         // The paired V_DC converter (convVdc) pins the DC voltage, so sweeping its targetVdc walks the
         // droop converter's solved U_dc through each band and past the extremes. The assertion reads the
-        // SOLVED U_dc, so it stays exact regardless of the DC-line voltage drop.
+        // SOLVED U_dc, so it stays exact.
         //
         // Note that the droop curve has the following reference points:
         // V = 380 kV => P = 35 MW

--- a/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
@@ -1059,19 +1059,20 @@ class AcDcLoadFlowTest {
 
     @Test
     void testDroopLaw() {
-        // A P_PCC_DROOP converter enforces P = refP + k*(U_dc - refVdc), where:
+        // A P_PCC_DROOP converter enforces U_dc = refVdc + k * (P_AC - refP), where:
         //   - k      = curve.getK(U_dc), the coefficient of the band containing the solved U_dc (clamped),
         //   - refVdc = the min voltage of that band.
         //   - refP   = the reference power, corresponding to the previous point in the curve.
+        // i.e. P_AC = refP + (U_dc - refVdc) / k: k is the slope of U_dc versus P_AC.
         // The paired V_DC converter (convVdc) pins the DC voltage, so sweeping its targetVdc walks the
         // droop converter's solved U_dc through each band and past the extremes. The assertion reads the
         // SOLVED U_dc, so it stays exact.
         //
         // Note that the droop curve has the following reference points:
-        // V = 380 kV => P = 35 MW
+        // V = 380 kV => P = 20 MW
         // V = 390 kV => P = 40 MW
         // V = 410 kV => P = 60 MW
-        // V = 420 kV => P = 80 MW
+        // V = 420 kV => P = 65 MW
         Network network = AcDcNetworkFactory.createAcDcNetworkWithDroopControl();
         parametersExt.setSlackBusSelectionMode(SlackBusSelectionMode.FIRST);
 
@@ -1087,14 +1088,14 @@ class AcDcLoadFlowTest {
         // This is also right in the middle of the middle droop segment.
         checkDroopResult(network, targetVdc, targetP);
 
-        // Then check expected values on each segment.
+        // Then check expected values on each segment (P = refP + (Vdc-refVdc)/k).
         // We take midpoints to simplify computations.
-        checkDroopResult(network, 385., 37.5);
-        checkDroopResult(network, 415., 70.);
+        checkDroopResult(network, 385., 30.);  // band [380,390], k=0.5
+        checkDroopResult(network, 415., 62.5); // band [410,420], k=2.0
 
-        // Finally check extrapolation
-        checkDroopResult(network, 370., 30.);
-        checkDroopResult(network, 430., 100.);
+        // Finally check extrapolation (clamped to the nearest band).
+        checkDroopResult(network, 370., 0.);   // clamp to [380,390], k=0.5: 20 + (370-380)/0.5 = 0
+        checkDroopResult(network, 430., 70.);  // clamp to [410,420], k=2.0: 60 + (430-410)/2.0 = 70
     }
 
     private void checkDroopResult(Network network, double vdc, double expectedPac) {
@@ -1145,14 +1146,51 @@ class AcDcLoadFlowTest {
     }
 
     @Test
-    void testDroopCurveWithAllZeroCoefficientsThrows() {
-        // A P_PCC_DROOP converter whose droop curve is flat (all coefficients zero) is equivalent to constant-power
-        // P_PCC control and cannot settle the DC voltage. Such a curve makes no sense, so loading must fail fast.
+    void testDroopCurveWithOneZeroCoefficientAmongNonZeroThrows() {
+        // A k=0 band (here mixed among non-zero bands, but this also covers an all-zero curve) makes that
+        // band's reference power undefined: positioning it on the curve (see buildDroopBands) divides by k.
         Network network = AcDcNetworkFactory.createAcDcNetworkWithDroopControl();
         network.getVoltageSourceConverter("convDroop").newDroopCurve()
-                .beginSegment().setK(0.).setMinV(380.).setMaxV(420.).endSegment()
+                .beginSegment().setK(0.5).setMinV(380.).setMaxV(400.).endSegment()
+                .beginSegment().setK(0.).setMinV(400.).setMaxV(420.).endSegment()
                 .add();
 
+        assertDroopCurveRejected(network);
+    }
+
+    @Test
+    void testDroopCurveWithMixedSignCoefficientsThrows() {
+        // All coefficients must have the same sign: a sign change would break the band lookup, since two
+        // different P values could then land on the same U_dc.
+        Network network = AcDcNetworkFactory.createAcDcNetworkWithDroopControl();
+        network.getVoltageSourceConverter("convDroop").newDroopCurve()
+                .beginSegment().setK(0.5).setMinV(380.).setMaxV(400.).endSegment()
+                .beginSegment().setK(-1.0).setMinV(400.).setMaxV(420.).endSegment()
+                .add();
+
+        assertDroopCurveRejected(network);
+    }
+
+    @Test
+    void testDroopCurveWithAllNegativeCoefficientsIsAccepted() {
+        // Coefficients may be all negative as well as all positive, as long as they share the same sign.
+        // The anchor invariant (Pac = targetP when Vdc = targetVdc) holds regardless of sign, but away from the
+        // anchor the slope 1/k differs from the all-positive curve, so also check a non-anchor point.
+        // P = refP + (Vdc-refVdc)/k; with this curve's bands, refP at [410,420] (k=-2.0) works out to 40 MW,
+        // so at Vdc=415: Pac = 37.5.
+        Network network = AcDcNetworkFactory.createAcDcNetworkWithDroopControl();
+        network.getVoltageSourceConverter("convDroop").newDroopCurve()
+                .beginSegment().setK(-0.5).setMinV(380.).setMaxV(390.).endSegment()
+                .beginSegment().setK(-1.0).setMinV(390.).setMaxV(410.).endSegment()
+                .beginSegment().setK(-2.0).setMinV(410.).setMaxV(420.).endSegment()
+                .add();
+        parametersExt.setSlackBusSelectionMode(SlackBusSelectionMode.FIRST);
+
+        checkDroopResult(network, 400., 50.);
+        checkDroopResult(network, 415., 37.5);
+    }
+
+    private void assertDroopCurveRejected(Network network) {
         LfNetworkParameters lfParameters = new LfNetworkParameters()
                 .setSlackBusSelector(new FirstSlackBusSelector())
                 .setAcDcNetwork(true);
@@ -1160,7 +1198,7 @@ class AcDcLoadFlowTest {
         LfNetworkLoader<Network> loader = new LfNetworkLoaderImpl();
         PowsyblException e = assertThrows(PowsyblException.class,
                 () -> LfNetwork.load(network, loader, lfParameters));
-        assertEquals("AC/DC converter 'convDroop' in P_PCC_DROOP control mode must have a droop curve with at least one non-zero coefficient",
+        assertEquals("AC/DC converter 'convDroop' in P_PCC_DROOP control mode must have a droop curve with all coefficients of the same strict sign (all positive or all negative)",
                 e.getMessage());
     }
 

--- a/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
@@ -1061,9 +1061,13 @@ class AcDcLoadFlowTest {
     void testDroopLaw() {
         // A P_PCC_DROOP converter enforces U_dc = refVdc + k * (P_AC - refP), where:
         //   - k      = curve.getK(U_dc), the coefficient of the band containing the solved U_dc (clamped),
+        //             the slope of U_dc versus P_AC, in kV/MW.
         //   - refVdc = the min voltage of that band.
         //   - refP   = the reference power, corresponding to the previous point in the curve.
-        // i.e. P_AC = refP + (U_dc - refVdc) / k: k is the slope of U_dc versus P_AC.
+        // The equation is solved in per unit (k_pu = k * SB / vBase, vBase = 400 kV, SB = 100 MVA, so
+        // k_pu = k/4 here); refP is anchored and integrated in that same per-unit system (see
+        // buildDroopBands), but since the per-unit conversion is dimensionally consistent it reduces to
+        // exactly the plain kV/MW arithmetic of k below.
         // The paired V_DC converter (convVdc) pins the DC voltage, so sweeping its targetVdc walks the
         // droop converter's solved U_dc through each band and past the extremes. The assertion reads the
         // SOLVED U_dc, so it stays exact.
@@ -1088,14 +1092,14 @@ class AcDcLoadFlowTest {
         // This is also right in the middle of the middle droop segment.
         checkDroopResult(network, targetVdc, targetP);
 
-        // Then check expected values on each segment (P = refP + (Vdc-refVdc)/k).
+        // Then check expected values on each segment.
         // We take midpoints to simplify computations.
-        checkDroopResult(network, 385., 30.);  // band [380,390], k=0.5
-        checkDroopResult(network, 415., 62.5); // band [410,420], k=2.0
+        checkDroopResult(network, 385., 30.);  // band [380,390], k=0.5: 380 + 0.5*(30-20) = 385
+        checkDroopResult(network, 415., 62.5); // band [410,420], k=2.0: 410 + 2.0*(62.5-60) = 415
 
         // Finally check extrapolation (clamped to the nearest band).
-        checkDroopResult(network, 370., 0.);   // clamp to [380,390], k=0.5: 20 + (370-380)/0.5 = 0
-        checkDroopResult(network, 430., 70.);  // clamp to [410,420], k=2.0: 60 + (430-410)/2.0 = 70
+        checkDroopResult(network, 370., 0.);   // clamp to [380,390], k=0.5: 380 + 0.5*(0-20) = 370
+        checkDroopResult(network, 430., 70.);  // clamp to [410,420], k=2.0: 410 + 2.0*(70-60) = 430
     }
 
     private void checkDroopResult(Network network, double vdc, double expectedPac) {
@@ -1175,9 +1179,9 @@ class AcDcLoadFlowTest {
     void testDroopCurveWithAllNegativeCoefficientsIsAccepted() {
         // Coefficients may be all negative as well as all positive, as long as they share the same sign.
         // The anchor invariant (Pac = targetP when Vdc = targetVdc) holds regardless of sign, but away from the
-        // anchor the slope 1/k differs from the all-positive curve, so also check a non-anchor point.
-        // P = refP + (Vdc-refVdc)/k; with this curve's bands, refP at [410,420] (k=-2.0) works out to 40 MW,
-        // so at Vdc=415: Pac = 37.5.
+        // anchor the slope k differs from the all-positive curve, so also check a non-anchor point.
+        // U_dc = refVdc + k*(P-refP); with this curve's bands, refP at [410,420] (k=-2.0) works out to 40 MW,
+        // so checking P=37.5: 410 + (-2.0)*(37.5-40) = 415.
         Network network = AcDcNetworkFactory.createAcDcNetworkWithDroopControl();
         network.getVoltageSourceConverter("convDroop").newDroopCurve()
                 .beginSegment().setK(-0.5).setMinV(380.).setMaxV(390.).endSegment()

--- a/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
@@ -1094,8 +1094,15 @@ class AcDcLoadFlowTest {
 
         // Then check expected values on each segment.
         // We take midpoints to simplify computations.
-        checkDroopResult(network, 385., 30.);  // band [380,390], k=0.5: 380 + 0.5*(30-20) = 385
-        checkDroopResult(network, 415., 62.5); // band [410,420], k=2.0: 410 + 2.0*(62.5-60) = 415
+        checkDroopResult(network, 385., 30.);
+        checkDroopResult(network, 415., 62.5);
+
+        // Check exactly at the internal band boundaries, where the droop coefficient k is discontinuous
+        // (0.5 -> 1.0 at 390, 1.0 -> 2.0 at 410) and the Jacobian term in ConverterDroopEquationTerm#der
+        // does not account for that discontinuity. Both bands agree on P at their shared boundary, so the
+        // expected value is exact regardless of which side the solver lands on.
+        checkDroopResult(network, 390., 40.);
+        checkDroopResult(network, 410., 60.);
 
         // Finally check extrapolation (clamped to the nearest band).
         checkDroopResult(network, 370., 0.);   // clamp to [380,390], k=0.5: 380 + 0.5*(0-20) = 370
@@ -1112,6 +1119,42 @@ class AcDcLoadFlowTest {
 
         Terminal droopConverterAcTerminal = network.getVoltageSourceConverter("convDroop").getTerminal1();
         assertActivePowerEquals(expectedPac, droopConverterAcTerminal);
+    }
+
+    @Test
+    void testSwitchToDroopControlMidTest() {
+        // Run #1: convDroop is in plain P_PCC mode (its droop curve is attached by the factory but unused
+        // while the control mode is not P_PCC_DROOP) with a target power that is deliberately inconsistent
+        // with what the droop law would give at the DC voltage convVdc is pinning it to. This gives a
+        // converged, non-flat starting state that is not already on the droop curve.
+        Network network = AcDcNetworkFactory.createAcDcNetworkWithDroopControl();
+        parametersExt.setSlackBusSelectionMode(SlackBusSelectionMode.FIRST);
+
+        VoltageSourceConverter convVdc = network.getVoltageSourceConverter("convVdc");
+        VoltageSourceConverter convDroop = network.getVoltageSourceConverter("convDroop");
+        convDroop.setControlMode(ControlMode.P_PCC);
+        convVdc.setTargetVdc(415.); // band [410,420]: droop would require P=62.5, but P_PCC pins P=50 instead.
+
+        LoadFlowResult result1 = loadFlowRunner.run(network, parameters);
+        assertTrue(result1.isFullyConverged());
+        assertActivePowerEquals(50., convDroop.getTerminal1()); // P_PCC: P_AC pinned to targetP, unaffected by U_dc.
+        assertVoltageEquals(415., network.getDcNode("dn1"));    // V_DC: U_dc pinned to targetVdc.
+
+        // Switch convDroop to droop control mid-test (its curve and its own anchor, targetP=50 /
+        // targetVdc=400, are unchanged since creation) and move convVdc's target into the first band.
+        // Warm-started from run #1's state (PREVIOUS_VALUES instead of a flat start), the solver must move
+        // U_dc from 415 down to 385, crossing both the 410 and 390 band boundaries, while also correcting
+        // P_AC from the run #1 value (50, off the droop curve) to the value the droop law now requires.
+        convDroop.setControlMode(ControlMode.P_PCC_DROOP);
+        convVdc.setTargetVdc(385.);
+        parameters.setVoltageInitMode(LoadFlowParameters.VoltageInitMode.PREVIOUS_VALUES);
+
+        LoadFlowResult result2 = loadFlowRunner.run(network, parameters);
+        assertTrue(result2.isFullyConverged(),
+                "did not converge after switching to droop control from a warm start in a different band");
+        // band [380,390], k=0.5: 380 + 0.5*(30-20) = 385
+        assertActivePowerEquals(30., convDroop.getTerminal1());
+        assertVoltageEquals(385., network.getDcNode("dn1"));
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
@@ -999,7 +999,7 @@ class AcDcLoadFlowTest {
 
         // Run load flow
         CompletionException e5 = assertThrows(CompletionException.class, () -> loadFlowRunner.run(network, parameters));
-        assertEquals("At least one AC/DC converter control mode must be V_DC or P_PCC_DROOP in each DC component, but DC component 1 does not have any", e5.getCause().getMessage());
+        assertEquals("At least one AC/DC converter control mode must be V_DC or DC_DROOP in each DC component, but DC component 1 does not have any", e5.getCause().getMessage());
     }
 
     @Test
@@ -1059,7 +1059,7 @@ class AcDcLoadFlowTest {
 
     @Test
     void testDroopLaw() {
-        // A P_PCC_DROOP converter enforces U_dc = refVdc + k * (P_AC - refP), where:
+        // A DC_DROOP converter enforces U_dc = refVdc + k * (P_AC - refP), where:
         //   - k      = curve.getK(U_dc), the coefficient of the band containing the solved U_dc (clamped),
         //             the slope of U_dc versus P_AC, in kV/MW.
         //   - refVdc = the min voltage of that band.
@@ -1124,7 +1124,7 @@ class AcDcLoadFlowTest {
     @Test
     void testSwitchToDroopControlMidTest() {
         // Run #1: convDroop is in plain P_PCC mode (its droop curve is attached by the factory but unused
-        // while the control mode is not P_PCC_DROOP) with a target power that is deliberately inconsistent
+        // while the control mode is not DC_DROOP) with a target power that is deliberately inconsistent
         // with what the droop law would give at the DC voltage convVdc is pinning it to. This gives a
         // converged, non-flat starting state that is not already on the droop curve.
         Network network = AcDcNetworkFactory.createAcDcNetworkWithDroopControl();
@@ -1145,7 +1145,7 @@ class AcDcLoadFlowTest {
         // Warm-started from run #1's state (PREVIOUS_VALUES instead of a flat start), the solver must move
         // U_dc from 415 down to 385, crossing both the 410 and 390 band boundaries, while also correcting
         // P_AC from the run #1 value (50, off the droop curve) to the value the droop law now requires.
-        convDroop.setControlMode(ControlMode.P_PCC_DROOP);
+        convDroop.setControlMode(ControlMode.DC_DROOP);
         convVdc.setTargetVdc(385.);
         parameters.setVoltageInitMode(LoadFlowParameters.VoltageInitMode.PREVIOUS_VALUES);
 
@@ -1159,7 +1159,7 @@ class AcDcLoadFlowTest {
 
     @Test
     void testDroopCountsAsVdcControl() {
-        // Check a DC component whose only DC-voltage-controlling converter is in P_PCC_DROOP mode
+        // Check a DC component whose only DC-voltage-controlling converter is in DC_DROOP mode
         // is accepted.
         // This is the mirror of testNoVdcControl, which rejects a component with only P_PCC converters.
         Network network = AcDcNetworkFactory.createAcDcNetworkWithDroopControl();
@@ -1174,7 +1174,7 @@ class AcDcLoadFlowTest {
 
     @Test
     void testGetDroopReferenceThrowsOnNonDroopConverter() {
-        // getDroopReference is only meaningful in P_PCC_DROOP mode. On any other converter the droop bands are
+        // getDroopReference is only meaningful in DC_DROOP mode. On any other converter the droop bands are
         // empty; the call must fail fast with a clear message.
         Network network = AcDcNetworkFactory.createAcDcNetworkWithDroopControl();
         LfNetworkParameters lfParameters = new LfNetworkParameters()
@@ -1188,7 +1188,7 @@ class AcDcLoadFlowTest {
                 .findFirst().orElseThrow();
 
         PowsyblException e = assertThrows(PowsyblException.class, () -> vdcConverter.getDroopReference(1.0));
-        assertEquals("getDroopReference called on AC/DC converter 'convVdc' which is not in P_PCC_DROOP control mode",
+        assertEquals("getDroopReference called on AC/DC converter 'convVdc' which is not in DC_DROOP control mode",
                 e.getMessage());
     }
 
@@ -1245,7 +1245,7 @@ class AcDcLoadFlowTest {
         LfNetworkLoader<Network> loader = new LfNetworkLoaderImpl();
         PowsyblException e = assertThrows(PowsyblException.class,
                 () -> LfNetwork.load(network, loader, lfParameters));
-        assertEquals("AC/DC converter 'convDroop' in P_PCC_DROOP control mode must have a droop curve with all coefficients of the same strict sign (all positive or all negative)",
+        assertEquals("AC/DC converter 'convDroop' in DC_DROOP control mode must have a droop curve with all coefficients of the same strict sign (all positive or all negative)",
                 e.getMessage());
     }
 

--- a/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
@@ -7,7 +7,6 @@
  */
 package com.powsybl.openloadflow.acdc;
 
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.AcDcConverter.ControlMode;
 import com.powsybl.iidm.network.test.DcDetailedNetworkFactory;
@@ -21,7 +20,6 @@ import com.powsybl.openloadflow.ServiceParameterResolver;
 import com.powsybl.openloadflow.network.AcDcNetworkFactory;
 import com.powsybl.openloadflow.network.FirstSlackBusSelector;
 import com.powsybl.openloadflow.network.LfNetwork;
-import com.powsybl.openloadflow.network.LfNetworkLoader;
 import com.powsybl.openloadflow.network.LfNetworkParameters;
 import com.powsybl.openloadflow.network.LfVoltageSourceConverter;
 import com.powsybl.openloadflow.network.SlackBusSelectionMode;
@@ -1066,8 +1064,7 @@ class AcDcLoadFlowTest {
         //   - refP   = the reference power, corresponding to the previous point in the curve.
         // The equation is solved in per unit (k_pu = k * SB / vBase, vBase = 400 kV, SB = 100 MVA, so
         // k_pu = k/4 here); refP is anchored and integrated in that same per-unit system (see
-        // buildDroopBands), but since the per-unit conversion is dimensionally consistent it reduces to
-        // exactly the plain kV/MW arithmetic of k below.
+        // buildDroopBands).
         // The paired V_DC converter (convVdc) pins the DC voltage, so sweeping its targetVdc walks the
         // droop converter's solved U_dc through each band and past the extremes. The assertion reads the
         // SOLVED U_dc, so it stays exact.
@@ -1173,9 +1170,8 @@ class AcDcLoadFlowTest {
     }
 
     @Test
-    void testGetDroopReferenceThrowsOnNonDroopConverter() {
-        // getDroopReference is only meaningful in DC_DROOP mode. On any other converter the droop bands are
-        // empty; the call must fail fast with a clear message.
+    void testGetDroopCurveEmptyOnNonDroopConverter() {
+        // getDroopCurve is only meaningful in DC_DROOP mode. On any other converter the droop bands are empty.
         Network network = AcDcNetworkFactory.createAcDcNetworkWithDroopControl();
         LfNetworkParameters lfParameters = new LfNetworkParameters()
                 .setSlackBusSelector(new FirstSlackBusSelector())
@@ -1187,40 +1183,43 @@ class AcDcLoadFlowTest {
                 .filter(c -> "convVdc".equals(c.getId()))
                 .findFirst().orElseThrow();
 
-        PowsyblException e = assertThrows(PowsyblException.class, () -> vdcConverter.getDroopReference(1.0));
-        assertEquals("getDroopReference called on AC/DC converter 'convVdc' which is not in DC_DROOP control mode",
-                e.getMessage());
+        assertEquals(List.of(), vdcConverter.getDroopCurve());
     }
 
     @Test
-    void testDroopCurveWithOneZeroCoefficientAmongNonZeroThrows() {
-        // A k=0 band (here mixed among non-zero bands, but this also covers an all-zero curve) makes that
-        // band's reference power undefined: positioning it on the curve (see buildDroopBands) divides by k.
+    void testGetDroopCurve() {
+        // Expected values come from the factory's 3-band droop curve (see
+        // AcDcNetworkFactory#createAcDcNetworkWithDroopControl): V=380kV/P=20MW, V=390kV/P=40MW,
+        // V=410kV/P=60MW, converted to per unit with vBase = 400 kV (dn1's nominal voltage) and SB = 100 MVA:
+        // k_pu = k * SB / vBase, V_pu = V / vBase, P_pu = P / SB.
         Network network = AcDcNetworkFactory.createAcDcNetworkWithDroopControl();
-        network.getVoltageSourceConverter("convDroop").newDroopCurve()
-                .beginSegment().setK(0.5).setMinV(380.).setMaxV(400.).endSegment()
-                .beginSegment().setK(0.).setMinV(400.).setMaxV(420.).endSegment()
-                .add();
+        LfNetworkParameters lfParameters = new LfNetworkParameters()
+                .setSlackBusSelector(new FirstSlackBusSelector())
+                .setAcDcNetwork(true);
+        LfNetwork lfNetwork = LfNetwork.load(network, new LfNetworkLoaderImpl(), lfParameters).get(0);
 
-        assertDroopCurveRejected(network);
+        LfVoltageSourceConverter droopConverter = lfNetwork.getVoltageSourceConverters().stream()
+                .filter(c -> "convDroop".equals(c.getId()))
+                .findFirst().orElseThrow();
+
+        List<LfVoltageSourceConverter.LfDroopReference> droopCurve = droopConverter.getDroopCurve();
+
+        assertEquals(3, droopCurve.size());
+        assertDroopReferenceEquals(0.125, 0.95, 0.2, droopCurve.get(0));
+        assertDroopReferenceEquals(0.25, 0.975, 0.4, droopCurve.get(1));
+        assertDroopReferenceEquals(0.5, 1.025, 0.6, droopCurve.get(2));
     }
 
-    @Test
-    void testDroopCurveWithMixedSignCoefficientsThrows() {
-        // All coefficients must have the same sign: a sign change would break the band lookup, since two
-        // different P values could then land on the same U_dc.
-        Network network = AcDcNetworkFactory.createAcDcNetworkWithDroopControl();
-        network.getVoltageSourceConverter("convDroop").newDroopCurve()
-                .beginSegment().setK(0.5).setMinV(380.).setMaxV(400.).endSegment()
-                .beginSegment().setK(-1.0).setMinV(400.).setMaxV(420.).endSegment()
-                .add();
-
-        assertDroopCurveRejected(network);
+    private void assertDroopReferenceEquals(double expectedK, double expectedRefVdc, double expectedRefP,
+                                             LfVoltageSourceConverter.LfDroopReference actual) {
+        assertEquals(expectedK, actual.k(), 1e-9);
+        assertEquals(expectedRefVdc, actual.refVdc(), 1e-9);
+        assertEquals(expectedRefP, actual.refP(), 1e-9);
     }
 
     @Test
     void testDroopCurveWithAllNegativeCoefficientsIsAccepted() {
-        // Coefficients may be all negative as well as all positive, as long as they share the same sign.
+        // Check that droop also works with a decreasing curve.
         // The anchor invariant (Pac = targetP when Vdc = targetVdc) holds regardless of sign, but away from the
         // anchor the slope k differs from the all-positive curve, so also check a non-anchor point.
         // U_dc = refVdc + k*(P-refP); with this curve's bands, refP at [410,420] (k=-2.0) works out to 40 MW,
@@ -1235,18 +1234,6 @@ class AcDcLoadFlowTest {
 
         checkDroopResult(network, 400., 50.);
         checkDroopResult(network, 415., 37.5);
-    }
-
-    private void assertDroopCurveRejected(Network network) {
-        LfNetworkParameters lfParameters = new LfNetworkParameters()
-                .setSlackBusSelector(new FirstSlackBusSelector())
-                .setAcDcNetwork(true);
-
-        LfNetworkLoader<Network> loader = new LfNetworkLoaderImpl();
-        PowsyblException e = assertThrows(PowsyblException.class,
-                () -> LfNetwork.load(network, loader, lfParameters));
-        assertEquals("AC/DC converter 'convDroop' in DC_DROOP control mode must have a droop curve with all coefficients of the same strict sign (all positive or all negative)",
-                e.getMessage());
     }
 
 }

--- a/src/test/java/com/powsybl/openloadflow/network/AcDcNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/AcDcNetworkFactory.java
@@ -2431,4 +2431,130 @@ public class AcDcNetworkFactory extends AbstractLoadFlowNetworkFactory {
 
         return net;
     }
+
+    /**
+     * ACDC droop-control test case.
+     *
+     * This is a back-to-back case between 2 VSC which are directly connected in the DC part.
+     * On the AC side they are also connected by a resistive AC line in parallel, and we have
+     * a generator on one side and a load on the other side. This configuration gives a full control
+     * on the DC side and makes it possible for power transfer to be always balanced.
+     *
+     * convVdc (V_DC) pins the DC voltage; convDroop (P_PCC_DROOP) enforces
+     * {@code P = refP + k*(U_dc - refVdc)} with a 3-band droop curve. Sweeping convVdc's
+     * {@code targetVdc} walks convDroop's solved {@code U_dc} through each band of the curve and past
+     * the extremes (clamping). convDroop has no losses so the droop law applies directly to its AC power.
+     */
+    public static Network createAcDcNetworkWithDroopControl() {
+
+        Network network = Network.create("vsc", "test");
+
+        // AC network: a generator and a load connected by an AC line.
+        Substation s1 = network.newSubstation()
+                .setId("S1")
+                .add();
+        VoltageLevel vl1 = s1.newVoltageLevel()
+                .setId("vl1")
+                .setNominalV(400.)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl1.getBusBreakerView().newBus()
+                .setId("b1")
+                .add();
+        vl1.newGenerator()
+                .setId("g1")
+                .setConnectableBus("b1")
+                .setBus("b1")
+                .setTargetP(100.)
+                .setTargetV(400.)
+                .setMinP(0)
+                .setMaxP(500)
+                .setVoltageRegulatorOn(true)
+                .add();
+
+        Substation s2 = network.newSubstation()
+                .setId("S2")
+                .add();
+        VoltageLevel vl2 = s2.newVoltageLevel()
+                .setId("vl2")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl2.getBusBreakerView().newBus()
+                .setId("b2")
+                .add();
+        vl2.newLoad()
+                .setId("ld2")
+                .setConnectableBus("b2")
+                .setBus("b2")
+                .setP0(100.0)
+                .setQ0(0.0)
+                .add();
+
+        network.newLine()
+                .setId("l12")
+                .setBus1("b1")
+                .setBus2("b2")
+                .setR(1)
+                .setX(3)
+                .add();
+
+        // DC network: back-to-back converters with a ground.
+        // One of converters is in DC voltage control mode, while the other is in droop control.
+        network.newDcNode().
+                setId("dn1").
+                setNominalV(400.).
+                add();
+        network.newDcNode().
+                setId("dnGround").
+                setNominalV(400.).
+                add();
+        network.newDcGround()
+                .setId("dcGround")
+                .setDcNode("dnGround")
+                .add();
+
+        vl1.newVoltageSourceConverter()
+                .setIdleLoss(0)
+                .setSwitchingLoss(0)
+                .setResistiveLoss(0)
+                .setControlMode(AcDcConverter.ControlMode.V_DC)
+                .setTargetVdc(400.)
+                .setId("convVdc")
+                .setBus1("b1")
+                .setDcNode1("dn1")
+                .setDcNode2("dnGround")
+                .setDcConnected1(true)
+                .setDcConnected2(true)
+                .setVoltageRegulatorOn(false)
+                .setReactivePowerSetpoint(0.0)
+                .add();
+
+        // Droop-controlled converter (no losses so the law applies directly to AC power).
+        VoltageSourceConverter droopConverter = vl2.newVoltageSourceConverter()
+                .setIdleLoss(0)
+                .setSwitchingLoss(0)
+                .setResistiveLoss(0)
+                .setControlMode(AcDcConverter.ControlMode.P_PCC_DROOP)
+                .setTargetP(50.)
+                .setTargetVdc(400.)
+                .setId("convDroop")
+                .setBus1("b2")
+                .setDcNode1("dn1")
+                .setDcNode2("dnGround")
+                .setDcConnected1(true)
+                .setDcConnected2(true)
+                .setVoltageRegulatorOn(false)
+                .setReactivePowerSetpoint(0.0)
+                .add();
+
+        // 3-band droop curve: coefficient k (MW/kV) piecewise-constant over DC-voltage bands (kV).
+        droopConverter.newDroopCurve()
+                .beginSegment().setK(0.5).setMinV(380.).setMaxV(390.).endSegment()
+                .beginSegment().setK(1.0).setMinV(390.).setMaxV(410.).endSegment()
+                .beginSegment().setK(2.0).setMinV(410.).setMaxV(420.).endSegment()
+                .add();
+
+        return network;
+    }
 }

--- a/src/test/java/com/powsybl/openloadflow/network/AcDcNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/AcDcNetworkFactory.java
@@ -2450,46 +2450,11 @@ public class AcDcNetworkFactory extends AbstractLoadFlowNetworkFactory {
         Network network = Network.create("vsc", "test");
 
         // AC network: a generator and a load connected by an AC line.
-        Substation s1 = network.newSubstation()
-                .setId("S1")
-                .add();
-        VoltageLevel vl1 = s1.newVoltageLevel()
-                .setId("vl1")
-                .setNominalV(400.)
-                .setTopologyKind(TopologyKind.BUS_BREAKER)
-                .add();
-        vl1.getBusBreakerView().newBus()
-                .setId("b1")
-                .add();
-        vl1.newGenerator()
-                .setId("g1")
-                .setConnectableBus("b1")
-                .setBus("b1")
-                .setTargetP(100.)
-                .setTargetV(400.)
-                .setMinP(0)
-                .setMaxP(500)
-                .setVoltageRegulatorOn(true)
-                .add();
+        Bus b1 = createBus(network, "b1", 400);
+        createGenerator(b1, "g1", 100., 400).setVoltageRegulatorOn(true);
 
-        Substation s2 = network.newSubstation()
-                .setId("S2")
-                .add();
-        VoltageLevel vl2 = s2.newVoltageLevel()
-                .setId("vl2")
-                .setNominalV(400)
-                .setTopologyKind(TopologyKind.BUS_BREAKER)
-                .add();
-        vl2.getBusBreakerView().newBus()
-                .setId("b2")
-                .add();
-        vl2.newLoad()
-                .setId("ld2")
-                .setConnectableBus("b2")
-                .setBus("b2")
-                .setP0(100.0)
-                .setQ0(0.0)
-                .add();
+        Bus b2 = createBus(network, "b2", 400);
+        createLoad(b2, "ld2", 100, 0);
 
         network.newLine()
                 .setId("l12")
@@ -2514,6 +2479,7 @@ public class AcDcNetworkFactory extends AbstractLoadFlowNetworkFactory {
                 .setDcNode("dnGround")
                 .add();
 
+        VoltageLevel vl1 = b1.getVoltageLevel();
         vl1.newVoltageSourceConverter()
                 .setIdleLoss(0)
                 .setSwitchingLoss(0)
@@ -2531,6 +2497,7 @@ public class AcDcNetworkFactory extends AbstractLoadFlowNetworkFactory {
                 .add();
 
         // Droop-controlled converter (no losses so the law applies directly to AC power).
+        VoltageLevel vl2 = b2.getVoltageLevel();
         VoltageSourceConverter droopConverter = vl2.newVoltageSourceConverter()
                 .setIdleLoss(0)
                 .setSwitchingLoss(0)

--- a/src/test/java/com/powsybl/openloadflow/network/AcDcNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/AcDcNetworkFactory.java
@@ -2515,7 +2515,7 @@ public class AcDcNetworkFactory extends AbstractLoadFlowNetworkFactory {
                 .setReactivePowerSetpoint(0.0)
                 .add();
 
-        // 3-band droop curve: coefficient k (MW/kV) piecewise-constant over DC-voltage bands (kV).
+        // 3-band droop curve: coefficient k (kV/MW) piecewise-constant over DC-voltage bands (kV).
         droopConverter.newDroopCurve()
                 .beginSegment().setK(0.5).setMinV(380.).setMaxV(390.).endSegment()
                 .beginSegment().setK(1.0).setMinV(390.).setMaxV(410.).endSegment()

--- a/src/test/java/com/powsybl/openloadflow/network/AcDcNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/AcDcNetworkFactory.java
@@ -2441,7 +2441,7 @@ public class AcDcNetworkFactory extends AbstractLoadFlowNetworkFactory {
      * on the DC side and makes it possible for power transfer to be always balanced.
      *
      * convVdc (V_DC) pins the DC voltage; convDroop (P_PCC_DROOP) enforces
-     * {@code P = refP + k*(U_dc - refVdc)} with a 3-band droop curve. Sweeping convVdc's
+     * {@code P = refP + (U_dc - refVdc)/k} with a 3-band droop curve. Sweeping convVdc's
      * {@code targetVdc} walks convDroop's solved {@code U_dc} through each band of the curve and past
      * the extremes (clamping). convDroop has no losses so the droop law applies directly to its AC power.
      */

--- a/src/test/java/com/powsybl/openloadflow/network/AcDcNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/AcDcNetworkFactory.java
@@ -2516,6 +2516,12 @@ public class AcDcNetworkFactory extends AbstractLoadFlowNetworkFactory {
                 .add();
 
         // 3-band droop curve: coefficient k (kV/MW) piecewise-constant over DC-voltage bands (kV).
+        // Note that the droop curve has the following reference points because it is anchored
+        // at targetVdc = 400 kV, targetP = 50 MW
+        // V = 380 kV => P = 20 MW
+        // V = 390 kV => P = 40 MW
+        // V = 410 kV => P = 60 MW
+        // V = 420 kV => P = 65 MW
         droopConverter.newDroopCurve()
                 .beginSegment().setK(0.5).setMinV(380.).setMaxV(390.).endSegment()
                 .beginSegment().setK(1.0).setMinV(390.).setMaxV(410.).endSegment()

--- a/src/test/java/com/powsybl/openloadflow/network/AcDcNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/AcDcNetworkFactory.java
@@ -2440,7 +2440,7 @@ public class AcDcNetworkFactory extends AbstractLoadFlowNetworkFactory {
      * a generator on one side and a load on the other side. This configuration gives a full control
      * on the DC side and makes it possible for power transfer to be always balanced.
      *
-     * convVdc (V_DC) pins the DC voltage; convDroop (P_PCC_DROOP) enforces
+     * convVdc (V_DC) pins the DC voltage; convDroop (DC_DROOP) enforces
      * {@code P = refP + (U_dc - refVdc)/k} with a 3-band droop curve. Sweeping convVdc's
      * {@code targetVdc} walks convDroop's solved {@code U_dc} through each band of the curve and past
      * the extremes (clamping). convDroop has no losses so the droop law applies directly to its AC power.
@@ -2502,7 +2502,7 @@ public class AcDcNetworkFactory extends AbstractLoadFlowNetworkFactory {
                 .setIdleLoss(0)
                 .setSwitchingLoss(0)
                 .setResistiveLoss(0)
-                .setControlMode(AcDcConverter.ControlMode.P_PCC_DROOP)
+                .setControlMode(AcDcConverter.ControlMode.DC_DROOP)
                 .setTargetP(50.)
                 .setTargetVdc(400.)
                 .setId("convDroop")

--- a/src/test/resources/debug-network.xiidm
+++ b/src/test/resources/debug-network.xiidm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_17" xmlns:reft="http://www.powsybl.org/schema/iidm/ext/reference_terminals/1_0" id="test" caseDate="2021-04-25T13:47:34.697+02:00" forecastDistance="0" sourceFormat="code" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_18" xmlns:reft="http://www.powsybl.org/schema/iidm/ext/reference_terminals/1_0" id="test" caseDate="2021-04-25T13:47:34.697+02:00" forecastDistance="0" sourceFormat="code" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
     <iidm:substation id="b1_s" country="FR">
         <iidm:voltageLevel id="b1_vl" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #1464

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
For now, control mode is called P_PCC_DROOP. The idea was to get a different behavior for security analysis (droop) and regular load flow. This looks confusing. Instead of this behavior, the user will have to set the droop control mode explicitly. The name of the identifier will be changed in PowSyBl in a later activity (see https://github.com/powsybl/powsybl-core/pull/4067).

The new behavior presented in https://github.com/powsybl/powsybl-core/pull/4067 is already implemented here. We will need a tiny bump activity to the DC_DROOP identifier to finish the transition. This makes it possible to test the big activity (this one) first and keep the cosmetic one for the end.