### PR TITLE
Avoid recomputation of Jacobian Matrix in DC mode when state update

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/AcEquationSystemUpdater.java
@@ -220,11 +220,11 @@ public class AcEquationSystemUpdater extends AbstractEquationSystemUpdater<AcVar
     }
 
     @Override
-    public void onTapPositionChange(LfBranch branch, int oldPosition, int newPosition) {
+    public void onTapPositionChange(LfBranch branch, int oldPosition, int newPosition, boolean modifiedTapImpedance) {
         // TODO :
         //  This code is not necessary with AcVectorizedEquationSystemCreator since values of closed branch terms are updated in AcBranchVector
         //  It should be removed if vectorized parameter in AcLoadFlowParameters is removed
-        if (branch.isConnectedSide1() && branch.isConnectedSide2()) { // Transformers that can change tap position should only be closed branches
+        if (modifiedTapImpedance && branch.isConnectedSide1() && branch.isConnectedSide2()) { // Transformers that can change tap position should only be closed branches
             PiModel piModel = branch.getPiModel();
             updateAcClosedBranchEquationTerm(branch.getClosedP1(), piModel);
             updateAcClosedBranchEquationTerm(branch.getClosedQ1(), piModel);
@@ -232,6 +232,7 @@ public class AcEquationSystemUpdater extends AbstractEquationSystemUpdater<AcVar
             updateAcClosedBranchEquationTerm(branch.getClosedP2(), piModel);
             updateAcClosedBranchEquationTerm(branch.getClosedQ2(), piModel);
             updateAcClosedBranchEquationTerm(branch.getClosedI2(), piModel);
+            equationSystem.notifyEquationTermConstantsChange();
         }
     }
 

--- a/src/main/java/com/powsybl/openloadflow/ac/equations/vector/AcNetworkVector.java
+++ b/src/main/java/com/powsybl/openloadflow/ac/equations/vector/AcNetworkVector.java
@@ -251,11 +251,13 @@ public class AcNetworkVector extends AbstractLfNetworkListener
     }
 
     @Override
-    public void onTapPositionChange(LfBranch branch, int oldPosition, int newPosition) {
+    public void onTapPositionChange(LfBranch branch, int oldPosition, int newPosition, boolean modifiedTapPosition) {
         PiModel piModel = branch.getPiModel();
 
-        double y = piModel.getY();
-        branchVector.y[branch.getNum()] = y;
+        if (modifiedTapPosition) {
+            double y = piModel.getY();
+            branchVector.y[branch.getNum()] = y;
+        }
         double ksi = piModel.getKsi();
         var w = new DoubleWrapper();
         branchVector.ksi[branch.getNum()] = ksi;
@@ -311,6 +313,11 @@ public class AcNetworkVector extends AbstractLfNetworkListener
 
     @Override
     public void onEquationIndexOrderChanged() {
+        // nothing to do
+    }
+
+    @Override
+    public void onEquationTermConstantsChanged() {
         // nothing to do
     }
 

--- a/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowContext.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/DcLoadFlowContext.java
@@ -37,7 +37,7 @@ public class DcLoadFlowContext extends AbstractLoadFlowContext<DcVariableType, D
     @Override
     public JacobianMatrix<DcVariableType, DcEquationType> getJacobianMatrix() {
         if (jacobianMatrix == null) {
-            jacobianMatrix = new JacobianMatrix<>(getEquationSystem(), parameters.getMatrixFactory());
+            jacobianMatrix = new JacobianMatrix<>(getEquationSystem(), parameters.getMatrixFactory(), false);
         }
         return jacobianMatrix;
     }

--- a/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationSystemUpdater.java
+++ b/src/main/java/com/powsybl/openloadflow/dc/equations/DcEquationSystemUpdater.java
@@ -87,6 +87,13 @@ public class DcEquationSystemUpdater extends AbstractEquationSystemUpdater<DcVar
     }
 
     @Override
+    public void onTapPositionChange(LfBranch branch, int oldPosition, int newPosition, boolean modifiedTapImpedance) {
+        if (modifiedTapImpedance) {
+            equationSystem.notifyEquationTermConstantsChange();
+        }
+    }
+
+    @Override
     protected DcEquationType getTypeBusTargetP() {
         return DcEquationType.BUS_TARGET_P;
     }

--- a/src/main/java/com/powsybl/openloadflow/equations/AbstractVector.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/AbstractVector.java
@@ -57,6 +57,11 @@ public abstract class AbstractVector<V extends Enum<V> & Quantity, E extends Enu
         public void onEquationIndexOrderChanged() {
             invalidateVector();
         }
+
+        @Override
+        public void onEquationTermConstantsChanged() {
+            // nothing to do
+        }
     };
 
     protected AbstractVector(EquationSystem<V, E> equationSystem) {

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationSystem.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationSystem.java
@@ -295,6 +295,10 @@ public class EquationSystem<V extends Enum<V> & Quantity, E extends Enum<E> & Qu
         listeners.forEach(listener -> listener.onEquationArrayChange(equationArray, elementNum, eventType));
     }
 
+    public void notifyEquationTermConstantsChange() {
+        listeners.forEach(listener -> listener.onEquationTermConstantsChange());
+    }
+
     public void write(Writer writer, boolean writeInactiveEquations) {
         try {
             for (SingleEquation<V, E> equation : equations.values().stream().sorted().collect(Collectors.toList())) {

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationSystemIndex.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationSystemIndex.java
@@ -87,6 +87,10 @@ public class EquationSystemIndex<V extends Enum<V> & Quantity, E extends Enum<E>
         listeners.forEach(EquationSystemIndexListener::onEquationIndexOrderChanged);
     }
 
+    private void notifyEquationTermConstantsChanged() {
+        listeners.forEach(EquationSystemIndexListener::onEquationTermConstantsChanged);
+    }
+
     private void updateEquationColumns(Collection<SingleEquation<V, E>> singleEquations, Collection<EquationArray<V, E>> equationArrays) {
         for (SingleEquation<V, E> equation : singleEquations) {
             equation.setColumn(columnCount++);
@@ -369,6 +373,11 @@ public class EquationSystemIndex<V extends Enum<V> & Quantity, E extends Enum<E>
                     throw new IllegalStateException("Event type not supported: " + eventType);
             }
         }
+    }
+
+    @Override
+    public void onEquationTermConstantsChange() {
+        notifyEquationTermConstantsChanged();
     }
 
     public List<SingleEquation<V, E>> getSortedSingleEquationsToSolve() {

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationSystemIndexListener.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationSystemIndexListener.java
@@ -40,4 +40,9 @@ public interface EquationSystemIndexListener<V extends Enum<V> & Quantity, E ext
      * Called when the order of variables or columns has been changed even without any change in equations (can happen when using Fast Decoupled)
      */
     void onEquationIndexOrderChanged();
+
+    /**
+     * Called when a constant has been modified in the equation terms (e.g. R or X of branches after tap position change)
+     */
+    void onEquationTermConstantsChanged();
 }

--- a/src/main/java/com/powsybl/openloadflow/equations/EquationSystemListener.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/EquationSystemListener.java
@@ -19,4 +19,6 @@ public interface EquationSystemListener<V extends Enum<V> & Quantity, E extends 
     void onEquationArrayChange(EquationArray<V, E> equationArray, int elementNum, EquationEventType eventType);
 
     void onEquationTermArrayChange(EquationTermArray<V, E> equationTermArray, int termNum, EquationTermEventType eventType);
+
+    void onEquationTermConstantsChange();
 }

--- a/src/main/java/com/powsybl/openloadflow/equations/JacobianMatrix.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/JacobianMatrix.java
@@ -35,6 +35,8 @@ public class JacobianMatrix<V extends Enum<V> & Quantity, E extends Enum<E> & Qu
 
     protected final MatrixFactory matrixFactory;
 
+    private final boolean invalidateValuesWhenStateUpdate; // in DC mode, there is no need to recompute derivatives after state update
+
     protected Matrix matrix;
 
     private LUDecomposition lu;
@@ -48,11 +50,16 @@ public class JacobianMatrix<V extends Enum<V> & Quantity, E extends Enum<E> & Qu
 
     private Status status = Status.STRUCTURE_INVALID;
 
-    public JacobianMatrix(EquationSystem<V, E> equationSystem, MatrixFactory matrixFactory) {
+    public JacobianMatrix(EquationSystem<V, E> equationSystem, MatrixFactory matrixFactory, boolean invalidateValuesWhenStateUpdate) {
         this.equationSystem = Objects.requireNonNull(equationSystem);
         this.matrixFactory = Objects.requireNonNull(matrixFactory);
+        this.invalidateValuesWhenStateUpdate = invalidateValuesWhenStateUpdate;
         equationSystem.getIndex().addListener(this);
         equationSystem.getStateVector().addListener(this);
+    }
+
+    public JacobianMatrix(EquationSystem<V, E> equationSystem, MatrixFactory matrixFactory) {
+        this(equationSystem, matrixFactory, true);
     }
 
     public MatrixFactory getMatrixFactory() {
@@ -96,8 +103,15 @@ public class JacobianMatrix<V extends Enum<V> & Quantity, E extends Enum<E> & Qu
     }
 
     @Override
-    public void onStateUpdate() {
+    public void onEquationTermConstantsChanged() {
         updateStatus(Status.VALUES_INVALID);
+    }
+
+    @Override
+    public void onStateUpdate() {
+        if (invalidateValuesWhenStateUpdate) {
+            updateStatus(Status.VALUES_INVALID);
+        }
     }
 
     protected void initDer() {

--- a/src/main/java/com/powsybl/openloadflow/equations/TargetVector.java
+++ b/src/main/java/com/powsybl/openloadflow/equations/TargetVector.java
@@ -61,7 +61,7 @@ public class TargetVector<V extends Enum<V> & Quantity, E extends Enum<E> & Quan
         }
 
         @Override
-        public void onTapPositionChange(LfBranch branch, int oldPosition, int newPosition) {
+        public void onTapPositionChange(LfBranch branch, int oldPosition, int newPosition, boolean modifiedTapImpedance) {
             invalidateValues();
         }
 

--- a/src/main/java/com/powsybl/openloadflow/network/AbstractLfNetworkListener.java
+++ b/src/main/java/com/powsybl/openloadflow/network/AbstractLfNetworkListener.java
@@ -77,7 +77,7 @@ public abstract class AbstractLfNetworkListener implements LfNetworkListener {
     }
 
     @Override
-    public void onTapPositionChange(LfBranch branch, int oldPosition, int newPosition) {
+    public void onTapPositionChange(LfBranch branch, int oldPosition, int newPosition, boolean modifiedTapImpedance) {
         // empty
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetworkListener.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetworkListener.java
@@ -40,7 +40,7 @@ public interface LfNetworkListener {
 
     void onDisableChange(LfElement element, boolean disabled);
 
-    void onTapPositionChange(LfBranch branch, int oldPosition, int newPosition);
+    void onTapPositionChange(LfBranch branch, int oldPosition, int newPosition, boolean modifiedTapImpedance);
 
     void onShuntSusceptanceChange(LfShunt shunt, double b);
 

--- a/src/main/java/com/powsybl/openloadflow/network/LfNetworkListenerTracer.java
+++ b/src/main/java/com/powsybl/openloadflow/network/LfNetworkListenerTracer.java
@@ -119,10 +119,10 @@ public class LfNetworkListenerTracer implements LfNetworkListener {
     }
 
     @Override
-    public void onTapPositionChange(LfBranch branch, int oldPosition, int newPosition) {
-        LOGGER.trace("onTapPositionChange(branchId='{}', oldPosition={}, newPosition={})",
-                branch.getId(), oldPosition, newPosition);
-        delegate.onTapPositionChange(branch, oldPosition, newPosition);
+    public void onTapPositionChange(LfBranch branch, int oldPosition, int newPosition, boolean modifiedTapImpedance) {
+        LOGGER.trace("onTapPositionChange(branchId='{}', oldPosition={}, newPosition={}, modifiedTapImpedance={})",
+                branch.getId(), oldPosition, newPosition, modifiedTapImpedance);
+        delegate.onTapPositionChange(branch, oldPosition, newPosition, modifiedTapImpedance);
     }
 
     @Override

--- a/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
+++ b/src/main/java/com/powsybl/openloadflow/network/PiModelArray.java
@@ -246,8 +246,11 @@ public class PiModelArray implements PiModel {
         tapPositionIndex = finder.find(models, tapPositionIndex, valueGetter, positionIndexRange, maxTapShift);
 
         if (tapPositionIndex != oldPositionIndex) {
+            PiModel oldPiModel = models.get(oldPositionIndex);
+            PiModel newPiModel = models.get(tapPositionIndex);
+            boolean modifiedTapImpedance = oldPiModel.getR() != newPiModel.getR() || oldPiModel.getX() != newPiModel.getX();
             for (LfNetworkListener listener : branch.getNetwork().getListeners()) {
-                listener.onTapPositionChange(branch, lowTapPosition + oldPositionIndex, lowTapPosition + tapPositionIndex);
+                listener.onTapPositionChange(branch, lowTapPosition + oldPositionIndex, lowTapPosition + tapPositionIndex, modifiedTapImpedance);
             }
 
             return Optional.of(tapPositionIndex - oldPositionIndex > 0 ? Direction.INCREASE : Direction.DECREASE);
@@ -319,8 +322,11 @@ public class PiModelArray implements PiModel {
 
         if (tapPositionIndex != oldTapPositionIndex) {
             a1 = Double.NaN;
+            PiModel oldPiModel = models.get(oldTapPositionIndex);
+            PiModel newPiModel = models.get(tapPositionIndex);
+            boolean modifiedTapImpedance = oldPiModel.getR() != newPiModel.getR() || oldPiModel.getX() != newPiModel.getX();
             for (LfNetworkListener listener : branch.getNetwork().getListeners()) {
-                listener.onTapPositionChange(branch, lowTapPosition + oldTapPositionIndex, lowTapPosition + tapPositionIndex);
+                listener.onTapPositionChange(branch, lowTapPosition + oldTapPositionIndex, lowTapPosition + tapPositionIndex, modifiedTapImpedance);
             }
             return true;
         }
@@ -399,8 +405,11 @@ public class PiModelArray implements PiModel {
             r1 = Double.NaN;
             continuousR1 = Double.NaN;
             a1 = Double.NaN;
+            PiModel oldPiModel = models.get(oldTapPositionIndex);
+            PiModel newPiModel = models.get(tapPosition - lowTapPosition);
+            boolean modifiedTapImpedance = oldPiModel.getR() != newPiModel.getR() || oldPiModel.getX() != newPiModel.getX();
             for (LfNetworkListener listener : branch.getNetwork().getListeners()) {
-                listener.onTapPositionChange(branch, lowTapPosition + oldTapPositionIndex, tapPosition);
+                listener.onTapPositionChange(branch, lowTapPosition + oldTapPositionIndex, tapPosition, modifiedTapImpedance);
             }
         }
         return this;

--- a/src/test/java/com/powsybl/openloadflow/equations/EquationSystemIndexTest.java
+++ b/src/test/java/com/powsybl/openloadflow/equations/EquationSystemIndexTest.java
@@ -110,6 +110,11 @@ class EquationSystemIndexTest {
             public void onEquationIndexOrderChanged() {
                 // nothing to do
             }
+
+            @Override
+            public void onEquationTermConstantsChanged() {
+                // nothing to do
+            }
         });
 
         // x = a + b

--- a/src/test/java/com/powsybl/openloadflow/equations/EquationSystemTest.java
+++ b/src/test/java/com/powsybl/openloadflow/equations/EquationSystemTest.java
@@ -74,6 +74,11 @@ class EquationSystemTest {
             public void onEquationTermArrayChange(EquationTermArray<AcVariableType, AcEquationType> equationTermArray, int termNum, EquationTermEventType eventType) {
                 // nothing to do
             }
+
+            @Override
+            public void onEquationTermConstantsChange() {
+                // nothing to do
+            }
         });
         assertTrue(equations.isEmpty());
         assertTrue(equationEventTypes.isEmpty());

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -16,10 +16,10 @@
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
-    <logger name="com.powsybl.openloadflow" level="DEBUG" additivity="false">
+    <logger name="com.powsybl.openloadflow" level="INFO" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
-    <logger name="com.powsybl.openloadflow.network.LfNetworkListenerTracer" level="TRACE" additivity="false">
+    <logger name="com.powsybl.openloadflow.network.LfNetworkListenerTracer" level="INFO" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
 </configuration>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
Jacobian matrix values were always recomputed when state variables are updated even in DC mode


**What is the current behavior?**
In DC mode (even with network cache enabled), any state variables change needs to recompute Jacobian matrix values

**What is the new behavior (if this is a feature change)?**
Since derivatives do not depend on state variables in DC mode, the boolean `invalidateValuesWhenStateUpdate` is introduced in the constructor of JacobianMatrix to avoid recomputation in DC mode if only state variables change.

Nevertheless the corner case of tap changes should be handled: if the tap impedance changes, the derivative should be recomputed, hence a new listener event `EquationTermConstantsChange` to update the matrix in this particular case


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
