### PR TITLE
Fix: Reset DC state variables

### DIFF
--- a/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
@@ -64,6 +64,16 @@ public final class Networks {
         resetInjectionsState(network.getLccConverterStations());
         resetInjectionsState(network.getBatteries());
         resetInjectionsState(network.getBoundaryLines());
+
+        for (DcBus dcb : network.getDcBuses()) {
+            dcb.setV(Double.NaN);
+        }
+        for (DcLine dcl : network.getDcLines()) {
+            dcl.unsetSolvedValues();
+        }
+        for (VoltageSourceConverter vsc : network.getVoltageSourceConverters()) {
+            vsc.unsetSolvedValues();
+        }
     }
 
     private static double getDoubleProperty(Identifiable<?> identifiable, String name) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Load flow variables of DC equipment are not reset. Therefore the IIDM might contain load flow results of two diferent load flow


**What is the new behavior (if this is a feature change)?**
DC equipment load flow variable are correctly reset in IIDM


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
