### PR TITLE
Faster ModificationsContext

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/graph/AbstractGraphConnectivity.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/AbstractGraphConnectivity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * Copyright (c) 2022-2026, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -89,8 +89,8 @@ public abstract class AbstractGraphConnectivity<V, E, G extends GraphModel<V, E>
     }
 
     @Override
-    public void startTemporaryChanges() {
-        ModificationsContext<V, E> modificationsContext = new ModificationsContext<>(this::getVerticesNotInMainComponent, defaultMainComponentVertex);
+    public void startTemporaryChanges(boolean computeComparisons) {
+        ModificationsContext<V, E> modificationsContext = new ModificationsContext<>(computeComparisons, this::getVerticesNotInMainComponent, defaultMainComponentVertex);
         modificationsContexts.add(modificationsContext);
         modificationsContext.computeVerticesNotInMainComponentBefore();
     }
@@ -202,9 +202,6 @@ public abstract class AbstractGraphConnectivity<V, E, G extends GraphModel<V, E>
         if (!modificationsContexts.isEmpty()) {
             var modificationsContext = modificationsContexts.peekLast();
             modificationsContext.setMainComponentVertex(mainComponentVertex);
-            if (!modificationsContext.isInMainComponentBefore(mainComponentVertex)) {
-                throw new PowsyblException("Cannot take the given vertex as main component vertex! This vertex was outside the main component before starting temporary changes");
-            }
         }
         defaultMainComponentVertex = mainComponentVertex;
     }

--- a/src/main/java/com/powsybl/openloadflow/graph/EvenShiloachGraphDecrementalConnectivity.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/EvenShiloachGraphDecrementalConnectivity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * Copyright (c) 2020-2026, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -90,11 +90,11 @@ public class EvenShiloachGraphDecrementalConnectivity<V, E> extends AbstractGrap
     }
 
     @Override
-    public void startTemporaryChanges() {
+    public void startTemporaryChanges(boolean computeComparisons) {
         if (!getModificationsContexts().isEmpty()) {
             throw new PowsyblException("This implementation supports only one level of temporary changes");
         }
-        super.startTemporaryChanges();
+        super.startTemporaryChanges(computeComparisons);
         if (levelNeighboursMap.isEmpty()) {
             Set<V> vertices = getGraph().getVertices();
             vertices.stream()

--- a/src/main/java/com/powsybl/openloadflow/graph/GraphConnectivity.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/GraphConnectivity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * Copyright (c) 2020-2026, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -47,8 +47,29 @@ public interface GraphConnectivity<V, E> {
 
     /**
      * Start recording topological changes to undo them later by a {@link #undoTemporaryChanges} call.
+     * Comparisons will be computed.
+     *
+     * @see #startTemporaryChanges(boolean)
      */
-    void startTemporaryChanges();
+    default void startTemporaryChanges() {
+        startTemporaryChanges(true);
+    }
+
+    /**
+     * Start recording topological changes to undo them later by a {@link #undoTemporaryChanges} call.
+     * When {@code computeComparisons} is {@code true}, it becomes possible to call the following methods:
+     * <ul>
+     *     <li>{@link #getVerticesRemovedFromMainComponent()}</li>
+     *     <li>{@link #getEdgesRemovedFromMainComponent()}</li>
+     *     <li>{@link #getVerticesAddedToMainComponent()}</li>
+     *     <li>{@link #getEdgesAddedToMainComponent()}</li>
+     * </ul>
+     * When these methods aren't needed, it is advised to set {@code computeComparisons} to {@code false}
+     * for performance reasons.
+     *
+     * @param computeComparisons {@code true} to enable computation of comparisons.
+     */
+    void startTemporaryChanges(boolean computeComparisons);
 
     /**
      * Undo all the connectivity changes (possibly none) since last call to {@link #startTemporaryChanges}.

--- a/src/main/java/com/powsybl/openloadflow/graph/MinimumSpanningTreeGraphConnectivity.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/MinimumSpanningTreeGraphConnectivity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * Copyright (c) 2020-2026, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -55,8 +55,8 @@ public class MinimumSpanningTreeGraphConnectivity<V, E> extends AbstractGraphCon
     }
 
     @Override
-    public void startTemporaryChanges() {
-        super.startTemporaryChanges();
+    public void startTemporaryChanges(boolean computeComparisons) {
+        super.startTemporaryChanges(computeComparisons);
         if (mst == null) {
             mst = new KruskalMinimumSpanningTrees().getSpanningTree();
         }

--- a/src/main/java/com/powsybl/openloadflow/graph/ModificationsContext.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/ModificationsContext.java
@@ -63,7 +63,7 @@ public class ModificationsContext<V, E> {
 
     public Set<E> getEdgesRemovedFromMainComponent(GraphModel<V, E> graph) {
         if (!computeComparisons) {
-            throw new PowsyblException("Cannot compute getEdgesRemovedFromMainComponent as requested by the last startTemporaryChanges!");
+            throw new PowsyblException("Topological comparisons are disabled for the current temporary changes context!");
         }
 
         if (edgesRemovedFromMainComponent == null) {
@@ -74,7 +74,7 @@ public class ModificationsContext<V, E> {
 
     public Set<V> getVerticesRemovedFromMainComponent() {
         if (!computeComparisons) {
-            throw new PowsyblException("Cannot compute getVerticesRemovedFromMainComponent as requested by the last startTemporaryChanges!");
+            throw new PowsyblException("Topological comparisons are disabled for the current temporary changes context!");
         }
 
         if (verticesRemovedFromMainComponent == null) {
@@ -99,7 +99,7 @@ public class ModificationsContext<V, E> {
 
     public Set<E> getEdgesAddedToMainComponent(GraphModel<V, E> graph) {
         if (!computeComparisons) {
-            throw new PowsyblException("Cannot compute getEdgesAddedToMainComponent as requested by the last startTemporaryChanges!");
+            throw new PowsyblException("Topological comparisons are disabled for the current temporary changes context!");
         }
 
         if (edgesAddedToMainComponent == null) {
@@ -110,7 +110,7 @@ public class ModificationsContext<V, E> {
 
     public Set<V> getVerticesAddedToMainComponent() {
         if (!computeComparisons) {
-            throw new PowsyblException("Cannot compute getVerticesAddedToMainComponent as requested by the last startTemporaryChanges!");
+            throw new PowsyblException("Topological comparisons are disabled for the current temporary changes context!");
         }
 
         if (verticesAddedToMainComponent == null) {

--- a/src/main/java/com/powsybl/openloadflow/graph/ModificationsContext.java
+++ b/src/main/java/com/powsybl/openloadflow/graph/ModificationsContext.java
@@ -1,11 +1,15 @@
 /**
- * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * Copyright (c) 2022-2026, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  * SPDX-License-Identifier: MPL-2.0
  */
 package com.powsybl.openloadflow.graph;
+
+import com.powsybl.commons.PowsyblException;
+import gnu.trove.map.hash.THashMap;
+import gnu.trove.set.hash.THashSet;
 
 import java.util.*;
 import java.util.function.Function;
@@ -17,6 +21,7 @@ import java.util.stream.Stream;
  */
 public class ModificationsContext<V, E> {
 
+    private final boolean computeComparisons;
     private final Deque<GraphModification<V, E>> modifications = new ArrayDeque<>();
     private final Function<V, Set<V>> verticesNotInMainComponentGetter;
     private Set<V> verticesNotInMainComponentBefore;
@@ -27,13 +32,16 @@ public class ModificationsContext<V, E> {
     private Map<E, AbstractEdgeModification<V, E>> edgeFirstModificationMap;
     private V mainComponentVertex;
 
-    public ModificationsContext(Function<V, Set<V>> verticesNotInMainComponentGetter, V mainComponentVertex) {
+    public ModificationsContext(boolean computeComparisons, Function<V, Set<V>> verticesNotInMainComponentGetter, V mainComponentVertex) {
+        this.computeComparisons = computeComparisons;
         this.mainComponentVertex = mainComponentVertex;
         this.verticesNotInMainComponentGetter = verticesNotInMainComponentGetter;
     }
 
     public void computeVerticesNotInMainComponentBefore() {
-        this.verticesNotInMainComponentBefore = verticesNotInMainComponentGetter.apply(mainComponentVertex);
+        if (computeComparisons) {
+            this.verticesNotInMainComponentBefore = verticesNotInMainComponentGetter.apply(mainComponentVertex);
+        }
     }
 
     public void add(GraphModification<V, E> graphModification) {
@@ -54,6 +62,10 @@ public class ModificationsContext<V, E> {
     }
 
     public Set<E> getEdgesRemovedFromMainComponent(GraphModel<V, E> graph) {
+        if (!computeComparisons) {
+            throw new PowsyblException("Cannot compute getEdgesRemovedFromMainComponent as requested by the last startTemporaryChanges!");
+        }
+
         if (edgesRemovedFromMainComponent == null) {
             edgesRemovedFromMainComponent = computeEdgesRemovedFromMainComponent(graph);
         }
@@ -61,9 +73,20 @@ public class ModificationsContext<V, E> {
     }
 
     public Set<V> getVerticesRemovedFromMainComponent() {
+        if (!computeComparisons) {
+            throw new PowsyblException("Cannot compute getVerticesRemovedFromMainComponent as requested by the last startTemporaryChanges!");
+        }
+
         if (verticesRemovedFromMainComponent == null) {
-            Set<V> result = new HashSet<>(getVerticesNotInMainComponentAfter());
-            result.removeAll(verticesNotInMainComponentBefore);
+            // result = after - before
+            Set<V> result = new THashSet<>();
+
+            for (V vertex : getVerticesNotInMainComponentAfter()) {
+                if (!verticesNotInMainComponentBefore.contains(vertex)) { // filter before doing the copy
+                    result.add(vertex);
+                }
+            }
+
             if (!result.isEmpty()) {
                 // remove vertices added in between
                 // note that there is no VertexRemove modification, thus we do not need to check if vertex is in the graph in the end
@@ -75,6 +98,10 @@ public class ModificationsContext<V, E> {
     }
 
     public Set<E> getEdgesAddedToMainComponent(GraphModel<V, E> graph) {
+        if (!computeComparisons) {
+            throw new PowsyblException("Cannot compute getEdgesAddedToMainComponent as requested by the last startTemporaryChanges!");
+        }
+
         if (edgesAddedToMainComponent == null) {
             edgesAddedToMainComponent = computeEdgesAddedToMainComponent(graph);
         }
@@ -82,10 +109,20 @@ public class ModificationsContext<V, E> {
     }
 
     public Set<V> getVerticesAddedToMainComponent() {
+        if (!computeComparisons) {
+            throw new PowsyblException("Cannot compute getVerticesAddedToMainComponent as requested by the last startTemporaryChanges!");
+        }
+
         if (verticesAddedToMainComponent == null) {
-            Set<V> result = new HashSet<>(verticesNotInMainComponentBefore);
+            // result = before - after
+            Set<V> result = new THashSet<>();
             Set<V> verticesNotInMainComponentAfter = getVerticesNotInMainComponentAfter();
-            result.removeAll(verticesNotInMainComponentAfter);
+            for (V vertex : verticesNotInMainComponentBefore) {
+                if (!verticesNotInMainComponentAfter.contains(vertex)) { // filter before doing the copy
+                    result.add(vertex);
+                }
+            }
+
             // add vertices added to main component in between
             // note that there is no VertexRemove modification, thus we do not need to check if vertex is in the graph before / in the end
             getAddedVertexStream().filter(addedVertex -> !verticesNotInMainComponentAfter.contains(addedVertex)).forEach(result::add);
@@ -100,7 +137,8 @@ public class ModificationsContext<V, E> {
 
     private Set<E> computeEdgesRemovedFromMainComponent(GraphModel<V, E> graph) {
         Set<V> verticesRemoved = getVerticesRemovedFromMainComponent();
-        Set<E> result = verticesRemoved.stream().map(graph::getNeighborEdgesOf).flatMap(Set::stream).collect(Collectors.toSet());
+        Set<E> result = verticesRemoved.stream().map(graph::getNeighborEdgesOf).flatMap(Set::stream)
+                .collect(Collectors.toCollection(THashSet::new));
 
         // We need to look in modifications to adjust the computation of the edges above, indeed:
         //  - result contains the edges which were added in the small components
@@ -125,7 +163,8 @@ public class ModificationsContext<V, E> {
     }
 
     private Set<E> computeEdgesAddedToMainComponent(GraphModel<V, E> graph) {
-        Set<E> result = getVerticesAddedToMainComponent().stream().map(graph::getNeighborEdgesOf).flatMap(Set::stream).collect(Collectors.toSet());
+        Set<E> result = getVerticesAddedToMainComponent().stream().map(graph::getNeighborEdgesOf).flatMap(Set::stream)
+                .collect(Collectors.toCollection(THashSet::new));
 
         // We need to look in modifications to adjust the computation of the edges above
         // Indeed result is missing the edges added in main component with an EdgeAdd modification
@@ -148,7 +187,7 @@ public class ModificationsContext<V, E> {
             edgeFirstModificationMap = modifications.stream()
                     .filter(AbstractEdgeModification.class::isInstance)
                     .map(m -> (AbstractEdgeModification<V, E>) m)
-                    .collect(Collectors.toMap(m -> m.e, m -> m, (m1, m2) -> m1));
+                    .collect(Collectors.toMap(m -> m.e, m -> m, (m1, m2) -> m1, THashMap::new));
         }
     }
 
@@ -163,11 +202,18 @@ public class ModificationsContext<V, E> {
     }
 
     public void setMainComponentVertex(V mainComponentVertex) {
-        invalidateComparisons();
+        if (computeComparisons) {
+            if (!isInMainComponentBefore(mainComponentVertex)) {
+                throw new PowsyblException("Cannot take the given vertex as main component vertex! This vertex was outside the main component before starting temporary changes");
+            }
+
+            invalidateComparisons();
+        }
+
         this.mainComponentVertex = mainComponentVertex;
     }
 
-    public boolean isInMainComponentBefore(V vertex) {
+    private boolean isInMainComponentBefore(V vertex) {
         return !verticesNotInMainComponentBefore.contains(vertex);
     }
 }

--- a/src/main/java/com/powsybl/openloadflow/network/action/LfActionUtils.java
+++ b/src/main/java/com/powsybl/openloadflow/network/action/LfActionUtils.java
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2025, Coreso SA (https://www.coreso.eu/) and TSCNET Services GmbH (https://www.tscnet.eu/)
- * Copyright (c) 2022-2025, RTE (http://www.rte-france.com)
+ * Copyright (c) 2022-2026, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -86,7 +85,7 @@ public final class LfActionUtils {
         GraphConnectivity<LfBus, LfBranch> connectivity = network.getConnectivity();
 
         // re-update connectivity according to post contingency state (revert after LfContingency apply)
-        connectivity.startTemporaryChanges();
+        connectivity.startTemporaryChanges(false);
         contingency.getDisabledNetwork().getBranches().forEach(connectivity::removeEdge);
 
         // update connectivity according to post action state

--- a/src/test/java/com/powsybl/openloadflow/graph/ConnectivityTest.java
+++ b/src/test/java/com/powsybl/openloadflow/graph/ConnectivityTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * Copyright (c) 2021-2026, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -490,6 +490,77 @@ class ConnectivityTest {
         assertEquals(Set.of(1, 2), c.getVerticesRemovedFromMainComponent());
         assertEquals(Set.of("1-2", "2-3"), c.getEdgesRemovedFromMainComponent());
         // 1---2   3---4---5   6
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideNonRestrictedConnectivities")
+    void quickStartTemporaryChangesTest(GraphConnectivity<Integer, String> c) {
+        String e11 = "1-1";
+        String e12 = "1-2";
+        String e23 = "2-3";
+        String e31 = "3-1";
+        String e45 = "4-5";
+        String e36 = "3-6";
+        String e16 = "1-6";
+
+        c.addVertex(1);
+        c.addVertex(2);
+        c.addVertex(3);
+        c.addVertex(4);
+        c.addVertex(5);
+        c.addVertex(6);
+        c.addEdge(1, 1, e11);
+        c.addEdge(1, 2, e12);
+        c.addEdge(2, 3, e23);
+        c.addEdge(3, 1, e31);
+        c.addEdge(4, 5, e45);
+        c.addEdge(3, 6, e36);
+        //  |-------|
+        //  1---2---3---6   4---5
+        // |_|
+
+        c.startTemporaryChanges(false);
+        c.removeEdge(e36);
+        //  |-------|
+        //  1---2---3   6   4---5
+        // |_|
+
+        assertThrows(PowsyblException.class, c::getVerticesRemovedFromMainComponent);
+        assertThrows(PowsyblException.class, c::getEdgesRemovedFromMainComponent);
+        assertThrows(PowsyblException.class, c::getVerticesAddedToMainComponent);
+        assertThrows(PowsyblException.class, c::getEdgesAddedToMainComponent);
+        assertEquals(3, c.getNbConnectedComponents());
+        assertEquals(Set.of(1, 2, 3), c.getConnectedComponent(1));
+        assertEquals(Set.of(6), c.getConnectedComponent(6));
+        assertEquals(Set.of(4, 5), c.getConnectedComponent(4));
+
+        c.startTemporaryChanges(true);
+        c.removeEdge(e23);
+        c.removeEdge(e31);
+        c.addEdge(1, 6, e16);
+        //  |-------|
+        //  1---2   6   3   4---5
+        // |_|
+
+        assertEquals(Set.of(e16), c.getEdgesAddedToMainComponent());
+        assertEquals(Set.of(6), c.getVerticesAddedToMainComponent());
+        assertEquals(Set.of(3), c.getVerticesRemovedFromMainComponent());
+        assertEquals(Set.of(e23, e31), c.getEdgesRemovedFromMainComponent());
+        assertEquals(3, c.getNbConnectedComponents());
+        assertEquals(Set.of(1, 2, 6), c.getConnectedComponent(1));
+        assertEquals(Set.of(3), c.getConnectedComponent(3));
+        assertEquals(Set.of(4, 5), c.getConnectedComponent(4));
+
+        c.undoTemporaryChanges();
+
+        assertThrows(PowsyblException.class, c::getVerticesRemovedFromMainComponent);
+        assertThrows(PowsyblException.class, c::getEdgesRemovedFromMainComponent);
+        assertThrows(PowsyblException.class, c::getVerticesAddedToMainComponent);
+        assertThrows(PowsyblException.class, c::getEdgesAddedToMainComponent);
+        assertEquals(3, c.getNbConnectedComponents());
+        assertEquals(Set.of(1, 2, 3), c.getConnectedComponent(1));
+        assertEquals(Set.of(6), c.getConnectedComponent(6));
+        assertEquals(Set.of(4, 5), c.getConnectedComponent(4));
     }
 
     private static Stream<Arguments> provideNonRestrictedConnectivities() {

--- a/src/test/java/com/powsybl/openloadflow/graph/ConnectivityTest.java
+++ b/src/test/java/com/powsybl/openloadflow/graph/ConnectivityTest.java
@@ -533,6 +533,7 @@ class ConnectivityTest {
         assertEquals(Set.of(1, 2, 3), c.getConnectedComponent(1));
         assertEquals(Set.of(6), c.getConnectedComponent(6));
         assertEquals(Set.of(4, 5), c.getConnectedComponent(4));
+        c.setMainComponentVertex(6); // must be still possible even if computeComparisons is false
 
         c.startTemporaryChanges(true);
         c.removeEdge(e23);

--- a/src/test/java/com/powsybl/openloadflow/graph/ConnectivityTest.java
+++ b/src/test/java/com/powsybl/openloadflow/graph/ConnectivityTest.java
@@ -543,10 +543,10 @@ class ConnectivityTest {
         //  1---2   6   3   4---5
         // |_|
 
-        assertEquals(Set.of(e16), c.getEdgesAddedToMainComponent());
-        assertEquals(Set.of(6), c.getVerticesAddedToMainComponent());
-        assertEquals(Set.of(3), c.getVerticesRemovedFromMainComponent());
-        assertEquals(Set.of(e23, e31), c.getEdgesRemovedFromMainComponent());
+        assertEquals(Set.of(e16, e12, e11), c.getEdgesAddedToMainComponent());
+        assertEquals(Set.of(1, 2), c.getVerticesAddedToMainComponent());
+        assertEquals(Set.of(), c.getVerticesRemovedFromMainComponent());
+        assertEquals(Set.of(), c.getEdgesRemovedFromMainComponent());
         assertEquals(3, c.getNbConnectedComponents());
         assertEquals(Set.of(1, 2, 6), c.getConnectedComponent(1));
         assertEquals(Set.of(3), c.getConnectedComponent(3));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature

**What is the current behavior?**
<!-- You can also link to an open issue here -->
This PR reduces the work performed by `ModificationsContext` in two ways. 

First, it changes how vertices removed from or added to the main component are computed to avoid an unnecessary copy and uses `THashSet` instead of `HashSet`.

Second, `AbstractGraphConnectivity#startTemporaryChanges` currently copies all vertices outside the main component so that callers can later invoke `get(Vertices|Edges)(AddedTo|RemovedFrom)MainComponent`. But, sometimes users don't call these methods, making this coy unnecessary.

For example: in `LfActionUtils#updateConnectivity`, the impact of a set of actions on the network connectivity after a contingency is simulated. Because the connectivity is in its initial state, that is before the contingency, it is necessary to
1. call `startTemporaryChanges` and apply the contingency
2. call `startTemporaryChanges` again (otherwise, topological comparisons would be performed against the pre-contingency state instead of the post-contingency state) and apply the actions
3. Use `get(Vertices|Edges)(AddedTo|removedFrom)MainComponent`.
4. undo the actions
6. undo the contingency

Notice that the first `startTemporaryChanges` isn't associated with any topological comparisons. So in this case, copying the vertices outside the main component is unnecessary.

**What is the new behavior (if this is a feature change)?**

This PR introduces a new method in GraphConnectivity: `startTemporaryChanges(boolean computeComparisons)`. Users can now explicitly disable the computation of topological comparisons by passing `false`. If they use one of the following methods: `get(Vertices|Edges)(AddedTo|removedFrom)MainComponent`, an exception is thrown.

`startTemporaryChanges` is kept and his behavior isn't changed.

When running a security analysis with ~5000 contingencies, ~5000 operator strategies with one action and `NaiveGraphConnectivity`, the total time spent on connectivity is reduced from 72 s to 60 s. When using DTree, the total time is reduced from 8.7 s to 5.6 s.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
