### PR TITLE
Detect and auto-repair invalid DC configuration

### DIFF
--- a/docs/loadflow/loadflow.md
+++ b/docs/loadflow/loadflow.md
@@ -379,7 +379,8 @@ Please note that converters with a second optional AC terminal are not supported
 
 The converter can control either the power received by the AC network (`P_PCC` control mode) 
 or the voltage between its two DC buses (`V_DC` control mode).
-At least one of the voltage source converters of the DC network must be in `V_DC` mode. Otherwise, an exception will be thrown.
+At least one of the voltage source converters of the DC network must control the voltage (i.e. be in `V_DC` or `P_PCC_DROOP` mode).
+If a DC network has only converters in `P_PCC` mode, they will be automatically set in `V_DC` mode with the DC nominal voltage as target voltage.
 
 In addition to the control modes `P_PCC` and `V_DC`, the voltage source converter can be set in two modes :
 - Reactive power control mode, in which it imposes the reactive power received from AC to DC, which is 0 by default.

--- a/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfAcDcConverter.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/AbstractLfAcDcConverter.java
@@ -12,6 +12,8 @@ import com.powsybl.openloadflow.network.*;
 import com.powsybl.openloadflow.util.Evaluable;
 import com.powsybl.openloadflow.util.PerUnit;
 
+import java.util.Optional;
+
 /**
  * @author Denis Bonnand {@literal <denis.bonnand at supergrid-institute.com>}
  */
@@ -43,16 +45,19 @@ public abstract class AbstractLfAcDcConverter extends AbstractElement implements
 
     protected final LfBus bus1;
 
-    protected AbstractLfAcDcConverter(AcDcConverter<?> converter, LfNetwork network, LfDcBus dcBus1, LfDcBus dcBus2, LfBus bus1) {
+    protected AbstractLfAcDcConverter(AcDcConverter<?> converter, LfNetwork network, LfDcBus dcBus1, LfDcBus dcBus2, LfBus bus1, Optional<Double> vdcOverride) {
         super(network);
 
         this.dcBus1 = dcBus1;
         this.dcBus2 = dcBus2;
         this.bus1 = bus1;
         this.lossFactors = new LossFactors(converter.getIdleLoss(), converter.getSwitchingLoss(), converter.getResistiveLoss());
-        this.controlMode = converter.getControlMode();
+        // vdcOverride is set when this converter has been automatically promoted to V_DC control because its DC
+        // island had no other element imposing the DC voltage (see DcComponentValidator.resolveDcComponent)
+        this.controlMode = vdcOverride.isPresent() ? AcDcConverter.ControlMode.V_DC : converter.getControlMode();
         this.targetP = converter.getTargetP() / PerUnit.SB;
-        targetVdc = dcBus1.isGrounded() ? converter.getTargetVdc() / dcBus2.getNominalV() : converter.getTargetVdc() / dcBus1.getNominalV();
+        double rawTargetVdc = vdcOverride.orElseGet(converter::getTargetVdc);
+        targetVdc = dcBus1.isGrounded() ? rawTargetVdc / dcBus2.getNominalV() : rawTargetVdc / dcBus1.getNominalV();
         this.pAc = converter.getTerminal1().getP();
         this.qAc = converter.getTerminal1().getQ();
     }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/DcComponentValidator.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/DcComponentValidator.java
@@ -1,0 +1,199 @@
+/**
+ * Copyright (c) 2026, SuperGrid Institute (http://www.supergrid-institute.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.openloadflow.network.impl;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.*;
+
+import java.util.*;
+import java.util.function.Predicate;
+
+/**
+ * Helper methods to validate a DcComponent configuration and, when possible, automatically resolve an
+ * otherwise invalid one.
+ *
+ * @author Baptiste Perreyon {@literal <baptiste.perreyon at supergrid-institute.com>}
+ */
+final class DcComponentValidator {
+
+    private DcComponentValidator() {
+    }
+
+    /**
+     * Check that a DC component is a configuration Open Load Flow can solve, and resolve any DC subcomponent (i.e. set
+     * of DC buses connected through DC lines only) that has no element imposing the DC voltage (no connected DC
+     * ground and no fully connected V_DC/P_PCC_DROOP converter), by selecting all fully connected P_PCC
+     * converters of that subcomponent to be promoted to V_DC control internally. Disconnected converters are
+     * ignored: only fully connected ones take part in the checks/resolution.
+     *
+     * @param dcBuses        All DC buses found in the DC component.
+     * @param acDcConverters All AC-DC converters found in the DC component.
+     * @param numDcc         The DC component's id, used in error messages.
+     * @return A list of AC-DC converter promoted to V_DC control, to use instead of the converter's own IIDM value;
+     *         empty if no promotion was necessary.
+     * @throws PowsyblException If the DC component configuration is invalid and cannot be resolved automatically.
+     */
+    static List<AcDcConverter<?>> resolveDcComponent(List<DcBus> dcBuses, Collection<AcDcConverter<?>> acDcConverters,
+                                                     int numDcc) {
+        List<AcDcConverter<?>> connectedConverters = acDcConverters.stream()
+                .filter(DcComponentValidator::isFullyConnected)
+                .toList();
+        checkAllConvertersAreIndirectlyConnectedToADcGround(connectedConverters);
+
+        List<AcDcConverter<?>> convertersToUpdate = new ArrayList<>();
+        Set<String> visitedBusIds = new HashSet<>();
+        List<DcBus> sortedDcBuses = dcBuses.stream().sorted(Comparator.comparing(DcBus::getId)).toList();
+        for (DcBus dcBus : sortedDcBuses) {
+            if (visitedBusIds.contains(dcBus.getId())) {
+                continue;
+            }
+            DcSubComponent dcSubComponent = DcSubComponent.around(dcBus);
+            visitedBusIds.addAll(dcSubComponent.getVisitedBusIds());
+            resolveDcSubComponentIfNeeded(dcSubComponent, convertersToUpdate, numDcc);
+        }
+        return convertersToUpdate;
+    }
+
+    /**
+     * Add all converters of the DC subcomponent to V_DC control if the subcomponent has no element already imposing DC
+     * voltage; do nothing otherwise.
+     *
+     * @throws PowsyblException If the DC subcomponent has no element imposing voltage and no converter can be promoted.
+     */
+    private static void resolveDcSubComponentIfNeeded(DcSubComponent dcSubComponent, List<AcDcConverter<?>> convertersToUpdate, int numDcc) {
+        if (dcSubComponent.hasConnectedDcGround()
+                || dcSubComponent.hasConverterMatching(c -> controlsDcVoltage(c) || convertersToUpdate.contains(c))) {
+            return; // already has (or was just given, while resolving an adjacent dcSubComponent) an element imposing DC voltage
+        }
+        Set<AcDcConverter<?>> dcSubComponentConverters = dcSubComponent.getConverters();
+        if (dcSubComponentConverters.isEmpty()) {
+            throw new PowsyblException("DC component " + numDcc + " has a DC subcomponent with no DC ground "
+                    + "and no AC-DC converter able to settle the DC voltage");
+        }
+        convertersToUpdate.addAll(dcSubComponentConverters);
+    }
+
+    /**
+     * Check that at least one of the DC terminal of each AC-DC converter is indirectly connected (i.e. through DC
+     * lines) to a DC ground.
+     *
+     * @param acDcConverters A list of AC-DC converters to check.
+     * @throws PowsyblException If at least one AC-DC converter is not indirectly connected to a DC ground
+     */
+    private static void checkAllConvertersAreIndirectlyConnectedToADcGround(List<AcDcConverter<?>> acDcConverters) {
+        for (AcDcConverter<?> converter : acDcConverters) {
+            if (!isConnectedToGround(converter.getDcTerminal1()) && !isConnectedToGround(converter.getDcTerminal2())) {
+                throw new PowsyblException(String.format("Converter %s is not indirectly connected to a DC ground", converter.getId()));
+            }
+        }
+    }
+
+    /**
+     * Tells whether a converter settles the DC voltage: V_DC does it directly, P_PCC_DROOP does it
+     * through the droop law.
+     */
+    private static boolean controlsDcVoltage(AcDcConverter<?> converter) {
+        return converter.getControlMode() == AcDcConverter.ControlMode.V_DC
+                || converter.getControlMode() == AcDcConverter.ControlMode.P_PCC_DROOP;
+    }
+
+    /**
+     * Tells whether a converter has its AC terminal and both its DC terminals connected.
+     */
+    private static boolean isFullyConnected(AcDcConverter<?> converter) {
+        return converter.getTerminal1().isConnected()
+                && converter.getDcTerminal1().isConnected()
+                && converter.getDcTerminal2().isConnected();
+    }
+
+    /**
+     * Tells whether a DC terminal is indirectly connected, through DC lines, to a connected DC ground.
+     */
+    private static boolean isConnectedToGround(DcTerminal startTerminal) {
+        return DcSubComponent.around(startTerminal).hasConnectedDcGround();
+    }
+
+    /**
+     * The set of DC buses, connected DC grounds, and connected AC/DC converters reachable from a given DC bus by following
+     * **only** connected DC lines but not AC/DC converters.
+     * Each DcSubComponent shall contain at least one element imposing voltage to be valid. Built using a breadth-first search.
+     * <p>
+     * Note: When all DC lines of the DcComponent are connected, this corresponds to a DC pole.
+     */
+    private static final class DcSubComponent implements DcTopologyVisitor {
+
+        private final Set<String> visitedBusIds = new HashSet<>();
+        private final Deque<DcBus> busesToVisit = new ArrayDeque<>();
+        private final List<DcGround> connectedGrounds = new ArrayList<>();
+        private final Set<AcDcConverter<?>> converters = new LinkedHashSet<>();
+
+        /**
+         * Explores the DC subcomponent around {@code startBus}; a null bus yields an empty DC subcomponent.
+         */
+        static DcSubComponent around(DcBus startBus) {
+            DcSubComponent dcSubComponent = new DcSubComponent();
+            dcSubComponent.enqueue(startBus);
+            while (!dcSubComponent.busesToVisit.isEmpty()) {
+                dcSubComponent.busesToVisit.poll().visitConnectedEquipments(dcSubComponent);
+            }
+            return dcSubComponent;
+        }
+
+        /**
+         * Explores the DC subcomponent around {@code startTerminal}; an unconnected terminal yields an empty DC DCsubcomponent.
+         */
+        static DcSubComponent around(DcTerminal startTerminal) {
+            return around(startTerminal.getDcBus());
+        }
+
+        private void enqueue(DcBus dcBus) {
+            if (dcBus != null && visitedBusIds.add(dcBus.getId())) {
+                busesToVisit.add(dcBus);
+            }
+        }
+
+        Set<String> getVisitedBusIds() {
+            return visitedBusIds;
+        }
+
+        boolean hasConnectedDcGround() {
+            return !connectedGrounds.isEmpty();
+        }
+
+        boolean hasConverterMatching(Predicate<AcDcConverter<?>> predicate) {
+            return converters.stream().anyMatch(predicate);
+        }
+
+        Set<AcDcConverter<?>> getConverters() {
+            return converters;
+        }
+
+        @Override
+        public void visitDcLine(DcLine dcLine, TwoSides side) {
+            // side is the one connected to the bus being visited: carry on through the other side
+            DcTerminal otherTerminal = dcLine.getDcTerminal(side == TwoSides.ONE ? TwoSides.TWO : TwoSides.ONE);
+            if (otherTerminal.isConnected()) {
+                enqueue(otherTerminal.getDcBus());
+            }
+        }
+
+        @Override
+        public void visitDcGround(DcGround dcGround) {
+            if (dcGround.getDcTerminal().isConnected()) {
+                connectedGrounds.add(dcGround);
+            }
+        }
+
+        @Override
+        public void visitAcDcConverter(AcDcConverter<?> converter, TerminalNumber terminalNumber) {
+            if (isFullyConnected(converter)) {
+                converters.add(converter);
+            }
+        }
+    }
+}

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfNetworkLoaderImpl.java
@@ -630,7 +630,14 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
         }
     }
 
-    private static void createAcDcConverter(AcDcConverter<?> acDcConverter, LfNetwork lfNetwork, LfNetworkParameters parameters) {
+    private static void createAcDcConverters(LfNetwork lfNetwork, LoadingContext loadingContext, LfNetworkParameters parameters,
+                                             List<AcDcConverter<?>> convertersToSetInVdcMode, double dcNominalV) {
+        for (AcDcConverter<?> acDcConverter : loadingContext.acDcConverterSet) {
+            createAcDcConverter(acDcConverter, lfNetwork, parameters, convertersToSetInVdcMode.contains(acDcConverter) ? Optional.of(dcNominalV) : Optional.empty());
+        }
+    }
+
+    private static void createAcDcConverter(AcDcConverter<?> acDcConverter, LfNetwork lfNetwork, LfNetworkParameters parameters, Optional<Double> vdcOverride) {
 
         if (acDcConverter.getTerminal2().isPresent()) {
             throw new PowsyblException("Open Load Flow does not support AC/DC converters with two AC terminals");
@@ -641,7 +648,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
             LfDcBus lfDcBus1 = getLfDcBus(acDcConverter.getDcTerminal1(), lfNetwork);
             LfDcBus lfDcBus2 = getLfDcBus(acDcConverter.getDcTerminal2(), lfNetwork);
             if (acDcConverter instanceof VoltageSourceConverter voltageSourceConverter) {
-                LfVoltageSourceConverterImpl voltageSourceConverterImpl = LfVoltageSourceConverterImpl.create(voltageSourceConverter, lfNetwork, lfDcBus1, lfDcBus2, lfBus1, parameters);
+                LfVoltageSourceConverterImpl voltageSourceConverterImpl = LfVoltageSourceConverterImpl.create(voltageSourceConverter, lfNetwork, lfDcBus1, lfDcBus2, lfBus1, parameters, vdcOverride);
 
                 if (voltageSourceConverterImpl.isVoltageRegulatorOn()) {
                     VoltageSourceConverterVoltageControl voltageControl = new VoltageSourceConverterVoltageControl(lfBus1,
@@ -1365,17 +1372,19 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
                     throw new PowsyblException("DcSwitch " + s.getId() + " has non zero resistance: not handled yet in AC DC load flow (R = " + s.getR() + ")");
                 });
 
-        // Ensure at least one converter controls V_DC
-        boolean isVdcControlled = false;
-        for (AcDcConverter<?> converter : loadingContext.acDcConverterSet) {
-            if (converter.getControlMode() == AcDcConverter.ControlMode.V_DC) {
-                isVdcControlled = true;
-                break;
-            }
-        }
-        if (!isVdcControlled) {
-            throw new PowsyblException("At least one AC/DC converter control mode must be V_DC in each DC component, but DC component " + numDcc + " does not have any");
-        }
+        // -- Sanity checks : detecting invalid DC configuration and automatically resolving reference-less islands
+        double dcNominalV = dcVoltages.iterator().next();
+        List<AcDcConverter<?>> convertersToSetInVdcMode =
+                DcComponentValidator.resolveDcComponent(dcBuses, loadingContext.acDcConverterSet, numDcc);
+        convertersToSetInVdcMode.forEach(converter -> {
+            LOGGER.info("Network {}: converter '{}' automatically set to V_DC control mode (target Vdc = {} kV) " +
+                            "to settle an otherwise unconstrained DC island in DC component {}",
+                    lfNetwork, converter.getId(), dcNominalV, numDcc);
+            Reports.reportAutomaticVdcReferenceConverter(lfNetwork.getReportNode(), numDcc, converter.getId(), dcNominalV);
+        });
+
+        // Add AC-DC converters to the LfNetwork
+        createAcDcConverters(lfNetwork, loadingContext, parameters, convertersToSetInVdcMode, dcNominalV);
 
         postProcessors.forEach(pp -> pp.onLfNetworkLoaded(network, lfNetwork));
     }
@@ -1675,7 +1684,7 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
                     )
             );
 
-            // Create DC networks
+            // Create DC networks and add AC-DC converters
             filteredDcBusesByComponentStream.forEach(e ->
                     addDcComponentElements(
                             e.getKey().getLeft(),
@@ -1687,20 +1696,6 @@ public class LfNetworkLoaderImpl implements LfNetworkLoader<Network> {
                     )
             );
 
-            // Add AC-DC converters
-            for (AcDcConverter<?> converter : network.getVoltageSourceConverters()) {
-                DcBus dcBus = converter.getDcTerminal1().getDcBus();
-                if (dcBus != null && dcBus.getConnectedComponent() != null) {
-                    int numCc = dcBus.getConnectedComponent().getNum();
-
-                    if (lfNetworkByCc.containsKey(numCc)) {
-                        createAcDcConverter(converter, lfNetworkByCc.get(numCc), parameters);
-                    } else {
-                        // Should not happen
-                        throw new PowsyblException("Found AC-DC converter in a connected component without AC buses");
-                    }
-                }
-            }
             if (network.getLineCommutatedConverterCount() > 0) {
                 throw new PowsyblException("Open Load Flow does not currently support LCC converters");
             }

--- a/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/LfVoltageSourceConverterImpl.java
@@ -12,6 +12,7 @@ import com.powsybl.openloadflow.network.*;
 import com.powsybl.openloadflow.util.PerUnit;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * @author Denis Bonnand {@literal <denis.bonnand at supergrid-institute.com>}
@@ -27,8 +28,8 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
     protected double targetVac; // In pu
 
     public LfVoltageSourceConverterImpl(VoltageSourceConverter converter, LfNetwork network, LfDcBus dcBus1, LfDcBus dcBus2, LfBus bus1,
-                                        LfNetworkParameters parameters) {
-        super(converter, network, dcBus1, dcBus2, bus1);
+                                        LfNetworkParameters parameters, Optional<Double> vdcOverride) {
+        super(converter, network, dcBus1, dcBus2, bus1, vdcOverride);
         bus1.addConverter(this);
         this.converterRef = Ref.create(converter, parameters.isCacheEnabled());
         this.isVoltageRegulatorOn = converter.isVoltageRegulatorOn();
@@ -39,14 +40,16 @@ public class LfVoltageSourceConverterImpl extends AbstractLfAcDcConverter implem
         }
     }
 
-    public static LfVoltageSourceConverterImpl create(VoltageSourceConverter acDcConverter, LfNetwork network, LfDcBus dcBus1, LfDcBus dcBus2, LfBus bus1, LfNetworkParameters parameters) {
+    public static LfVoltageSourceConverterImpl create(VoltageSourceConverter acDcConverter, LfNetwork network, LfDcBus dcBus1, LfDcBus dcBus2, LfBus bus1, LfNetworkParameters parameters,
+                                                      Optional<Double> vdcOverride) {
         Objects.requireNonNull(network);
         Objects.requireNonNull(acDcConverter);
         Objects.requireNonNull(dcBus1);
         Objects.requireNonNull(dcBus2);
         Objects.requireNonNull(bus1);
         Objects.requireNonNull(parameters);
-        return new LfVoltageSourceConverterImpl(acDcConverter, network, dcBus1, dcBus2, bus1, parameters);
+        Objects.requireNonNull(vdcOverride);
+        return new LfVoltageSourceConverterImpl(acDcConverter, network, dcBus1, dcBus2, bus1, parameters, vdcOverride);
 
     }
 

--- a/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
+++ b/src/main/java/com/powsybl/openloadflow/network/impl/Networks.java
@@ -278,7 +278,7 @@ public final class Networks {
     }
 
     public static DcBus getDcBus(DcTerminal terminal) {
-        return terminal.getDcNode().getDcBus();
+        return terminal.getDcBus();
     }
 
     public static boolean isIsolatedBusForHvdc(LfBus bus, GraphConnectivity<LfBus, LfBranch> connectivity) {

--- a/src/main/java/com/powsybl/openloadflow/util/Reports.java
+++ b/src/main/java/com/powsybl/openloadflow/util/Reports.java
@@ -1150,6 +1150,16 @@ public final class Reports {
                 .add());
     }
 
+    public static void reportAutomaticVdcReferenceConverter(ReportNode reportNode, int dcComponentNum, String converterId, double targetVdc) {
+        reportNode.newReportNode()
+                .withMessageTemplate("olf.automaticVdcReferenceConverter")
+                .withUntypedValue("dcComponentNum", dcComponentNum)
+                .withUntypedValue("converterId", converterId)
+                .withUntypedValue("targetVdc", targetVdc)
+                .withSeverity(TypedValue.INFO_SEVERITY)
+                .add();
+    }
+
     public static void reportAcEmulationDisabledInWoodburyDcSecurityAnalysis(ReportNode reportNode) {
         reportNode.newReportNode()
                 .withMessageTemplate("olf.acEmulationDisabledInWoodburyDcSecurityAnalysis")

--- a/src/main/resources/com/powsybl/openloadflow/reports.properties
+++ b/src/main/resources/com/powsybl/openloadflow/reports.properties
@@ -23,6 +23,7 @@ olf.areaInterchangeControlSlackDistributionSuccess = Area ${area} slack distribu
 olf.areaNoInterchangeControlMissingBuses = Area ${area} will not be considered in area interchange control, reason: Area does not have all its boundary buses in the same connected component or synchronous component
 olf.areaNoInterchangeControlNoBoundary = Area ${area} will not be considered in area interchange control, reason: Area does not have any area boundary
 olf.areaNoInterchangeControlNoInterchangeTarget = Area ${area} will not be considered in area interchange control, reason: Area does not have an interchange target
+olf.automaticVdcReferenceConverter = Converter ${converterId} automatically set to V_DC control mode (target Vdc = ${targetVdc} kV) to settle the DC voltage of an otherwise unconstrained island in DC component ${dcComponentNum}
 olf.branchControlledAtBothSides = Controlled branch ${controlledBranchId} is controlled at both sides. Controlled side ${keptSide} (kept), side ${rejectedSide} (rejected).
 olf.busAlreadyControlledWithDifferentTargetV = Bus ${controllerBusId} controls voltage of bus ${controlledBusId} which is already controlled by buses [${busesId}] with a different target voltage: ${keptTargetV} kV (kept) and ${ignoredTargetV} kV (ignored)
 olf.busForcedToBePv = All PV buses should switch PQ, strongest one will stay PV: ${busId}

--- a/src/main/resources/com/powsybl/openloadflow/reports_fr.properties
+++ b/src/main/resources/com/powsybl/openloadflow/reports_fr.properties
@@ -23,6 +23,7 @@ olf.areaInterchangeControlSlackDistributionSuccess = Zone ${area) - participatio
 olf.areaNoInterchangeControlMissingBuses = Zone ${area} - zone non prise en compte dans le contrôle des échanges interzones, raison : La zone n'a pas tous ses noeuds frontières sur le même composant connecté ou le même composant synchrone.
 olf.areaNoInterchangeControlNoBoundary = Zone ${area} - zone non prise en compte dans le contrôle des échanges interzones, raison : La zone n'a pas de limite de zone
 olf.areaNoInterchangeControlNoInterchangeTarget = Zone ${area} - zone non prise en compte dans le contrôle des échanges interzones, raison : La zone n'a pas de cible d'échange
+olf.automaticVdcReferenceConverter = Convertisseur ${converterId} automatiquement plac� en mode de contr�le V_DC (tension DC cible = ${targetVdc} kV) pour fixer la tension DC d'un �lot autrement non contraint dans le composant DC ${dcComponentNum}
 olf.branchControlledAtBothSides = Le quadripôle réglé ${controlledBranchId} est contrôlé en réactif des deux côtés. Côté contrôlé ${keptSide} (maintenu), côté ${rejectedSide} (rejeté).
 olf.busAlreadyControlledWithDifferentTargetV = Le noeud électrique ${controllerBusId} règle la tension de ${controlledBusId} qui est déjà réglée par les noeuds électriques [${busesId}] avec une tension de consigne différente : ${keptTargetV} kV (conservée) et ${ignoredTargetV} kV (ignorée).
 olf.busForcedToBePv = Tous les noeuds électriques en PV devraient passer en PQ, celui ayant la plus forte injection restera en PV : ${busId}

--- a/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
+++ b/src/test/java/com/powsybl/openloadflow/acdc/AcDcLoadFlowTest.java
@@ -980,18 +980,25 @@ class AcDcLoadFlowTest {
     }
 
     @Test
-    void testNoVdcControl() {
-        // At least one AC/DC converter should control the DC voltage per DC component. This should trigger an Exception
+    void testNoVdcControlIsAutomaticallyResolved() {
         Network network = AcDcNetworkFactory.createAcDcNetworkTwoDcSubNetworks();
 
-        // Change control mode of one VSC. Thus, one DC component is valid but the second one is not
+        // Changing conv56's control mode leaves the second DC component with only P_PCC converters (conv14, conv56).
+        // Since both are still individually grounded, Open Load Flow automatically promotes both of the to V_DC control
+        // internally instead of failing.
         network.getVoltageSourceConverter("conv56")
                 .setTargetP(50)
                 .setControlMode(AcDcConverter.ControlMode.P_PCC);
 
         // Run load flow
-        CompletionException e5 = assertThrows(CompletionException.class, () -> loadFlowRunner.run(network, parameters));
-        assertEquals("At least one AC/DC converter control mode must be V_DC in each DC component, but DC component 1 does not have any", e5.getCause().getMessage());
+        LoadFlowResult result = loadFlowRunner.run(network, parameters);
+        assertTrue(result.isFullyConverged());
+        // The automatic promotion is purely internal: both converters' IIDM control mode are left untouched
+        assertEquals(AcDcConverter.ControlMode.P_PCC, network.getVoltageSourceConverter("conv14").getControlMode());
+        assertEquals(AcDcConverter.ControlMode.P_PCC, network.getVoltageSourceConverter("conv56").getControlMode());
+
+        // Both converters have been set in V_DC mode with the same voltage setpoint. No current passes through the line
+        assertEquals(0., network.getDcLine("dl45").getDcTerminal1().getI());
     }
 
     @Test

--- a/src/test/java/com/powsybl/openloadflow/network/AcDcNetworkFactory.java
+++ b/src/test/java/com/powsybl/openloadflow/network/AcDcNetworkFactory.java
@@ -334,6 +334,59 @@ public class AcDcNetworkFactory extends AbstractLoadFlowNetworkFactory {
     }
 
     /**
+     * ACDC test case, same topology as {@link #createAcDcNetwork1()} but with both converters left in P_PCC
+     * control mode. The DC island formed by dn3/dn4 (joined by dl34) then has no element imposing the DC
+     * voltage (the DC grounds are on the separate dnDummy3/dnDummy4 buses, reached only through the converters
+     * themselves, not through DC lines), so one of the two converters must be automatically promoted to V_DC
+     * control for the load flow to converge.
+     *
+     * <pre>
+     * g1       ld2                                 ld5
+     * |         |                                   |
+     * b1 -------b2conv23-dn3--------------dn4conv45-b5
+     * l12       |        dl34                       |
+     *           |                                   |
+     *           |                                   |
+     *           |l25--------------------------------
+     * </pre>
+     *
+     */
+    public static Network createAcDcNetworkTwoPccConvertersWithoutVdcReference() {
+        Network network = createBaseNetwork();
+        VoltageLevel vl2 = network.getVoltageLevel("vl2");
+        VoltageLevel vl5 = network.getVoltageLevel("vl5");
+
+        vl2.newVoltageSourceConverter()
+                .setIdleLoss(0.5)
+                .setSwitchingLoss(0.001)
+                .setResistiveLoss(1)
+                .setControlMode(AcDcConverter.ControlMode.P_PCC)
+                .setTargetP(50.)
+                .setId("conv23")
+                .setBus1("b2")
+                .setDcNode1("dn3")
+                .setDcNode2("dnDummy3")
+                .setVoltageRegulatorOn(false)
+                .setReactivePowerSetpoint(0.0)
+                .add();
+
+        vl5.newVoltageSourceConverter()
+                .setIdleLoss(0.5)
+                .setSwitchingLoss(0.001)
+                .setResistiveLoss(1)
+                .setControlMode(AcDcConverter.ControlMode.P_PCC)
+                .setTargetP(-50.)
+                .setId("conv45")
+                .setBus1("b5")
+                .setDcNode1("dn4")
+                .setDcNode2("dnDummy4")
+                .setVoltageRegulatorOn(false)
+                .setReactivePowerSetpoint(0.0)
+                .add();
+        return network;
+    }
+
+    /**
      * ACDC test case.
      * <pre>
      * g1       ld2                                 ld5

--- a/src/test/java/com/powsybl/openloadflow/network/impl/DcComponentValidatorTest.java
+++ b/src/test/java/com/powsybl/openloadflow/network/impl/DcComponentValidatorTest.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2026, SuperGrid Institute (http://www.supergrid-institute.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.openloadflow.network.impl;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.*;
+import com.powsybl.openloadflow.network.AcDcNetworkFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Baptiste Perreyon {@literal <baptiste.perreyon at supergrid-institute.com>}
+ */
+class DcComponentValidatorTest {
+
+    private static final int NUM_DCC = 1;
+
+    @Test
+    void dcSubComponentAlreadyResolvedByVDcConverterNeedsNoPromotion() {
+        // conv23 (P_PCC) and conv45 (V_DC) share the dn3/dn4 subcomponent: conv45 already settles its DC voltage
+        Network network = AcDcNetworkFactory.createAcDcNetwork1();
+        List<AcDcConverter<?>> convertersToSetInVdcMode = DcComponentValidator.resolveDcComponent(
+                allDcBuses(network),
+                List.of(network.getVoltageSourceConverter("conv23"), network.getVoltageSourceConverter("conv45")),
+                NUM_DCC);
+
+        assertTrue(convertersToSetInVdcMode.isEmpty());
+    }
+
+    @Test
+    void droopModeIsAlsoConsideredAsControllingVoltage() {
+        // conv23 (P_PCC) and conv45 (V_DC) share the dn3/dn4 subcomponent: conv45 already settles its DC voltage
+        Network network = AcDcNetworkFactory.createAcDcNetwork1();
+        network.getVoltageSourceConverter("conv45").setControlMode(AcDcConverter.ControlMode.P_PCC_DROOP);
+        List<AcDcConverter<?>> convertersToSetInVdcMode = DcComponentValidator.resolveDcComponent(
+                allDcBuses(network),
+                List.of(network.getVoltageSourceConverter("conv23"), network.getVoltageSourceConverter("conv45")),
+                NUM_DCC);
+
+        assertTrue(convertersToSetInVdcMode.isEmpty());
+    }
+
+    @Test
+    void disconnectedConvertersAreNotConsidered() {
+        // conv23 (P_PCC) and conv45 (V_DC) share the dn3/dn4 subcomponent: conv45 already settles its DC voltage but is
+        // disconnected. it cannot control DC voltage anymore
+        Network network = AcDcNetworkFactory.createAcDcNetwork1();
+        VoltageSourceConverter conv45 = network.getVoltageSourceConverter("conv45");
+
+        // AC disconnection
+        conv45.disconnect();
+        List<AcDcConverter<?>> convertersToSetInVdcMode = DcComponentValidator.resolveDcComponent(
+                allDcBuses(network),
+                List.of(network.getVoltageSourceConverter("conv23"), network.getVoltageSourceConverter("conv45")),
+                NUM_DCC);
+
+        assertEquals(1, convertersToSetInVdcMode.size());
+        assertEquals(network.getVoltageSourceConverter("conv23"), convertersToSetInVdcMode.getFirst());
+
+        // DC disconnection
+        conv45.connect();
+        conv45.disconnectDc();
+        List<AcDcConverter<?>> convertersToSetInVdcMode2 = DcComponentValidator.resolveDcComponent(
+                allDcBuses(network),
+                List.of(network.getVoltageSourceConverter("conv23"), network.getVoltageSourceConverter("conv45")),
+                NUM_DCC);
+
+        assertEquals(1, convertersToSetInVdcMode2.size());
+        assertEquals(network.getVoltageSourceConverter("conv23"), convertersToSetInVdcMode2.getFirst());
+    }
+
+    @Test
+    void allPccConverterArePromotedWhenTwoShareAnDcSubComponent() {
+        Network network = AcDcNetworkFactory.createAcDcNetworkTwoPccConvertersWithoutVdcReference();
+
+        List<AcDcConverter<?>> convertersToSetInVdcMode = DcComponentValidator.resolveDcComponent(
+                allDcBuses(network),
+                List.of(network.getVoltageSourceConverter("conv23"), network.getVoltageSourceConverter("conv45")),
+                NUM_DCC);
+
+        assertEquals(2, convertersToSetInVdcMode.size());
+    }
+
+    @Test
+    void dcSubComponentWithNoConverterAndNoGroundIsRejected() {
+        // Restricting the resolution to dn3/dn4 only (ignoring the grounded dnDummy3/dnDummy4 buses) simulates a
+        // pocket of DC buses reachable only through DC lines, with no converter and no ground at all
+        Network network = AcDcNetworkFactory.createBaseNetwork();
+        List<DcBus> deadSubComponent = List.of(network.getDcNode("dn3").getDcBus(), network.getDcNode("dn4").getDcBus());
+
+        PowsyblException exception = assertThrows(PowsyblException.class,
+                () -> DcComponentValidator.resolveDcComponent(deadSubComponent, List.of(), NUM_DCC));
+        assertTrue(exception.getMessage().contains("no AC-DC converter able to settle the DC voltage"));
+    }
+
+    @Test
+    void converterWithNoTerminalReachingGroundIsRejected() {
+        // A converter whose two DC terminals are only linked to each other, with no DC ground anywhere: promoting
+        // it to V_DC would only add a relative constraint, never anchoring an absolute voltage
+        Network network = Network.create("dc-validator-ungrounded-test", "test");
+        Substation s = network.newSubstation().setId("S").add();
+        VoltageLevel vl = s.newVoltageLevel().setId("vl").setNominalV(400).setTopologyKind(TopologyKind.BUS_BREAKER).add();
+        vl.getBusBreakerView().newBus().setId("b").add();
+        network.newDcNode().setId("dnA").setNominalV(400.).add();
+        network.newDcNode().setId("dnB").setNominalV(400.).add();
+        vl.newVoltageSourceConverter()
+                .setIdleLoss(0.5)
+                .setSwitchingLoss(0.001)
+                .setResistiveLoss(1)
+                .setControlMode(AcDcConverter.ControlMode.P_PCC)
+                .setTargetP(10.)
+                .setId("conv")
+                .setBus1("b")
+                .setDcNode1("dnA")
+                .setDcNode2("dnB")
+                .setVoltageRegulatorOn(false)
+                .setReactivePowerSetpoint(0.0)
+                .add();
+
+        List<AcDcConverter<?>> converters = List.of(network.getVoltageSourceConverter("conv"));
+        List<DcBus> dcBuses = allDcBuses(network);
+        PowsyblException exception = assertThrows(PowsyblException.class,
+                () -> DcComponentValidator.resolveDcComponent(dcBuses, converters, NUM_DCC));
+        assertTrue(exception.getMessage().contains("not indirectly connected to a DC ground"));
+    }
+
+    private static List<DcBus> allDcBuses(Network network) {
+        return network.getDcBusStream().toList();
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
This PR add a validator class that verifies if a DC component can be simulated by Open Load Flow and fix it if needed.



**What is the current behavior?**
<!-- You can also link to an open issue here -->
Before builing the LfNetwork, we make sure at least one AC/DC converter controls DC voltage, and throw an error otherwise.


**What is the new behavior (if this is a feature change)?**
We introduce here the concept of DC subcomponent: a set of DC buses connected by DC lines only (i.e. not converters).
A DC component is valid if:
- All AC/DC converters are indirectly connected to a DC ground with at least one of their DC terminal. An error is raised otherwise.
- In each DC subcomponent, there is at least one element imposing voltage (a DC ground or a converter not in P_PCC mode). This ensures that the voltage of all DC buses in the DC component is controlled. If no element control the DC voltage in a DC subcomponent, all converters belonging to this subcomponent are set in V_DC mode during the load flow with the nominal voltage as targetVdc.

_Example of invalid DC component configuration:_ a bipolar P2P connection with 3 converters in P_PCC mode and one converter in V_DC mode (connecting the positive and the neutral pole). The voltage in the negative pole would not be imposed : the load flow cannot converge.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
