### PR TITLE
Security Analysis Monitors: report disabled elements as NaN instead of omitting them

### DIFF
--- a/docs/security/parameters.md
+++ b/docs/security/parameters.md
@@ -59,8 +59,8 @@ The `dcFastMode` property allows to use fast DC security analysis, based on Wood
 when DC mode is activated.
 
 Please note that fast mode has a few limitations:
-- Contingencies applied on branches opened on one side are ignored. Also, if a contingency causes the loss of one side of a branch, 
-it is considered completely disabled, and no results are reported for this branch.
+- Contingencies applied on branches opened on one side are ignored. Also, if a contingency causes the loss of one side of a branch,
+it is considered completely disabled, and NaN values are reported for this branch instead of a computed flow.
 - AC emulation of HVDC lines is disabled, as it is not yet supported.
 Instead, the [active power setpoint](../loadflow/loadflow.md#computing-hvdc-power-flow) mode is used to control the active power flow through these lines. 
 - Only PST and topological (except for transformer closing) remedial actions are supported for now.

--- a/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfBranch.java
@@ -12,6 +12,7 @@ import com.powsybl.iidm.network.LimitType;
 import com.powsybl.iidm.network.LoadingLimits;
 import com.powsybl.iidm.network.ThreeSides;
 import com.powsybl.iidm.network.TwoSides;
+import com.powsybl.openloadflow.network.impl.OlfBranchResult;
 import com.powsybl.openloadflow.sa.LimitReductionManager;
 import com.powsybl.openloadflow.util.Evaluable;
 import com.powsybl.openloadflow.util.PerUnit;
@@ -331,6 +332,25 @@ public interface LfBranch extends LfElement {
     List<BranchResult> createBranchResult(double preContingencyBranchP1, double preContingencyBranchOfContingencyP1,
                                           boolean createExtension, Map<String, LfBranchResults> zeroImpedanceFlows,
                                           LoadFlowModel loadFlowModel);
+
+    /**
+     * Builds the branch result to report when this branch is disabled (by a contingency, or already at N-state):
+     * P1/Q1/I1/P2/Q2/I2/flowTransfer are all NaN.
+     */
+    default List<BranchResult> createDisabledBranchResult(boolean createExtension) {
+        BranchResult result = new BranchResult(getId(), Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
+        if (createExtension) {
+            LfBus bus1 = getBus1();
+            LfBus bus2 = getBus2();
+            PiModel piModel = getPiModel();
+            result.addExtension(OlfBranchResult.class, new OlfBranchResult(piModel.getR1(), piModel.getContinuousR1(),
+                    bus1 != null ? bus1.getV() * bus1.getNominalV() : Double.NaN,
+                    bus2 != null ? bus2.getV() * bus2.getNominalV() : Double.NaN,
+                    bus1 != null ? Math.toDegrees(bus1.getAngle()) : Double.NaN,
+                    bus2 != null ? Math.toDegrees(bus2.getAngle()) : Double.NaN));
+        }
+        return List.of(result);
+    }
 
     double computeApparentPower1();
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBoundaryLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBoundaryLineBranch.java
@@ -81,6 +81,12 @@ public class LfBoundaryLineBranch extends AbstractImpedantLfBranch {
         return List.of(buildBranchResult(loadFlowModel, zeroImpedanceFlows, currentScale, currentScale, Double.NaN, Double.NaN));
     }
 
+    @Override
+    public List<BranchResult> createDisabledBranchResult(boolean createExtension) {
+        // no extension for boundary lines, same as the enabled-path createBranchResult above
+        return List.of(new BranchResult(getId(), Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN));
+    }
+
     private <T extends LoadingLimits> Supplier<Map<String, T>> toMapIndexedByOperationalLimitsGroupId(Function<OperationalLimitsGroup, Optional<T>> limitsGetter) {
         return () -> getBoundaryLine()
                 .getAllSelectedOperationalLimitsGroups()

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfBusImpl.java
@@ -168,17 +168,19 @@ public class LfBusImpl extends AbstractLfBus {
     @Override
     public List<BusResult> createBusResults() {
         var bus = getBus();
+        double reportedV = isDisabled() ? Double.NaN : v;
+        double reportedAngle = isDisabled() ? Double.NaN : Math.toDegrees(angle);
         if (breakers) {
             if (bbsIds.isEmpty()) {
-                return List.of(new BusResult(getVoltageLevelId(), bus.getId(), v, Math.toDegrees(angle)));
+                return List.of(new BusResult(getVoltageLevelId(), bus.getId(), reportedV, reportedAngle));
             } else {
                 return bbsIds.stream()
-                        .map(bbsId -> new BusResult(getVoltageLevelId(), bbsId, v, Math.toDegrees(angle)))
+                        .map(bbsId -> new BusResult(getVoltageLevelId(), bbsId, reportedV, reportedAngle))
                         .collect(Collectors.toList());
             }
         } else {
             return bus.getVoltageLevel().getBusBreakerView().getBusesFromBusViewBusId(bus.getId())
-                    .stream().map(b -> new BusResult(getVoltageLevelId(), b.getId(), v, Math.toDegrees(angle))).collect(Collectors.toList());
+                    .stream().map(b -> new BusResult(getVoltageLevelId(), b.getId(), reportedV, reportedAngle)).collect(Collectors.toList());
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfLegBranch.java
@@ -224,26 +224,52 @@ public final class LfLegBranch extends AbstractImpedantLfBranch {
         LfLegBranch leg2 = (LfLegBranch) network.getBranchById(LfLegBranch.getId(threeWindingsTransformerId, 2));
         LfLegBranch leg3 = (LfLegBranch) network.getBranchById(LfLegBranch.getId(threeWindingsTransformerId, 3));
 
-        double i1Base = PerUnit.ib(leg1.legRef.get().getTerminal().getVoltageLevel().getNominalV());
-        double i2Base = PerUnit.ib(leg2.legRef.get().getTerminal().getVoltageLevel().getNominalV());
-        double i3Base = PerUnit.ib(leg3.legRef.get().getTerminal().getVoltageLevel().getNominalV());
+        // when the star bus is disabled, the legs' flows are meaningless (their equations are out of the system):
+        // report NaN for P/Q/I, but the extension below still reads each leg's live network-side terminal bus,
+        // which is not implied disabled by the star bus being disabled.
+        boolean disabled = network.getBusById(LfStarBus.getId(threeWindingsTransformerId)).isDisabled();
 
-        LfBranchResults legBranchResults1 = leg1.isZeroImpedance(loadFlowModel) ? zeroImpedanceFlows.get(leg1.getId())
-                : extractLegBranchResults(leg1);
-        LfBranchResults legBranchResults2 = leg2.isZeroImpedance(loadFlowModel) ? zeroImpedanceFlows.get(leg2.getId())
-                : extractLegBranchResults(leg2);
-        LfBranchResults legBranchResults3 = leg3.isZeroImpedance(loadFlowModel) ? zeroImpedanceFlows.get(leg3.getId())
-                : extractLegBranchResults(leg3);
+        double flowP1;
+        double flowP2;
+        double flowP3;
+        double flowQ1;
+        double flowQ2;
+        double flowQ3;
+        double currentI1;
+        double currentI2;
+        double currentI3;
+        if (disabled) {
+            flowP1 = Double.NaN;
+            flowP2 = Double.NaN;
+            flowP3 = Double.NaN;
+            flowQ1 = Double.NaN;
+            flowQ2 = Double.NaN;
+            flowQ3 = Double.NaN;
+            currentI1 = Double.NaN;
+            currentI2 = Double.NaN;
+            currentI3 = Double.NaN;
+        } else {
+            double i1Base = PerUnit.ib(leg1.legRef.get().getTerminal().getVoltageLevel().getNominalV());
+            double i2Base = PerUnit.ib(leg2.legRef.get().getTerminal().getVoltageLevel().getNominalV());
+            double i3Base = PerUnit.ib(leg3.legRef.get().getTerminal().getVoltageLevel().getNominalV());
 
-        double flowP1 = legBranchResults1.p1() * PerUnit.SB;
-        double flowP2 = legBranchResults2.p1() * PerUnit.SB;
-        double flowP3 = legBranchResults3.p1() * PerUnit.SB;
-        double flowQ1 = legBranchResults1.q1() * PerUnit.SB;
-        double flowQ2 = legBranchResults2.q1() * PerUnit.SB;
-        double flowQ3 = legBranchResults3.q1() * PerUnit.SB;
-        double currentI1 = legBranchResults1.i1() * i1Base;
-        double currentI2 = legBranchResults2.i1() * i2Base;
-        double currentI3 = legBranchResults3.i1() * i3Base;
+            LfBranchResults legBranchResults1 = leg1.isZeroImpedance(loadFlowModel) ? zeroImpedanceFlows.get(leg1.getId())
+                    : extractLegBranchResults(leg1);
+            LfBranchResults legBranchResults2 = leg2.isZeroImpedance(loadFlowModel) ? zeroImpedanceFlows.get(leg2.getId())
+                    : extractLegBranchResults(leg2);
+            LfBranchResults legBranchResults3 = leg3.isZeroImpedance(loadFlowModel) ? zeroImpedanceFlows.get(leg3.getId())
+                    : extractLegBranchResults(leg3);
+
+            flowP1 = legBranchResults1.p1() * PerUnit.SB;
+            flowP2 = legBranchResults2.p1() * PerUnit.SB;
+            flowP3 = legBranchResults3.p1() * PerUnit.SB;
+            flowQ1 = legBranchResults1.q1() * PerUnit.SB;
+            flowQ2 = legBranchResults2.q1() * PerUnit.SB;
+            flowQ3 = legBranchResults3.q1() * PerUnit.SB;
+            currentI1 = legBranchResults1.i1() * i1Base;
+            currentI2 = legBranchResults2.i1() * i2Base;
+            currentI3 = legBranchResults3.i1() * i3Base;
+        }
 
         ThreeWindingsTransformerResult result = new ThreeWindingsTransformerResult(threeWindingsTransformerId,
                 flowP1, flowQ1, currentI1, flowP2, flowQ2, currentI2, flowP3, flowQ3, currentI3);

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfTieLineBranch.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfTieLineBranch.java
@@ -103,6 +103,25 @@ public class LfTieLineBranch extends AbstractImpedantLfBranch {
         return List.of(branchResult, half1Result, half2Result); // make sure to put the tie-line first in the list, used in post-contingency flow filtering
     }
 
+    @Override
+    public List<BranchResult> createDisabledBranchResult(boolean createExtension) {
+        double nominalV1 = getHalf1().getTerminal().getVoltageLevel().getNominalV();
+        double nominalV2 = getHalf2().getTerminal().getVoltageLevel().getNominalV();
+
+        var branchResult = new BranchResult(getId(), Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
+        var half1Result = new BranchResult(getHalf1().getId(), Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
+        var half2Result = new BranchResult(getHalf2().getId(), Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
+        if (createExtension) {
+            branchResult.addExtension(OlfBranchResult.class, new OlfBranchResult(piModel.getR1(), piModel.getContinuousR1(),
+                    getV1() * nominalV1, getV2() * nominalV2, Math.toDegrees(getAngle1()), Math.toDegrees(getAngle2())));
+            half1Result.addExtension(OlfBranchResult.class, new OlfBranchResult(piModel.getR1(), piModel.getContinuousR1(),
+                    getV1() * nominalV1, Double.NaN, Math.toDegrees(getAngle1()), Double.NaN));
+            half2Result.addExtension(OlfBranchResult.class, new OlfBranchResult(piModel.getR1(), piModel.getContinuousR1(),
+                    Double.NaN, getV2() * nominalV2, Double.NaN, Math.toDegrees(getAngle2())));
+        }
+        return List.of(branchResult, half1Result, half2Result);
+    }
+
     private <T extends LoadingLimits> Supplier<Map<String, T>> toMapIndexedByOperationalLimitsGroupId(Function<OperationalLimitsGroup, Optional<T>> limitsGetter, TwoSides side) {
         return () -> (side == TwoSides.ONE ? getHalf1() : getHalf2())
                 .getAllSelectedOperationalLimitsGroups()

--- a/src/main/java/com/powsybl/openloadflow/sa/AbstractNetworkResult.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/AbstractNetworkResult.java
@@ -19,7 +19,6 @@ import com.powsybl.security.results.ThreeWindingsTransformerResult;
 
 import java.util.*;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 
 import static com.powsybl.openloadflow.network.LfBranch.BranchType.TRANSFO_3_LEG_1;
 import static com.powsybl.openloadflow.network.LfBranch.BranchType.TRANSFO_3_LEG_2;
@@ -56,12 +55,11 @@ public abstract class AbstractNetworkResult {
         this.dcPowerFactor = dcPowerFactor;
     }
 
-    protected void addResults(StateMonitor monitor, Consumer<LfBranch> branchConsumer, Predicate<LfBranch> isBranchDisabled,
+    protected void addResults(StateMonitor monitor, Consumer<LfBranch> branchConsumer,
                               Consumer<LfBus> busConsumer, Consumer<String> threeWindingsTransformerResultsConsumer) {
         Objects.requireNonNull(monitor);
         if (!monitor.getBranchIds().isEmpty()) {
             network.getBranches().stream()
-                    .filter(lfBranch -> !isBranchDisabled.test(lfBranch))
                     .forEach(lfBranch -> {
                         for (String originalId : lfBranch.getOriginalIds()) {
                             if (monitor.getBranchIds().contains(originalId)) {
@@ -75,13 +73,12 @@ public abstract class AbstractNetworkResult {
         if (!monitor.getVoltageLevelIds().isEmpty()) {
             network.getBuses().stream()
                     .filter(lfBus -> monitor.getVoltageLevelIds().contains(lfBus.getVoltageLevelId()))
-                    .filter(lfBus -> !lfBus.isDisabled())
                     .forEach(busConsumer);
         }
 
         if (!monitor.getThreeWindingsTransformerIds().isEmpty()) {
             monitor.getThreeWindingsTransformerIds().stream()
-                    .filter(id -> network.getBusById(LfStarBus.getId(id)) != null && !network.getBusById(LfStarBus.getId(id)).isDisabled())
+                    .filter(id -> network.getBusById(LfStarBus.getId(id)) != null)
                     .forEach(threeWindingsTransformerResultsConsumer);
         }
     }

--- a/src/main/java/com/powsybl/openloadflow/sa/PostContingencyNetworkResult.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/PostContingencyNetworkResult.java
@@ -52,34 +52,50 @@ public class PostContingencyNetworkResult extends AbstractNetworkResult {
     }
 
     public void addResults(StateMonitor monitor, Predicate<LfBranch> isBranchDisabled, Map<String, LfBranch.LfBranchResults> zeroImpedanceFlows) {
-        addResults(monitor, branch -> createBranchResults(branch, zeroImpedanceFlows), isBranchDisabled,
+        addResults(monitor, branch -> createBranchResults(branch, isBranchDisabled.test(branch), zeroImpedanceFlows),
                 this::createBusResults, id -> create3WTransformerResults(id, zeroImpedanceFlows));
     }
 
-    private void createBranchResults(LfBranch branch, Map<String, LfBranch.LfBranchResults> zeroImpedanceFlows) {
+    private void createBranchResults(LfBranch branch, boolean disabled, Map<String, LfBranch.LfBranchResults> zeroImpedanceFlows) {
         var preContingencyBranchResult = preContingencyMonitorInfos.getBranchResult(branch.getId());
-        double preContingencyBranchP1 = preContingencyBranchResult != null ? preContingencyBranchResult.getP1() : Double.NaN;
-        double preContingencyBranchOfContingencyP1 = Double.NaN;
-        if (contingency.getElements().size() == 1) {
-            ContingencyElement contingencyElement = contingency.getElements().getFirst();
-            if (contingencyElement.getType() == ContingencyElementType.BRANCH
-                    || contingencyElement.getType() == ContingencyElementType.LINE
-                    || contingencyElement.getType() == ContingencyElementType.BOUNDARY_LINE
-                    || contingencyElement.getType() == ContingencyElementType.TWO_WINDINGS_TRANSFORMER) {
-                BranchResult preContingencyBranchOfContingencyResult = preContingencyMonitorInfos.getBranchResult(contingencyElement.getId());
-                if (preContingencyBranchOfContingencyResult != null) {
-                    preContingencyBranchOfContingencyP1 = preContingencyBranchOfContingencyResult.getP1();
+        List<BranchResult> results;
+        if (disabled) {
+            results = branch.createDisabledBranchResult(createResultExtension);
+        } else {
+            double preContingencyBranchP1 = preContingencyBranchResult != null ? preContingencyBranchResult.getP1() : Double.NaN;
+            double preContingencyBranchOfContingencyP1 = Double.NaN;
+            if (contingency.getElements().size() == 1) {
+                ContingencyElement contingencyElement = contingency.getElements().getFirst();
+                if (contingencyElement.getType() == ContingencyElementType.BRANCH
+                        || contingencyElement.getType() == ContingencyElementType.LINE
+                        || contingencyElement.getType() == ContingencyElementType.BOUNDARY_LINE
+                        || contingencyElement.getType() == ContingencyElementType.TWO_WINDINGS_TRANSFORMER) {
+                    BranchResult preContingencyBranchOfContingencyResult = preContingencyMonitorInfos.getBranchResult(contingencyElement.getId());
+                    if (preContingencyBranchOfContingencyResult != null) {
+                        preContingencyBranchOfContingencyP1 = preContingencyBranchOfContingencyResult.getP1();
+                    }
                 }
             }
+            results = branch.createBranchResult(preContingencyBranchP1, preContingencyBranchOfContingencyP1, createResultExtension, zeroImpedanceFlows, loadFlowModel);
         }
-        List<BranchResult> results = branch.createBranchResult(preContingencyBranchP1, preContingencyBranchOfContingencyP1, createResultExtension, zeroImpedanceFlows, loadFlowModel);
         BranchResult postContingencyBranchResult = results.getFirst(); // getFirst for the tie-line case, all others have only one BranchResult
         if (changed(preContingencyBranchResult, postContingencyBranchResult)) {
             branchResults.addAll(results);
         }
     }
 
+    /**
+     * A threshold of zero or less disables filtering unconditionally: every value is reported regardless of
+     * whether it changed. Above zero: both values absent (disabled at both states) is not a change; exactly one
+     * value absent (got disabled, or got re-enabled) is always a change; otherwise compare against the threshold.
+     */
     private static boolean changed(double pre, double post, double threshold) {
+        if (threshold <= 0) {
+            return true;
+        }
+        if (Double.isNaN(pre) && Double.isNaN(post)) {
+            return false;
+        }
         return Double.isNaN(pre) || Double.isNaN(post) || Math.abs(pre - post) > threshold;
     }
 
@@ -89,8 +105,7 @@ public class PostContingencyNetworkResult extends AbstractNetworkResult {
         }
         Objects.requireNonNull(postCtg);
         double threshold = modifiedMonitoredElementsParameters.getPowerModificationThreshold();
-        return threshold <= 0
-            || changed(preCtg.getP1(), postCtg.getP1(), threshold)
+        return changed(preCtg.getP1(), postCtg.getP1(), threshold)
             || changed(preCtg.getQ1(), postCtg.getQ1(), threshold)
             || changed(preCtg.getP2(), postCtg.getP2(), threshold)
             || changed(preCtg.getQ2(), postCtg.getQ2(), threshold);
@@ -102,7 +117,7 @@ public class PostContingencyNetworkResult extends AbstractNetworkResult {
             var preContingencyBusResult = preContingencyMonitorInfos.getBusResult("%s_%s".formatted(busResult.getVoltageLevelId(), busResult.getBusId()));
             if (preContingencyBusResult != null) {
                 double threshold = modifiedMonitoredElementsParameters.getVoltageModificationThreshold(preContingencyBusResult.getV());
-                if (Math.abs(preContingencyBusResult.getV() - busResult.getV()) < threshold) {
+                if (!changed(preContingencyBusResult.getV(), busResult.getV(), threshold)) {
                     continue;
                 }
             }
@@ -124,8 +139,7 @@ public class PostContingencyNetworkResult extends AbstractNetworkResult {
         }
         Objects.requireNonNull(postCtg);
         double threshold = modifiedMonitoredElementsParameters.getPowerModificationThreshold();
-        return threshold <= 0
-                || changed(preCtg.getP1(), postCtg.getP1(), threshold)
+        return changed(preCtg.getP1(), postCtg.getP1(), threshold)
                 || changed(preCtg.getQ1(), postCtg.getQ1(), threshold)
                 || changed(preCtg.getP2(), postCtg.getP2(), threshold)
                 || changed(preCtg.getQ2(), postCtg.getQ2(), threshold)

--- a/src/main/java/com/powsybl/openloadflow/sa/PreContingencyNetworkResult.java
+++ b/src/main/java/com/powsybl/openloadflow/sa/PreContingencyNetworkResult.java
@@ -40,9 +40,12 @@ public class PreContingencyNetworkResult extends AbstractNetworkResult {
 
     private void addResults(StateMonitor monitor, Predicate<LfBranch> isBranchDisabled, Map<String, LfBranch.LfBranchResults> zeroImpedanceFlows) {
         addResults(monitor,
-                branch -> branch.createBranchResult(Double.NaN, Double.NaN, createResultExtension, zeroImpedanceFlows, loadFlowModel)
-                .forEach(branchResult -> branchResults.put(branchResult.getBranchId(), branchResult)),
-                isBranchDisabled,
+                branch -> {
+                    List<BranchResult> results = isBranchDisabled.test(branch)
+                            ? branch.createDisabledBranchResult(createResultExtension)
+                            : branch.createBranchResult(Double.NaN, Double.NaN, createResultExtension, zeroImpedanceFlows, loadFlowModel);
+                    results.forEach(branchResult -> branchResults.put(branchResult.getBranchId(), branchResult));
+                },
                 bus -> bus.createBusResults().forEach(busResult -> busResults.put("%s_%s".formatted(busResult.getVoltageLevelId(), busResult.getBusId()), busResult)),
                 id -> threeWindingsTransformerResults.put(id, LfLegBranch.createThreeWindingsTransformerResult(network, id, createResultExtension, zeroImpedanceFlows, loadFlowModel)));
     }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -562,8 +562,15 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertAlmostEquals(new BranchResult("NGEN_NHV1", 606, 225, 15226, -605, -198, 914),
                            preContingencyResult.getNetworkResult().getBranchResult("NGEN_NHV1"), 1);
 
-        //No result when the branch itself is disconnected
-        assertNull(result.getPostContingencyResults().get(0).getNetworkResult().getBranchResult("NHV1_NHV2_1"));
+        // The branch itself is disconnected: it is reported with NaN P/Q/I
+        BranchResult disabledBranchResult = result.getPostContingencyResults().get(0).getNetworkResult().getBranchResult("NHV1_NHV2_1");
+        assertNotNull(disabledBranchResult);
+        assertTrue(Double.isNaN(disabledBranchResult.getP1()));
+        assertTrue(Double.isNaN(disabledBranchResult.getQ1()));
+        assertTrue(Double.isNaN(disabledBranchResult.getI1()));
+        assertTrue(Double.isNaN(disabledBranchResult.getP2()));
+        assertTrue(Double.isNaN(disabledBranchResult.getQ2()));
+        assertTrue(Double.isNaN(disabledBranchResult.getI2()));
 
         assertAlmostEquals(new BranchResult("NHV1_NHV2_1", 611, 334, 1009, -601, -285, 1048),
                 result.getPostContingencyResults().get(1).getNetworkResult().getBranchResult("NHV1_NHV2_1"), 1);
@@ -746,7 +753,8 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(4, result.getPostContingencyResults().get(4).getLimitViolationsResult().getLimitViolations().size());
 
         //Branch result for first contingency
-        assertEquals(4, result.getPostContingencyResults().get(0).getNetworkResult().getBranchResults().size());
+        // l14, disabled by its own contingency, is reported with NaN values
+        assertEquals(5, result.getPostContingencyResults().get(0).getNetworkResult().getBranchResults().size());
 
         //Check branch results for flowTransfer computation for contingency on l14
         PostContingencyResult postContl14 = getPostContingencyResult(result, "l14");
@@ -796,8 +804,10 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals("l12", result.getPreContingencyResult().getNetworkResult().getBranchResults().get(1).getBranchId());
 
         assertEquals(5, result.getPostContingencyResults().size());
-        assertEquals(4, getPostContingencyResult(result, "l14").getNetworkResult().getBranchResults().size());
-        assertEquals(1, getPostContingencyResult(result, "l12").getNetworkResult().getBranchResults().size());
+        // l14, disabled by its own contingency, is reported with NaN values
+        assertEquals(5, getPostContingencyResult(result, "l14").getNetworkResult().getBranchResults().size());
+        // l12, disabled by its own contingency, is reported with NaN values
+        assertEquals(2, getPostContingencyResult(result, "l12").getNetworkResult().getBranchResults().size());
         assertEquals(2, getPostContingencyResult(result, "l13").getNetworkResult().getBranchResults().size());
         assertEquals(2, getPostContingencyResult(result, "l34").getNetworkResult().getBranchResults().size());
         assertEquals(2, getPostContingencyResult(result, "l23").getNetworkResult().getBranchResults().size());
@@ -842,7 +852,8 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(4, result.getPostContingencyResults().get(4).getLimitViolationsResult().getLimitViolations().size());
 
         //Branch result for first contingency
-        assertEquals(4, result.getPostContingencyResults().get(0).getNetworkResult().getBranchResults().size());
+        // l14, disabled by its own contingency, is reported with NaN values
+        assertEquals(5, result.getPostContingencyResults().get(0).getNetworkResult().getBranchResults().size());
 
         //Check branch results for flowTransfer computation for contingency on l14
         PostContingencyResult postContl14 = getPostContingencyResult(result, "l14");
@@ -878,7 +889,8 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(5, result.getPostContingencyResults().size());
 
         for (PostContingencyResult r : result.getPostContingencyResults()) {
-            assertEquals(4, r.getNetworkResult().getBranchResults().size());
+            // the contingency's own branch is reported with NaN values
+            assertEquals(5, r.getNetworkResult().getBranchResults().size());
         }
 
         //Check branch results for flowTransfer computation for contingency on l14
@@ -2312,8 +2324,9 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
             PostContingencyResult postContingencyResult = result.getPostContingencyResults().get(0);
             assertSame(PostContingencyComputationStatus.CONVERGED, postContingencyResult.getStatus());
 
-            // verify only flows in slack component have been computed
-            assertEquals(3, postContingencyResult.getNetworkResult().getBranchResults().size());
+            // all monitored branches are reported; those outside the computed slack component have NaN
+            // values, only 3 have real, computed flows
+            assertEquals(12, postContingencyResult.getNetworkResult().getBranchResults().size());
 
             // verify flows on the branches
             assertEquals(-1, postContingencyResult.getNetworkResult().getBranchResult("l12").getP1(), LoadFlowAssert.DELTA_POWER);
@@ -2412,7 +2425,8 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(446.765, preContingencyNetworkResult.getBranchResult("L2").getI1(), LoadFlowAssert.DELTA_I);
 
         assertEquals(945.514, getPostContingencyResult(result, "BBS1").getNetworkResult().getBranchResult("L2").getI1(), LoadFlowAssert.DELTA_I);
-        assertNull(getPostContingencyResult(result, "BBS1").getNetworkResult().getBranchResult("L1"));
+        // L1 is disabled by the BBS1 contingency propagation: it is reported with NaN I1
+        assertTrue(Double.isNaN(getPostContingencyResult(result, "BBS1").getNetworkResult().getBranchResult("L1").getI1()));
 
         OpenSecurityAnalysisParameters openSecurityAnalysisParameters = new OpenSecurityAnalysisParameters();
         openSecurityAnalysisParameters.setContingencyPropagation(false);
@@ -3091,7 +3105,8 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals("BBS3", preContingencyResult.getNetworkResult().getBusResults().get(2).getBusId());
         assertEquals(400.0, preContingencyResult.getNetworkResult().getBusResult("BBS3").getV(), LoadFlowAssert.DELTA_V);
         PostContingencyResult postContingencyResult = getPostContingencyResult(result, "C1");
-        assertNull(postContingencyResult.getNetworkResult().getBusResult("BBS1"));
+        // BBS1 is disabled by the C1 contingency: it is reported with a NaN V
+        assertTrue(Double.isNaN(postContingencyResult.getNetworkResult().getBusResult("BBS1").getV()));
         assertEquals(400.0, postContingencyResult.getNetworkResult().getBusResult("BBS2").getV(), LoadFlowAssert.DELTA_V);
         assertEquals(400.0, postContingencyResult.getNetworkResult().getBusResult("BBS3").getV(), LoadFlowAssert.DELTA_V);
     }
@@ -3118,7 +3133,10 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals("BBS3", preContingencyResult.getNetworkResult().getBusResults().get(2).getBusId());
         assertEquals(400.0, preContingencyResult.getNetworkResult().getBusResult("BBS3").getV(), LoadFlowAssert.DELTA_V);
         PostContingencyResult postContingencyResult = getPostContingencyResult(result, "C1");
-        assertEmpty(postContingencyResult.getNetworkResult().getBusResults());
+        // BBS1 is disabled by C1: a real V -> NaN transition is always reported, even though BBS2/BBS3 stay
+        // filtered out (unchanged V)
+        assertEquals(1, postContingencyResult.getNetworkResult().getBusResults().size());
+        assertTrue(Double.isNaN(postContingencyResult.getNetworkResult().getBusResult("BBS1").getV()));
     }
 
     @Test
@@ -4613,7 +4631,9 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         // post-contingency tests
         PostContingencyResult postContingencyResult = getPostContingencyResult(result, "l25");
         assertEquals(1, postContingencyResult.getConnectivityResult().getCreatedSynchronousComponentCount());
-        assertEquals(3, postContingencyResult.getNetworkResult().getBranchResults().size()); // only branches in main synchronous component
+        // all monitored branches are reported; those outside the main synchronous component have NaN
+        // values, only 3 have real, computed flows
+        assertEquals(7, postContingencyResult.getNetworkResult().getBranchResults().size());
         assertEquals(network.getLine("l12").getTerminal1().getP(), postContingencyResult.getNetworkResult().getBranchResult("l12").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(network.getLine("l13").getTerminal1().getP(), postContingencyResult.getNetworkResult().getBranchResult("l13").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(network.getLine("l23").getTerminal1().getP(), postContingencyResult.getNetworkResult().getBranchResult("l23").getP1(), LoadFlowAssert.DELTA_POWER);
@@ -4649,7 +4669,9 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         // post-contingency tests
         PostContingencyResult postContingencyResult = getPostContingencyResult(result, "l25+l45+l46");
         assertEquals(2, postContingencyResult.getConnectivityResult().getCreatedSynchronousComponentCount());
-        assertEquals(3, postContingencyResult.getNetworkResult().getBranchResults().size()); // only branches in main synchronous component
+        // all monitored branches are reported; those outside the main synchronous component have NaN
+        // values, only 3 have real, computed flows
+        assertEquals(7, postContingencyResult.getNetworkResult().getBranchResults().size());
         assertEquals(network.getLine("l12").getTerminal1().getP(), postContingencyResult.getNetworkResult().getBranchResult("l12").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(network.getLine("l13").getTerminal1().getP(), postContingencyResult.getNetworkResult().getBranchResult("l13").getP1(), LoadFlowAssert.DELTA_POWER);
         assertEquals(network.getLine("l23").getTerminal1().getP(), postContingencyResult.getNetworkResult().getBranchResult("l23").getP1(), LoadFlowAssert.DELTA_POWER);
@@ -4912,8 +4934,9 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         assertEquals(200.0, postContingencyResult.getNetworkResult().getBranchResult("PS1").getP1(), DELTA_POWER);
         assertEquals(-200.0, postContingencyResult.getNetworkResult().getBranchResult("PS1").getP2(), DELTA_POWER);
         assertEquals(0, postContingencyResult.getLimitViolationsResult().getLimitViolations().size());
-        // in fast dc mode, no branch result is created for disabled branches on one side
-        assertEquals(1, postContingencyResult.getNetworkResult().getBranchResults().size());
+        // in fast dc mode too, disabled-on-one-side branches are reported with NaN values, so both modes
+        // report the same monitored branch count
+        assertEquals(5, postContingencyResult.getNetworkResult().getBranchResults().size());
     }
 
     @Test
@@ -5221,8 +5244,11 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
 
         SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies, monitors, loadFlowParameters);
         NetworkResult networkResult = result.getPostContingencyResults().getFirst().getNetworkResult();
-        assertEquals(4, networkResult.getBranchResults().size());
-        networkResult.getBranchResults()
+        // l14, disabled by its own contingency, is reported with NaN values
+        assertEquals(5, networkResult.getBranchResults().size());
+        assertTrue(Double.isNaN(networkResult.getBranchResult("l14").getFlowTransfer()));
+        networkResult.getBranchResults().stream()
+            .filter(br -> !br.getBranchId().equals("l14"))
             .forEach(br -> assertEquals(0., br.getFlowTransfer(), DELTA_POWER));
     }
 
@@ -5338,5 +5364,64 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
         parameters.getModifiedMonitoredElementsParameters().setPowerModificationThreshold(170); // MW-MVAr, this time should filter
         SecurityAnalysisResult resultFiltered2 = runSecurityAnalysis(network, contingencies, monitors, parameters);
         assertEmpty(resultFiltered2.getPostContingencyResults().getFirst().getNetworkResult().getThreeWindingsTransformerResults());
+    }
+
+    @Test
+    void testDisabledBranchAlwaysReportedDespiteChangeFilteringThreshold() {
+        Network network = FourBusNetworkFactory.create();
+        List<Contingency> contingencies = List.of(new Contingency("l14", new BranchContingency("l14")));
+        List<StateMonitor> monitors = List.of(
+                new StateMonitor(ContingencyContext.all(), Set.of("l14", "l12", "l23", "l34", "l13"), emptySet(), emptySet()));
+        SecurityAnalysisParameters parameters = new SecurityAnalysisParameters()
+                .setModifiedMonitoredElementsParameters(new SecurityAnalysisParameters.ModifiedMonitoredElementsParameters()
+                        .setPowerModificationThreshold(1000)); // absurdly high threshold: suppresses any real flow change
+
+        SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies, monitors, parameters);
+
+        NetworkResult postCtg = result.getPostContingencyResults().getFirst().getNetworkResult();
+        // l14 is disabled by its own contingency: real -> NaN is always a change, reported regardless of threshold
+        BranchResult l14Result = postCtg.getBranchResult("l14");
+        assertNotNull(l14Result);
+        assertTrue(Double.isNaN(l14Result.getP1()));
+        // the other branches see their flow redistributed but stay below the (huge) threshold: filtered out
+        assertNull(postCtg.getBranchResult("l12"));
+        assertNull(postCtg.getBranchResult("l23"));
+        assertNull(postCtg.getBranchResult("l34"));
+        assertNull(postCtg.getBranchResult("l13"));
+    }
+
+    @Test
+    void testZeroImpedanceBranchDisabledByOwnContingencyDoesNotThrow() {
+        Network network = ZeroImpedanceNetworkFactory.createWith3BusesNonImpedantSubNetwork();
+        List<Contingency> contingencies = List.of(new Contingency("l23", new BranchContingency("l23")));
+        List<StateMonitor> monitors = List.of(
+                new StateMonitor(ContingencyContext.all(), Set.of("l23"), emptySet(), emptySet()));
+
+        SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies, monitors);
+
+        BranchResult postCtg = result.getPostContingencyResults().getFirst().getNetworkResult().getBranchResult("l23");
+        assertNotNull(postCtg);
+        assertTrue(Double.isNaN(postCtg.getP1()));
+        assertTrue(Double.isNaN(postCtg.getQ1()));
+        assertTrue(Double.isNaN(postCtg.getI1()));
+    }
+
+    @Test
+    void testDisabled3wtReportsNanFlows() {
+        Network network = T3wtFactory.create();
+        List<Contingency> contingencies = List.of(new Contingency("3wt", new ThreeWindingsTransformerContingency("3wt")));
+        List<StateMonitor> monitors = List.of(
+                new StateMonitor(ContingencyContext.all(), emptySet(), emptySet(), Set.of("3wt")));
+
+        SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies, monitors);
+
+        var postCtg = result.getPostContingencyResults().getFirst().getNetworkResult().getThreeWindingsTransformerResult("3wt");
+        assertNotNull(postCtg);
+        assertTrue(Double.isNaN(postCtg.getP1()));
+        assertTrue(Double.isNaN(postCtg.getQ1()));
+        assertTrue(Double.isNaN(postCtg.getP2()));
+        assertTrue(Double.isNaN(postCtg.getQ2()));
+        assertTrue(Double.isNaN(postCtg.getP3()));
+        assertTrue(Double.isNaN(postCtg.getQ3()));
     }
 }

--- a/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/OpenSecurityAnalysisTest.java
@@ -2317,7 +2317,7 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
 
         List<List<String>> slackBusesIdList = List.of(List.of("b3_vl"), List.of("b3_vl", "b7_vl"), List.of("b3_vl", "b7_vl", "b10_vl"));
         // verify that for each list of slacks buses, fast dc sa runs only in component of first slack bus
-        slackBusesIdList.forEach(slackBusesId -> {
+        for (List<String> slackBusesId : slackBusesIdList) {
             openLoadFlowParameters.setSlackBusesIds(slackBusesId)
                     .setMaxSlackBusCount(slackBusesId.size());
             SecurityAnalysisResult result = runSecurityAnalysis(network, contingencies, monitors, parameters, ReportNode.NO_OP);
@@ -2329,14 +2329,25 @@ class OpenSecurityAnalysisTest extends AbstractOpenSecurityAnalysisTest {
             assertEquals(12, postContingencyResult.getNetworkResult().getBranchResults().size());
 
             // verify flows on the branches
-            assertEquals(-1, postContingencyResult.getNetworkResult().getBranchResult("l12").getP1(), LoadFlowAssert.DELTA_POWER);
-            assertEquals(0, postContingencyResult.getNetworkResult().getBranchResult("l13").getP1(), LoadFlowAssert.DELTA_POWER);
-            assertEquals(1, postContingencyResult.getNetworkResult().getBranchResult("l23").getP1(), LoadFlowAssert.DELTA_POWER);
+            assertEquals(-1, postContingencyResult.getNetworkResult().getBranchResult("l12").getP1(), DELTA_POWER);
+            assertEquals(0, postContingencyResult.getNetworkResult().getBranchResult("l13").getP1(), DELTA_POWER);
+            assertEquals(1, postContingencyResult.getNetworkResult().getBranchResult("l23").getP1(), DELTA_POWER);
+            postContingencyResult.getNetworkResult().getBranchResults().stream()
+                    .filter(br -> !Set.of("l12", "l13", "l23").contains(br.getBranchId()))
+                    .forEach(br -> {
+                        assertTrue(Double.isNaN(br.getP1()));
+                        assertTrue(Double.isNaN(br.getQ1()));
+                        assertTrue(Double.isNaN(br.getI1()));
+                        assertTrue(Double.isNaN(br.getP2()));
+                        assertTrue(Double.isNaN(br.getQ2()));
+                        assertTrue(Double.isNaN(br.getI2()));
+                        assertTrue(Double.isNaN(br.getFlowTransfer()));
+                    });
 
             // verify active load and generation of other components have been lost
-            assertEquals(6, postContingencyResult.getConnectivityResult().getDisconnectedGenerationActivePower(), LoadFlowAssert.DELTA_POWER);
-            assertEquals(7, postContingencyResult.getConnectivityResult().getDisconnectedLoadActivePower(), LoadFlowAssert.DELTA_POWER);
-        });
+            assertEquals(6, postContingencyResult.getConnectivityResult().getDisconnectedGenerationActivePower(), DELTA_POWER);
+            assertEquals(7, postContingencyResult.getConnectivityResult().getDisconnectedLoadActivePower(), DELTA_POWER);
+        }
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysisWithActionsTest.java
+++ b/src/test/java/com/powsybl/openloadflow/sa/WoodburyDcSecurityAnalysisWithActionsTest.java
@@ -787,7 +787,8 @@ class WoodburyDcSecurityAnalysisWithActionsTest extends AbstractOpenSecurityAnal
         assertEquals(200.0, operatorStrategyResult.getNetworkResult().getBranchResult("PS1").getP1(), DELTA_POWER);
         assertEquals(-200.0, operatorStrategyResult.getNetworkResult().getBranchResult("PS1").getP2(), DELTA_POWER);
         assertEquals(0, operatorStrategyResult.getLimitViolationsResult().getLimitViolations().size());
-        // in fast dc mode, no branch result is created for disabled branches on one side
-        assertEquals(1, operatorStrategyResult.getNetworkResult().getBranchResults().size());
+        // in fast dc mode too, disabled-on-one-side branches are reported with NaN values, so both modes
+        // report the same monitored branch count
+        assertEquals(5, operatorStrategyResult.getNetworkResult().getBranchResults().size());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
This comment: https://github.com/powsybl/powsybl-open-loadflow/pull/1398#pullrequestreview-4600529363


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->

`com.powsybl.openloadflow.sa.AbstractNetworkResult.addResults` (shared by `PreContingencyNetworkResult` and
`PostContingencyNetworkResult`) filtered out branches/buses/3WT disabled by a contingency (or already disabled at
N-state) — they never appeared in `NetworkResult` at all.

PR #1398 (commit `93e57ea8a`) added a second, independent filter: post-contingency results whose values didn't
change significantly vs. pre-contingency were also omitted (`ModifiedMonitoredElementsParameters` thresholds).

This created an ambiguity for API consumers: a missing monitored element could mean either "no significant
change" or "disabled by the contingency" — indistinguishable from the outside:
- for post contingency results, one need to combine with connectivity results to distinguish between the two cases, feasible but cumbersome
- for operator strategy results, distinguishing is impossible because connectivity results are not available.

**What is the new behavior (if this is a feature change)?**

**Fix**: disabled elements are now reported with NaN values for P/Q/I (branches, 3WT) and V/angle (buses) instead
of being omitted. The "no significant change" filter now treats NaN→NaN as *no change* (stays filtered, same net
effect as before) and any transition to/from NaN as *always a change* (must be reported — the common case of an
element getting disabled by the contingency).

This generalizes beyond N-1: removing the disabled-filter in the shared `addResults` also makes
`PreContingencyNetworkResult` (N-state) report NaN entries for elements already disabled at base case. This is a
visible behavior change beyond the N-1 case and should be called out in the PR description.

**Does this PR introduce a breaking change or deprecate an API?**
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

**AI disclosure**: PR generated with AI assistance and some manual edits.

Some more information from AI below:

## Key design facts

- Branch "disabled" is **not** always `branch.isDisabled()`. The regular AC/DC path's default predicate is
  `LfBranch::isDisabled` (true only for `DisabledBranchStatus.BOTH_SIDES`); the Woodbury fast-DC path
  (`WoodburyDcSecurityAnalysis`) uses a broader predicate that also treats `SIDE_1`/`SIDE_2`-only disables as
  "disabled for reporting" (that path doesn't re-solve for a partially-opened branch). Both callers already had
  their own `Predicate<LfBranch> isBranchDisabled` in scope, so the fix gates at the call site rather than
  threading a new parameter through the `LfBranch.createBranchResult(...)` interface.
- Bus/3WT-star-bus disabled status **is** reliably `LfBus.isDisabled()` in both paths (`LfContingency.apply()`
  unconditionally sets it), so buses/3WT self-check internally — no predicate threading needed there.
- `com.powsybl.security.results.BranchResult`/`BusResult`/`ThreeWindingsTransformerResult` (powsybl-core) are
  plain-double-field, unvalidated — they already fully support NaN with no changes needed there.

## Changes

### `AbstractNetworkResult.addResults`
Removed the three disabled-exclusion filters (branches, buses, 3WT), keeping only the 3WT star-bus existence
check (a monitored id with no matching element is genuinely excluded, not a NaN row).

### Branch NaN results
Added `LfBranch.createDisabledBranchResult(boolean createExtension)` (default method) building an all-NaN
`BranchResult`, with overrides in `LfTieLineBranch` (3 results: main + 2 boundary-line halves) and
`LfBoundaryLineBranch` (suppresses the extension, matching its enabled-path behavior). No changes needed to
`AbstractImpedantLfBranch`, `LfBranchImpl`, `LfLegBranch`, `LfSwitch`, or the `createBranchResult` interface
signature. `Pre`/`PostContingencyNetworkResult` gate on `isBranchDisabled.test(branch)` at the call site to
choose `createDisabledBranchResult(...)` vs. `createBranchResult(...)`.

### Bus NaN results
`LfBusImpl.createBusResults()` substitutes NaN for V/angle when `isDisabled()`, keeping the existing bus-id
enumeration logic (bbsIds / bus-breaker-view) unchanged.

### 3WT NaN results
`LfLegBranch.createThreeWindingsTransformerResult(...)` reports NaN P1/Q1/I1/P2/Q2/I2/P3/Q3/I3 when the star bus
is disabled, but keeps the `OlfThreeWindingsTransformerResult` extension (V/angle) built unconditionally from
each leg's live network-side terminal bus — the star bus being disabled doesn't imply those buses are disabled.

### "No significant change" filter
`PostContingencyNetworkResult`'s scalar `changed(double, double, double)` is the single shared helper used by the
branch, 3WT, and bus comparisons. Its priority order: a threshold of zero or less disables filtering
unconditionally (always report, no matter what — including NaN↔NaN); above zero, both values NaN is not a change,
exactly one NaN is always a change, otherwise the values are compared against the threshold. Centralizing the
`threshold <= 0` check in this one helper (rather than duplicating it in each of the branch/3WT/bus call sites)
keeps the "zero threshold = never filter" guarantee uniform across all three result types.