### PR TITLE
Refactor DistributedSlackOuterLoop reports when handling several SC

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/outerloop/DistributedSlackOuterLoop.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/outerloop/DistributedSlackOuterLoop.java
@@ -61,34 +61,43 @@ public class DistributedSlackOuterLoop
     public OuterLoopResult check(AcOuterLoopContext context, ReportNode reportNode) {
         Map<Integer, Double> slackMismatchPerSynchronousComponent = context.getLastSolverResult().getSlackBusActivePowerMismatch();
 
-        // If the LfNetwork contains only one synchronous component, it is not necessary to add a new indent level in
-        // the report node logs, i.e. we can use the input report node directly.
-        // Otherwise, we create one sub-report per synchronous component.
-        if (context.getNetwork().getSynchronousNetworks().size() == 1) {
-            LfSynchronousNetwork lfScNetwork = context.getNetwork().getSynchronousNetworks().getFirst();
-            return check(lfScNetwork, slackMismatchPerSynchronousComponent.get(lfScNetwork.getNumSC()), context, reportNode);
-        }
+        // We need to create a root report node in oder to include it only if there are child reports
+        ReportNode iterationReportNode = Reports.createRootOuterLoopIterationReporter(reportNode, context.getOuterLoopTotalIterations() + 1);
+        boolean severalSc = context.getNetwork().getSynchronousNetworks().size() > 1;
 
         OuterLoopStatus globalStatus = OuterLoopStatus.STABLE;
         for (LfSynchronousNetwork lfScNetwork : context.getNetwork().getSynchronousNetworks()) {
-            // We create one sub-report per synchronous component
-            ReportNode synchronousNetworkReport = Reports.createLfSynchronousNetworkReportNode(reportNode, lfScNetwork.getNumSC());
-            OuterLoopResult result = check(lfScNetwork, slackMismatchPerSynchronousComponent.get(lfScNetwork.getNumSC()), context, synchronousNetworkReport);
+            OuterLoopResult result = check(lfScNetwork, slackMismatchPerSynchronousComponent.get(lfScNetwork.getNumSC()), context, iterationReportNode, severalSc);
             if (result.status() == OuterLoopStatus.FAILED) {
+                // Include iteration report node in the main report node if it has children reports
+                if (!iterationReportNode.getChildren().isEmpty()) {
+                    reportNode.include(iterationReportNode);
+                }
                 return result; // We do not wait for the outer loops on other synchronous components
             } else if (result.status() == OuterLoopStatus.UNSTABLE) {
                 globalStatus = OuterLoopStatus.UNSTABLE;
             }
-            // Include synchronous network report node only if something was reported.
-            if (!synchronousNetworkReport.getChildren().isEmpty()) {
-                reportNode.include(synchronousNetworkReport);
-            }
+        }
+
+        // Include iteration report node in the main report node if it has children reports
+        if (!iterationReportNode.getChildren().isEmpty()) {
+            reportNode.include(iterationReportNode);
         }
         return new OuterLoopResult(this, globalStatus);
 
     }
 
-    public OuterLoopResult check(LfSynchronousNetwork lfScNetwork, double slackBusActivePowerMismatch, AcOuterLoopContext context, ReportNode reportNode) {
+    /**
+     * Check if slack buses active power mismatch must be distributed over generators or loads and update their target
+     * active power to do so if such case.
+     * @param lfScNetwork: The synchronous network on which slack bus mismatch must be checked and fixed.
+     * @param slackBusActivePowerMismatch Active power mismatch in the synchronous network. In per unit.
+     * @param context AC outer loop context.
+     * @param reportNode Report node of the current outer loop iteration
+     * @param createSubReport if true, create a sub report node with the synchronous network number. Otherwise, reports are directly added to the main report node.
+     * @return Outer loop result with its status and error message in case of failure.
+     */
+    public OuterLoopResult check(LfSynchronousNetwork lfScNetwork, double slackBusActivePowerMismatch, AcOuterLoopContext context, ReportNode reportNode, boolean createSubReport) {
         double absMismatch = Math.abs(slackBusActivePowerMismatch);
         boolean shouldDistributeSlack = absMismatch > slackBusPMaxMismatch / PerUnit.SB && absMismatch > ActivePowerDistribution.P_RESIDUE_EPS;
 
@@ -96,7 +105,7 @@ public class DistributedSlackOuterLoop
             LOGGER.debug("Already balanced");
             return new OuterLoopResult(this, OuterLoopStatus.STABLE);
         }
-        ReportNode iterationReportNode = Reports.createOuterLoopIterationReporter(reportNode, context.getOuterLoopTotalIterations() + 1);
+        ReportNode iterationReportNode = createSubReport ? Reports.createLfSynchronousNetworkReportNode(reportNode, lfScNetwork.getNumSC()) : reportNode;
         ActivePowerDistribution.Result result = activePowerDistribution.run(lfScNetwork, slackBusActivePowerMismatch);
         ActivePowerDistribution.ResultWithFailureBehaviorHandling resultWbh = ActivePowerDistribution.handleDistributionFailureBehavior(
                 context.getLoadFlowContext().getParameters().getSlackDistributionFailureBehavior(),

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetwork.java
@@ -742,7 +742,6 @@ public class LfNetwork extends AbstractPropertyBag implements PropertyBag, LfEle
                             ReportNode synchronousNetworkReport = Reports.createLfSynchronousNetworkReportNode(networkReport, lfScNetwork.getNumSC());
                             Reports.reportAngleReferenceBusAndSlackBuses(synchronousNetworkReport, lfScNetwork.getReferenceBus().getId(),
                                 lfScNetwork.getSlackBuses().stream().map(LfBus::getId).toList());
-                            networkReport.include(synchronousNetworkReport);
                         }
                     }
                     lfNetwork.setReportNode(Reports.includeLfNetworkReportNode(reportNode, lfNetwork.getReportNode()));

--- a/src/main/java/com/powsybl/openloadflow/util/Reports.java
+++ b/src/main/java/com/powsybl/openloadflow/util/Reports.java
@@ -873,18 +873,15 @@ public final class Reports {
     }
 
     /**
-     * Create a Root report node for a synchronous network. It is identified only by its synchronous component number.
-     * @param firstRootReportNode original root report node. Used to get locale parameter.
+     * Create a report node for a synchronous network. It is identified only by its synchronous component number.
      * @param networkNumSc number of the synchronous component represented by the LfSynchronousNetwork associated to this report node.
      * @return a new report node to be used by a LfSynchronousNetwork.
      */
-    public static ReportNode createLfSynchronousNetworkReportNode(ReportNode firstRootReportNode, int networkNumSc) {
-        return ReportNode.newRootReportNode()
-            .withLocale(firstRootReportNode.getTreeContext().getLocale())
-            .withAllResourceBundlesFromClasspath()
+    public static ReportNode createLfSynchronousNetworkReportNode(ReportNode reportNode, int networkNumSc) {
+        return reportNode.newReportNode()
             .withMessageTemplate("olf.lfScNetwork")
             .withUntypedValue(NETWORK_NUM_SC, networkNumSc)
-            .build();
+            .add();
     }
 
     public static ReportNode includeLfNetworkReportNode(ReportNode reportNode, ReportNode lfNetworkReportNode) {
@@ -910,6 +907,15 @@ public final class Reports {
                 .withMessageTemplate("olf.OuterLoopIteration")
                 .withUntypedValue("outerLoopIteration", outerLoopIteration)
                 .add();
+    }
+
+    public static ReportNode createRootOuterLoopIterationReporter(ReportNode firstRootReportNode, int outerLoopIteration) {
+        return ReportNode.newRootReportNode()
+            .withLocale(firstRootReportNode.getTreeContext().getLocale())
+            .withAllResourceBundlesFromClasspath()
+            .withMessageTemplate("olf.OuterLoopIteration")
+            .withUntypedValue("outerLoopIteration", outerLoopIteration)
+            .build();
     }
 
     public static ReportNode createSensitivityAnalysis(ReportNode reportNode, String networkId) {

--- a/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowReportTest.java
+++ b/src/test/java/com/powsybl/openloadflow/ac/AcLoadFlowReportTest.java
@@ -482,11 +482,10 @@ class AcLoadFlowReportTest {
                               Bus V: 1 pu, 0 rad
                               Bus injection: 70 MW, 0 MVar
                      + Outer loop DistributedSlack
-                        + SC0
-                           + Outer loop iteration 1
+                        + Outer loop iteration 1
+                           + SC0
                               Slack bus active power (40 MW) distributed in 1 distribution iteration(s)
-                        + SC1
-                           + Outer loop iteration 1
+                           + SC1
                               Slack bus active power (-19.998222 MW) distributed in 1 distribution iteration(s)
                      + Newton-Raphson on Network CC0
                         Newton-Raphson of outer loop iteration 1 of type DistributedSlack


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] A PR or issue has been opened in all impacted repositories (if any)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Minor feature change, not covered in the last PR : clean reports for distributed slack outer loop when there are several SC


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Report structure is
```
+ Outer loop DistributedSlack
   + SC0
      + Outer loop iteration 1
         Slack bus active power (40 MW) distributed in 1 distribution iteration(s)
   + SC1
      + Outer loop iteration 1
         Slack bus active power (-19.998222 MW) distributed in 1 distribution iteration(s)
```


**What is the new behavior (if this is a feature change)?**
New structure is 
```
+ Outer loop DistributedSlack
   + Outer loop iteration 1
      + SC0
         Slack bus active power (40 MW) distributed in 1 distribution iteration(s)
      + SC1
         Slack bus active power (-19.998222 MW) distributed in 1 distribution iteration(s)
```
Please not that a SC is not added if there is no report inside.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

