### PR TITLE
Support HvdcAcEmulationLimits outer loop with parameter outerloopNames

### DIFF
--- a/docs/loadflow/parameters.md
+++ b/docs/loadflow/parameters.md
@@ -575,18 +575,20 @@ and then the `DistributedSlack` outerloop.
 
 For AC load flow the supported outer loop names, their default execution order, and their corresponding high-level parameter, are:
 1. `DistributedSlack` / `AreaInterchangeControl` (parameters: [`distributedSlack`](inv:powsyblcore:*:*:#param-lf-distributed-slack) / [`areaInterchangeControl`](#areainterchangecontrol))
-2. `SecondaryVoltageControl` (parameter: [`secondaryVoltageControl`](#secondaryvoltagecontrol))
-3. `VoltageMonitoring` (parameter: [`svcVoltageMonitoring`](#svcvoltagemonitoring))
-4. `ReactiveLimits` (parameter: [`useReactiveLimits`](inv:powsyblcore:*:*:#param-lf-use-reactive-limits))
-5. `PhaseControl` / `IncrementalPhaseControl` (parameters: [`phaseShifterRegulationOn`](inv:powsyblcore:*:*:#param-lf-phase-shifter-regulation-on) and [`phaseShifterControlMode`](#phaseshiftercontrolmode))
-6. `SimpleTransformerVoltageControl` / `TransformerVoltageControl` / `IncrementalTransformerVoltageControl` (parameters: [`transformerVoltageControlOn`](inv:powsyblcore:*:*:#param-lf-transformer-voltage-control-on) and [`transformerVoltageControlMode`](#transformervoltagecontrolmode))
-7. `IncrementalTransformerReactivePowerControl` (parameter: [`transformerReactivePowerControl`](#transformerreactivepowercontrol))
-8. `ShuntVoltageControl` / `IncrementalShuntVoltageControl` (parameters: [`shuntCompensatorVoltageControlOn`](inv:powsyblcore:*:*:#param-lf-shunt-compensator-voltage-control-on) and [`shuntVoltageControlMode`](#shuntvoltagecontrolmode))
-9. `AutomationSystem` (parameter: [`simulateAutomationSystems`](#simulateautomationsystems))
+2. `HvdcAcEmulationLimits` (parameter: [`hvdcAcEmulation`](inv:powsyblcore:*:*:#param-lf-hvdc-ac-emulation))
+3. `SecondaryVoltageControl` (parameter: [`secondaryVoltageControl`](#secondaryvoltagecontrol))
+4. `VoltageMonitoring` (parameter: [`svcVoltageMonitoring`](#svcvoltagemonitoring))
+5. `ReactiveLimits` (parameter: [`useReactiveLimits`](inv:powsyblcore:*:*:#param-lf-use-reactive-limits))
+6. `PhaseControl` / `IncrementalPhaseControl` (parameters: [`phaseShifterRegulationOn`](inv:powsyblcore:*:*:#param-lf-phase-shifter-regulation-on) and [`phaseShifterControlMode`](#phaseshiftercontrolmode))
+7. `SimpleTransformerVoltageControl` / `TransformerVoltageControl` / `IncrementalTransformerVoltageControl` (parameters: [`transformerVoltageControlOn`](inv:powsyblcore:*:*:#param-lf-transformer-voltage-control-on) and [`transformerVoltageControlMode`](#transformervoltagecontrolmode))
+8. `IncrementalTransformerReactivePowerControl` (parameter: [`transformerReactivePowerControl`](#transformerreactivepowercontrol))
+9. `ShuntVoltageControl` / `IncrementalShuntVoltageControl` (parameters: [`shuntCompensatorVoltageControlOn`](inv:powsyblcore:*:*:#param-lf-shunt-compensator-voltage-control-on) and [`shuntVoltageControlMode`](#shuntvoltagecontrolmode))
+10. `AutomationSystem` (parameter: [`simulateAutomationSystems`](#simulateautomationsystems))
 
 And for DC load flow:
-1. `IncrementalPhaseControl` (parameter: [`phaseShifterRegulationOn`](inv:powsyblcore:*:*:#param-lf-phase-shifter-regulation-on))
-2. `AreaInterchangeControl` (parameter: [`areaInterchangeControl`](#areainterchangecontrol))
+1. `HvdcAcEmulationLimits` (parameter: [`hvdcAcEmulation`](inv:powsyblcore:*:*:#param-lf-hvdc-ac-emulation))
+2. `IncrementalPhaseControl` (parameter: [`phaseShifterRegulationOn`](inv:powsyblcore:*:*:#param-lf-phase-shifter-regulation-on))
+3. `AreaInterchangeControl` (parameter: [`areaInterchangeControl`](#areainterchangecontrol))
 
 (param-lf-line-per-unit-mode)=
 ### linePerUnitMode

--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcHvdcAcEmulationLimitsOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/AcHvdcAcEmulationLimitsOuterLoop.java
@@ -29,12 +29,6 @@ public class AcHvdcAcEmulationLimitsOuterLoop
         implements AcOuterLoop {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AcHvdcAcEmulationLimitsOuterLoop.class);
-    public static final String NAME = "AcHvdcAcEmulationLimits";
-
-    @Override
-    public String getName() {
-        return NAME;
-    }
 
     @Override
     public OuterLoopResult check(AcOuterLoopContext context, ReportNode reportNode) {

--- a/src/main/java/com/powsybl/openloadflow/dc/DcHvdcAcEmulationLimitsOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcHvdcAcEmulationLimitsOuterLoop.java
@@ -26,12 +26,6 @@ public class DcHvdcAcEmulationLimitsOuterLoop
         implements DcOuterLoop {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DcHvdcAcEmulationLimitsOuterLoop.class);
-    public static final String NAME = "DcHvdcAcEmulationLimits";
-
-    @Override
-    public String getName() {
-        return NAME;
-    }
 
     @Override
     public OuterLoopResult check(DcOuterLoopContext context, ReportNode reportNode) {

--- a/src/main/java/com/powsybl/openloadflow/lf/outerloop/AbstractHvdcAcEmulationLimitsOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/outerloop/AbstractHvdcAcEmulationLimitsOuterLoop.java
@@ -28,7 +28,14 @@ public abstract class AbstractHvdcAcEmulationLimitsOuterLoop<V extends Enum<V> &
         C extends LoadFlowContext<V, E, P>,
         O extends OuterLoopContext<V, E, P, C>> implements OuterLoop<V, E, P, C, O> {
 
+    public static final String NAME = "HvdcAcEmulationLimits";
+
     protected AbstractHvdcAcEmulationLimitsOuterLoop() { }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
 
     protected static boolean checkAcEmulationMode(LfHvdc hvdc, boolean computeLoss, Logger logger, ReportNode reportNode) {
         LfHvdc.AcEmulationControl acEmulationControl = hvdc.getAcEmulationControl();

--- a/src/main/java/com/powsybl/openloadflow/lf/outerloop/config/AbstractAcOuterLoopConfig.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/outerloop/config/AbstractAcOuterLoopConfig.java
@@ -54,7 +54,7 @@ public abstract class AbstractAcOuterLoopConfig implements AcOuterLoopConfig {
         return Optional.empty();
     }
 
-    protected static Optional<AcOuterLoop> createAcHvdcAcEmulationLimitsOuterLoop(LoadFlowParameters parameters) {
+    protected static Optional<AcOuterLoop> createHvdcAcEmulationLimitsOuterLoop(LoadFlowParameters parameters) {
         if (parameters.isHvdcAcEmulation()) {
             return Optional.of(new AcHvdcAcEmulationLimitsOuterLoop());
         }

--- a/src/main/java/com/powsybl/openloadflow/lf/outerloop/config/AbstractDcOuterLoopConfig.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/outerloop/config/AbstractDcOuterLoopConfig.java
@@ -52,7 +52,7 @@ public abstract class AbstractDcOuterLoopConfig implements DcOuterLoopConfig {
         return Optional.empty();
     }
 
-    protected static Optional<DcOuterLoop> createDcHvdcAcEmulationLimitsOuterLoop(LoadFlowParameters parameters) {
+    protected static Optional<DcOuterLoop> createHvdcAcEmulationLimitsOuterLoop(LoadFlowParameters parameters) {
         if (parameters.isHvdcAcEmulation()) {
             return Optional.of(new DcHvdcAcEmulationLimitsOuterLoop());
         }

--- a/src/main/java/com/powsybl/openloadflow/lf/outerloop/config/DefaultAcOuterLoopConfig.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/outerloop/config/DefaultAcOuterLoopConfig.java
@@ -33,7 +33,7 @@ public class DefaultAcOuterLoopConfig extends AbstractAcOuterLoopConfig {
         // freezing hvdc in AC emulation
         createFreezingHvdcACEmulationOuterLoop(parametersExt).ifPresent(outerLoops::add);
         // AC emulation
-        createAcHvdcAcEmulationLimitsOuterLoop(parameters).ifPresent(outerLoops::add);
+        createHvdcAcEmulationLimitsOuterLoop(parameters).ifPresent(outerLoops::add);
         // area interchange control
         createAreaInterchangeControlOuterLoop(parameters, parametersExt, loadFlowParametersOverride).ifPresent(outerLoops::add);
         // secondary voltage control

--- a/src/main/java/com/powsybl/openloadflow/lf/outerloop/config/DefaultDcOuterLoopConfig.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/outerloop/config/DefaultDcOuterLoopConfig.java
@@ -29,7 +29,7 @@ public class DefaultDcOuterLoopConfig extends AbstractDcOuterLoopConfig {
     public List<DcOuterLoop> configure(LoadFlowParameters parameters, OpenLoadFlowParameters parametersExt, LoadFlowParametersOverride loadFlowParametersOverride) {
         List<DcOuterLoop> outerLoops = new ArrayList<>(2);
         // ac emulation
-        createDcHvdcAcEmulationLimitsOuterLoop(parameters).ifPresent(outerLoops::add);
+        createHvdcAcEmulationLimitsOuterLoop(parameters).ifPresent(outerLoops::add);
         // incremental phase control
         createIncrementalPhaseControlOuterLoop(parameters).ifPresent(outerLoops::add);
         // area interchange control

--- a/src/main/java/com/powsybl/openloadflow/lf/outerloop/config/ExplicitAcOuterLoopConfig.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/outerloop/config/ExplicitAcOuterLoopConfig.java
@@ -13,6 +13,7 @@ import com.powsybl.openloadflow.LoadFlowParametersOverride;
 import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.ac.outerloop.*;
 import com.powsybl.openloadflow.lf.outerloop.AbstractAreaInterchangeControlOuterLoop;
+import com.powsybl.openloadflow.lf.outerloop.AbstractHvdcAcEmulationLimitsOuterLoop;
 import com.powsybl.openloadflow.lf.outerloop.AbstractIncrementalPhaseControlOuterLoop;
 import com.powsybl.openloadflow.lf.outerloop.OuterLoop;
 
@@ -41,7 +42,8 @@ public class ExplicitAcOuterLoopConfig extends AbstractAcOuterLoopConfig {
                                                      AutomationSystemOuterLoop.NAME,
                                                      IncrementalTransformerReactivePowerControlOuterLoop.NAME,
                                                      AbstractAreaInterchangeControlOuterLoop.NAME,
-                                                     FreezingHvdcACEmulationOuterloop.NAME);
+                                                     FreezingHvdcACEmulationOuterloop.NAME,
+                                                     AbstractHvdcAcEmulationLimitsOuterLoop.NAME);
 
     private static Optional<AcOuterLoop> createOuterLoop(String name, LoadFlowParameters parameters, OpenLoadFlowParameters parametersExt, LoadFlowParametersOverride loadFlowParametersOverride) {
         return switch (name) {
@@ -78,6 +80,7 @@ public class ExplicitAcOuterLoopConfig extends AbstractAcOuterLoopConfig {
             case IncrementalTransformerReactivePowerControlOuterLoop.NAME -> createTransformerReactivePowerControlOuterLoop(parametersExt);
             case AbstractAreaInterchangeControlOuterLoop.NAME -> createAreaInterchangeControlOuterLoop(parameters, parametersExt, loadFlowParametersOverride);
             case FreezingHvdcACEmulationOuterloop.NAME -> createFreezingHvdcACEmulationOuterLoop(parametersExt);
+            case AbstractHvdcAcEmulationLimitsOuterLoop.NAME -> createHvdcAcEmulationLimitsOuterLoop(parameters);
             default -> throw new PowsyblException("Unknown outer loop '" + name + "' for AC load flow");
         };
     }

--- a/src/main/java/com/powsybl/openloadflow/lf/outerloop/config/ExplicitDcOuterLoopConfig.java
+++ b/src/main/java/com/powsybl/openloadflow/lf/outerloop/config/ExplicitDcOuterLoopConfig.java
@@ -13,6 +13,7 @@ import com.powsybl.openloadflow.LoadFlowParametersOverride;
 import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.dc.DcOuterLoop;
 import com.powsybl.openloadflow.lf.outerloop.AbstractAreaInterchangeControlOuterLoop;
+import com.powsybl.openloadflow.lf.outerloop.AbstractHvdcAcEmulationLimitsOuterLoop;
 import com.powsybl.openloadflow.lf.outerloop.AbstractIncrementalPhaseControlOuterLoop;
 
 import java.util.List;
@@ -25,12 +26,14 @@ import java.util.Optional;
 public class ExplicitDcOuterLoopConfig extends AbstractDcOuterLoopConfig {
 
     public static final List<String> NAMES = List.of(AbstractIncrementalPhaseControlOuterLoop.NAME,
-                                                        AbstractAreaInterchangeControlOuterLoop.NAME);
+                                                        AbstractAreaInterchangeControlOuterLoop.NAME,
+                                                        AbstractHvdcAcEmulationLimitsOuterLoop.NAME);
 
     private static Optional<DcOuterLoop> createOuterLoop(String name, LoadFlowParameters parameters, OpenLoadFlowParameters parametersExt, LoadFlowParametersOverride loadFlowParametersOverride) {
         return switch (name) {
             case AbstractIncrementalPhaseControlOuterLoop.NAME -> createIncrementalPhaseControlOuterLoop(parameters);
             case AbstractAreaInterchangeControlOuterLoop.NAME -> createAreaInterchangeControlOuterLoop(parameters, parametersExt, loadFlowParametersOverride);
+            case AbstractHvdcAcEmulationLimitsOuterLoop.NAME -> createHvdcAcEmulationLimitsOuterLoop(parameters);
             default -> throw new PowsyblException("Unknown outer loop '" + name + "' for DC load flow");
         };
     }

--- a/src/test/java/com/powsybl/openloadflow/OpenLoadFlowParametersTest.java
+++ b/src/test/java/com/powsybl/openloadflow/OpenLoadFlowParametersTest.java
@@ -570,7 +570,7 @@ class OpenLoadFlowParametersTest {
         OpenLoadFlowParameters parametersExt = new OpenLoadFlowParameters()
                 .setSecondaryVoltageControl(true);
 
-        assertEquals(List.of("DistributedSlack", "AcHvdcAcEmulationLimits", "SecondaryVoltageControl", "VoltageMonitoring", "ReactiveLimits", "ShuntVoltageControl"),
+        assertEquals(List.of("DistributedSlack", "HvdcAcEmulationLimits", "SecondaryVoltageControl", "VoltageMonitoring", "ReactiveLimits", "ShuntVoltageControl"),
             OpenLoadFlowParameters.createAcOuterLoops(parameters, parametersExt).stream().map(OuterLoop::getType).toList());
 
         parametersExt.setOuterLoopNames(List.of("ReactiveLimits", "SecondaryVoltageControl"));
@@ -588,8 +588,8 @@ class OpenLoadFlowParametersTest {
         assertEquals("Ordered explicit list of outer loop names, supported outer loops are for AC : [IncrementalPhaseControl, " +
                 "DistributedSlack, IncrementalShuntVoltageControl, IncrementalTransformerVoltageControl, VoltageMonitoring, PhaseControl, " +
                 "ReactiveLimits, SecondaryVoltageControl, ShuntVoltageControl, SimpleTransformerVoltageControl, TransformerVoltageControl, " +
-                "AutomationSystem, IncrementalTransformerReactivePowerControl, AreaInterchangeControl, FreezingHvdcACEmulation], and for DC : " +
-                "[IncrementalPhaseControl, AreaInterchangeControl]",
+                "AutomationSystem, IncrementalTransformerReactivePowerControl, AreaInterchangeControl, FreezingHvdcACEmulation, HvdcAcEmulationLimits], " +
+                "and for DC : [IncrementalPhaseControl, AreaInterchangeControl, HvdcAcEmulationLimits]",
             OpenLoadFlowParameters.SPECIFIC_PARAMETERS.stream().filter(p -> p.getName().equals(OpenLoadFlowParameters.OUTER_LOOP_NAMES_PARAM_NAME)).findFirst().orElseThrow().getDescription());
     }
 
@@ -600,11 +600,14 @@ class OpenLoadFlowParametersTest {
         OpenLoadFlowParameters parametersExt = new OpenLoadFlowParameters()
                 .setAreaInterchangeControl(true);
 
-        assertEquals(List.of("DcHvdcAcEmulationLimits", "IncrementalPhaseControl", "AreaInterchangeControl"),
+        assertEquals(List.of("HvdcAcEmulationLimits", "IncrementalPhaseControl", "AreaInterchangeControl"),
             OpenLoadFlowParameters.createDcOuterLoops(parameters, parametersExt).stream().map(OuterLoop::getName).toList());
 
         parametersExt.setOuterLoopNames(List.of("IncrementalPhaseControl"));
         assertEquals(List.of("IncrementalPhaseControl"), OpenLoadFlowParameters.createDcOuterLoops(parameters, parametersExt).stream().map(OuterLoop::getName).toList());
+
+        parametersExt.setOuterLoopNames(List.of("IncrementalPhaseControl", "HvdcAcEmulationLimits"));
+        assertEquals(List.of("IncrementalPhaseControl", "HvdcAcEmulationLimits"), OpenLoadFlowParameters.createDcOuterLoops(parameters, parametersExt).stream().map(OuterLoop::getName).toList());
 
         parametersExt.setOuterLoopNames(List.of("IncrementalPhaseControl", "DistributedSlack"));
         PowsyblException e = assertThrows(PowsyblException.class, () -> OpenLoadFlowParameters.createDcOuterLoops(parameters, parametersExt));
@@ -617,11 +620,11 @@ class OpenLoadFlowParametersTest {
                 .setDistributedSlack(true);
         OpenLoadFlowParameters parametersExt = new OpenLoadFlowParameters();
 
-        assertEquals(List.of("DistributedSlack", "AcHvdcAcEmulationLimits", "VoltageMonitoring", "ReactiveLimits"),
+        assertEquals(List.of("DistributedSlack", "HvdcAcEmulationLimits", "VoltageMonitoring", "ReactiveLimits"),
             OpenLoadFlowParameters.createAcOuterLoops(parameters, parametersExt).stream().map(OuterLoop::getType).toList());
 
         parametersExt.setAreaInterchangeControl(true);
-        assertEquals(List.of("AcHvdcAcEmulationLimits", "AreaInterchangeControl", "VoltageMonitoring", "ReactiveLimits"),
+        assertEquals(List.of("HvdcAcEmulationLimits", "AreaInterchangeControl", "VoltageMonitoring", "ReactiveLimits"),
             OpenLoadFlowParameters.createAcOuterLoops(parameters, parametersExt).stream().map(OuterLoop::getType).toList());
 
         parametersExt.setOuterLoopNames(List.of("DistributedSlack", "AreaInterchangeControl"));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
**HvdcAcEmulationLimits** was missing in the supported outer loop names for the parameter **outerloopNames**


**What is the current behavior?**
Missing

**What is the new behavior (if this is a feature change)?**
**HvdcAcEmulatioLimits** outer loop can be used in a specific outer loop order configuration


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
